### PR TITLE
it's better to set the recommended path

### DIFF
--- a/script/init.d/zammad
+++ b/script/init.d/zammad
@@ -11,7 +11,7 @@
 ### END INIT INFO
 
 
-APP_ROOT="/home/zammad/zammad"
+APP_ROOT="/opt/zammad"
 PID_PATH="$APP_ROOT/tmp/pids"
 WEB_SERVER_PID="$PID_PATH/puma.pid"
 WEBSOCKET_SERVER_PID="$PID_PATH/websocket.pid"


### PR DESCRIPTION
In all tutorials the path zammad is installed in is /opt/zammad. So I think is better for the startup-script to use this one.