### PR TITLE
Use https in links were possible

### DIFF
--- a/README_Install_Mac.md
+++ b/README_Install_Mac.md
@@ -15,9 +15,9 @@ Get Zammad
 ----------
 
 ````shell
-    test -d ~/zammad/ || mkdir ~/zammad 
+    test -d ~/zammad/ || mkdir ~/zammad
     cd ~/zammad/
-    curl -L -O http://zammad.org/zammad-latest.tar.bz2 | tar -xj
+    curl -L -O http://ftp.zammad.com/zammad-latest.tar.bz2 | tar -xj
 ````
 
 Install Zammad

--- a/README_Install_Ubuntu.md
+++ b/README_Install_Ubuntu.md
@@ -53,4 +53,3 @@
 ### Restart nginx as root
 * exit
 * systemctl restart nginx
-

--- a/app/assets/javascripts/app/views/facebook/app_config.jst.eco
+++ b/app/assets/javascripts/app/views/facebook/app_config.jst.eco
@@ -1,6 +1,6 @@
 <div class="alert alert--danger hidden" role="alert"></div>
 <p>
-  <%- @T('The tutorial on how to manage a %s is hosted on our [online documentation](http://zammad.org/documentation/channel/facebook).', 'Facebook App') %>
+  <%- @T('The tutorial on how to manage a %s is hosted on our [online documentation](https://zammad.org/documentation/channel/facebook).', 'Facebook App') %>
 </p>
 <fieldset>
   <h2><%- @T('Enter your %s App Keys', 'Facebook') %></h2>

--- a/app/assets/javascripts/app/views/layout_ref/communication_overview.jst.eco
+++ b/app/assets/javascripts/app/views/layout_ref/communication_overview.jst.eco
@@ -7,7 +7,7 @@
   <h2>Ticket Article</h2>
 
   <div class="ticketZoom">
-    <div class="scrollPageHeader tabsSidebar-sidebarSpacer" 
+    <div class="scrollPageHeader tabsSidebar-sidebarSpacer"
       data-anchor-target=".ticketZoom .page-header"
       data-128-top-bottom="transform: translateY(-64px);"
       data-64-top-bottom="transform: translateY(0px);"
@@ -37,7 +37,7 @@
           <h1 contenteditable="true" class="ticket-title-update" data-placeholder="Enter Title...">Welcome to Zammad! We want to entertain you and your whole family!</h1>
         </div>
         <div class="ticket-meta">
-          <small class="task-subline">Ticket# <span class="ticket-number">10001</span> - erstellte <span class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="11.07.2014 12:10">11.07.2014</span> 
+          <small class="task-subline">Ticket# <span class="ticket-number">10001</span> - erstellte <span class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="11.07.2014 12:10">11.07.2014</span>
           </small>
         </div>
       </div>
@@ -65,12 +65,12 @@ Welcome!
 <br/>
 Thank you for installing Zammad.<br/>
 <br/>
-You will find updates and patches at <a href="http://zammad.org/" title="http://zammad.org/" target="_blank">http://zammad.org/</a>. Online<br/>
-documentation is available at <a href="http://guides.zammad.org/" title="http://guides.zammad.org/" target="_blank">http://guides.zammad.org/</a>. You can also<br/>
-use our forums at <a href="http://forums.zammad.org/" title="http://forums.zammad.org/" target="_blank">http://forums.zammad.org/</a><br/>
+You will find updates and patches at <a href="https://zammad.org/" title="https://zammad.org/" target="_blank">https://zammad.org/</a>. Online<br/>
+documentation is available at <a href="https://zammad.org/documentation/" title="https://zammad.org/documentation/" target="_blank">https://zammad.org/documentation/</a>. Get involved<br/>
+(discussions, contributing, ...) at <a href="https://zammad.org/participate" title="https://zammad.org/participate" target="_blank">https://zammad.org/participate</a>.<br/>
 <br/>
 Regards,<br/>
-The <a href="http://Zammad.org" title="http://Zammad.org" target="_blank">Zammad.org</a> Project
+The <a href="https://zammad.org" title="https://zammad.org" target="_blank">zammad.org</a> Project
                 <div class="textBubble-overflowContainer">
                   <div class="btn btn--text js-unfold"><%- @T('See more') %></div>
                 </div>
@@ -105,7 +105,7 @@ The <a href="http://Zammad.org" title="http://Zammad.org" target="_blank">Zammad
         <small class="task-subline"><time class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="2014-07-11 12:10">2014-07-11</time></small>
       </div>
 
-      <div class="ticket-article-item agent note" data-id="23" id="article-23">      
+      <div class="ticket-article-item agent note" data-id="23" id="article-23">
         <div class="article-meta-clip top">
           <div class="article-content-meta top hide">
             <div class="article-meta top">
@@ -189,7 +189,7 @@ Grüße, Peter</div>
         <small class="task-subline"><time class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="2014-07-11 12:10">2014-07-11</time></small>
       </div>
 
-      <div class="ticket-article-item agent note" data-id="23" id="article-23">      
+      <div class="ticket-article-item agent note" data-id="23" id="article-23">
         <div class="article-meta-clip top">
           <div class="article-content-meta top hide">
             <div class="article-meta top">

--- a/app/assets/javascripts/app/views/layout_ref/merge_customer_view.jst.eco
+++ b/app/assets/javascripts/app/views/layout_ref/merge_customer_view.jst.eco
@@ -97,15 +97,15 @@
                     </div>
 
                     <div>
-                      You will find updates and patches at <a href="http://zammad.org/" target="_blank" title="http://zammad.org/">http://zammad.org/</a>. Online
+                      You will find updates and patches at <a href="https://zammad.org/" target="_blank" title="https://zammad.org/">https://zammad.org/</a>. Online
                     </div>
 
                     <div>
-                      documentation is available at <a href="http://guides.zammad.org/" target="_blank" title="http://guides.zammad.org/">http://guides.zammad.org/</a>. You can also
+                      documentation is available at <a href="https://zammad.org/documentation/" target="_blank" title="https://zammad.org/documentation/>https://zammad.org/documentation/</a>. You can also
                     </div>
 
                     <div>
-                      use our forums at <a href="http://forums.zammad.org/" target="_blank" title="http://forums.zammad.org/">http://forums.zammad.org/</a>
+                      get involved (discussions, contributing, ...) at <a href="https://zammad.org/participate" target="_blank" title="https://zammad.org/participate">https://zammad.org/participate</a>.
                     </div>
 
                     <div>
@@ -121,7 +121,7 @@
                     </div>
 
                     <div>
-                      The <a href="http://Zammad.org" target="_blank" title="http://Zammad.org">Zammad.org</a> Project
+                      The <a href="https://zammad.org" target="_blank" title="https://zammad.org">zammad.org</a> Project
                     </div>
 
                     <div class="textBubble-overflowContainer hide">
@@ -625,7 +625,7 @@
                     <option selected value="1">
                       Users
                     </option>
-                  </select> 
+                  </select>
                 </div><span class="help-inline"></span> <span class="help-block"></span>
               </div>
             </div>
@@ -649,7 +649,7 @@
                     <option selected value="4">
                       Hans Huber
                     </option>
-                  </select> 
+                  </select>
                 </div><span class="help-inline"></span> <span class="help-block"></span>
               </div>
             </div>
@@ -677,7 +677,7 @@
                     <option value="3">
                       pending reminder
                     </option>
-                  </select> 
+                  </select>
                 </div><span class="help-inline"></span> <span class="help-block"></span>
               </div>
             </div>
@@ -717,7 +717,7 @@
                     <option value="3">
                       3 high
                     </option>
-                  </select> 
+                  </select>
                 </div><span class="help-inline"></span> <span class="help-block"></span>
               </div>
             </div>
@@ -896,7 +896,7 @@
           <option value="3">
             pending
           </option>
-        </select> 
+        </select>
       </div>
 
       <div class="form-group is-changed">
@@ -912,7 +912,7 @@
           <option value="3">
             3 high
           </option>
-        </select> 
+        </select>
       </div>
 
       <div class="form-group">
@@ -932,7 +932,7 @@
           <option selected value="1">
             Users
           </option>
-        </select> 
+        </select>
       </div>
 
       <div class="form-group">
@@ -944,7 +944,7 @@
           <option value="3">
             Felix Niklas
           </option>
-        </select> 
+        </select>
       </div>
     </form>
 

--- a/app/assets/javascripts/app/views/layout_ref/ticket_zoom.jst.eco
+++ b/app/assets/javascripts/app/views/layout_ref/ticket_zoom.jst.eco
@@ -27,7 +27,7 @@
         </div>
       </div>
 
-      <div class="scrollPageHeader tabsSidebar-sidebarSpacer" 
+      <div class="scrollPageHeader tabsSidebar-sidebarSpacer"
         data-anchor-target=".ticketZoom .page-header"
         data-128-top-bottom="transform: translateY(-64px);"
         data-64-top-bottom="transform: translateY(0px);"
@@ -57,7 +57,7 @@
             <h1 contenteditable="true" class="ticket-title-update" data-placeholder="Enter Title...">Welcome to Zammad! We want to entertain you and your whole family!</h1>
           </div>
           <div class="ticket-meta">
-            <small class="task-subline">Ticket# <span class="ticket-number">10001</span> - erstellte <span class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="11.07.2014 12:10">11.07.2014</span> 
+            <small class="task-subline">Ticket# <span class="ticket-number">10001</span> - erstellte <span class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="11.07.2014 12:10">11.07.2014</span>
             </small>
           </div>
         </div>
@@ -86,12 +86,12 @@
   <br/>
   Thank you for installing Zammad.<br/>
   <br/>
-  You will find updates and patches at <a href="http://zammad.org/" title="http://zammad.org/" target="_blank">http://zammad.org/</a>. Online<br/>
-  documentation is available at <a href="http://guides.zammad.org/" title="http://guides.zammad.org/" target="_blank">http://guides.zammad.org/</a>. You can also<br/>
-  use our forums at <a href="http://forums.zammad.org/" title="http://forums.zammad.org/" target="_blank">http://forums.zammad.org/</a><br/>
+  You will find updates and patches at <a href="https://zammad.org/" title="https://zammad.org/" target="_blank">https://zammad.org/</a>. Online<br/>
+  documentation is available at <a href="https://zammad.org/documentation/" title="https://zammad.org/documentation/" target="_blank">https://zammad.org/documentation/</a>. Get involved<br/>
+  (discussions, contributing, ...) at <a href="https://zammad.org/participate" title="https://zammad.org/participate" target="_blank">https://zammad.org/participate</a>.<br/>
   <br/>
   Regards,<br/>
-  The <a href="http://Zammad.org" title="http://Zammad.org" target="_blank">Zammad.org</a> Project
+  The <a href="https://zammad.org" title="https://zammad.org" target="_blank">zammad.org</a> Project
                   </div>
                   <div class="textBubble-overflowContainer">
                     <div class="btn btn--text js-unfold"><%- @T('See more') %></div>
@@ -130,7 +130,7 @@
           <small class="task-subline"><time class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="2014-07-11 12:10">2014-07-11</time></small>
         </div>
 
-        <div class="ticket-article-item agent note" data-id="23" id="article-23">      
+        <div class="ticket-article-item agent note" data-id="23" id="article-23">
           <div class="article-meta-clip top">
             <div class="article-content-meta top hide">
               <div class="article-meta top">
@@ -219,7 +219,7 @@
           <small class="task-subline"><time class="humanTimeFromNow" data-time="2014-07-11T10:10:32.000Z" title="2014-07-11 12:10">2014-07-11</time></small>
         </div>
 
-        <div class="ticket-article-item agent note" data-id="23" id="article-23">      
+        <div class="ticket-article-item agent note" data-id="23" id="article-23">
           <div class="article-meta-clip top">
             <div class="article-content-meta top hide">
               <div class="article-meta top">

--- a/app/assets/javascripts/app/views/twitter/app_config.jst.eco
+++ b/app/assets/javascripts/app/views/twitter/app_config.jst.eco
@@ -1,6 +1,6 @@
 <div class="alert alert--danger hidden" role="alert"></div>
 <p>
-  <%- @T('The tutorial on how to manage a %s is hosted on our [online documentation](http://zammad.org/documentation/channel/twitter).', 'Twitter App') %>
+  <%- @T('The tutorial on how to manage a %s is hosted on our [online documentation](https://zammad.org/documentation/channel/twitter).', 'Twitter App') %>
 </p>
 <fieldset>
   <h2><%- @T('Enter your %s App Keys', 'Twitter') %></h2>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3029,9 +3029,9 @@ Ticket::Article.create(
 
 Thank you for choosing Zammad.
 
-You will find updates and patches at http://zammad.org/. Online
-documentation is available at http://zammad.org/documentation. Get
-involved (discussions, contributing, ...) at http://zammad.org/participate.
+You will find updates and patches at https://zammad.org/. Online
+documentation is available at https://zammad.org/documentation. Get
+involved (discussions, contributing, ...) at https://zammad.org/participate.
 
 Regards,
 

--- a/test/browser/maintenance_session_message_test.rb
+++ b/test/browser/maintenance_session_message_test.rb
@@ -6,8 +6,8 @@ class MaintenanceSessionMessageTest < TestCase
     string       = rand(99_999_999_999_999_999).to_s
     title_html   = "test <b>#{string}</b>"
     title_text   = "test <b>#{string}<\/b>"
-    message_html = "message <b>1äöüß</b> #{string}\n\n\nhttp://zammad.org"
-    message_text = "message <b>1äöüß</b> #{string}\n\n\nhttp://zammad.org"
+    message_html = "message <b>1äöüß</b> #{string}\n\n\nhttps://zammad.org"
+    message_text = "message <b>1äöüß</b> #{string}\n\n\nhttps://zammad.org"
 
     # check #1
     browser1 = browser_instance

--- a/test/unit/aaa_string_test.rb
+++ b/test/unit/aaa_string_test.rb
@@ -129,10 +129,10 @@ class AaaStringTest < ActiveSupport::TestCase
     result = 'test'
     assert_equal(result, html.html2text)
 
-    html = "\n<div><a href=\"http://zammad.org\">Best Tool of the World</a>
+    html = "\n<div><a href=\"https://zammad.org\">Best Tool of the World</a>
      some other text</div>
     <div>"
-    result = "[1] Best Tool of the Worldsome other text\n\n[1] http://zammad.org"
+    result = "[1] Best Tool of the Worldsome other text\n\n[1] https://zammad.org"
     assert_equal(result, html.html2text)
 
     html = "<!-- some comment -->
@@ -397,10 +397,10 @@ P.S.: You receive this e-mail because you are listed in our database as person w
 [1] http://www.teamviewer.example/en/company/unsubscribe.aspx?id=1009645&ident=xxx'
     assert_equal(result, html.html2text)
 
-    html   = "<div><br>Dave and leaned her 
-days adam.</div><span style=\"color:#F7F3FF; font-size:8px\">Maybe we 
-want any help me that.<br>Next morning charlie saw at their 
-father.<br>Well as though adam took out here. Melvin will be more money. 
+    html   = "<div><br>Dave and leaned her
+days adam.</div><span style=\"color:#F7F3FF; font-size:8px\">Maybe we
+want any help me that.<br>Next morning charlie saw at their
+father.<br>Well as though adam took out here. Melvin will be more money.
 Called him into this one last thing.<br>Men-----------------------
 <br />"
     result = 'Dave and leaned her days adam.


### PR DESCRIPTION
I updated zammad to use https links to zammad.org where possible.

There were links to forums which do not exist. I changed them to links to the /participate part of the web site.

The download link to the tarball in the OS X documentation was broken, I fixed that.
But I also noticed the software download - where you'd really want it - is served from ftp.zammad.com which does not have https. Can you maybe enable that?