### PR TITLE
SLES12, postgresql with sockets, possiblity to use "rake db:drop and rake db:create"

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -17,7 +17,7 @@ targets:
       - postgresql|mysql-server|mariadb-server|sqlite
   sles-12:
     dependencies:
-      - nginx|apache2
+      - nginx
       - postgresql-server
 before:
   - uname -a

--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -17,7 +17,7 @@ targets:
       - postgresql|mysql-server|mariadb-server|sqlite
   sles-12:
     dependencies:
-      - nginx
+      - nginx|apache2
       - postgresql-server
 before:
   - uname -a

--- a/config/database.yml.pkgr
+++ b/config/database.yml.pkgr
@@ -1,8 +1,9 @@
 production:
   adapter: postgresql
-  database: zammad_production
-  pool: 50
+  database: zammad
+  pool: 100
   timeout: 5000
   encoding: utf8
   username: zammad
   password:
+  host:


### PR DESCRIPTION
- Some SLES12 fixes.
- Replaed \t with spaces.
- Postgres: Use socket connections (user changes on pg_hba.conf needed).
- Postgres: Added zammad user as owner to zammad database of be able to use “rake db:drop and rake db:create” (in you want to to a re-setup)
- Moved from config/database.yml.dist ro config/database.yml.pkgr
- Renamed database from zammad_production to zammad (since we only have one zammad database user)