### PR TITLE
Fix race condition in tests

### DIFF
--- a/test/unit/ticket_overview_test.rb
+++ b/test/unit/ticket_overview_test.rb
@@ -614,7 +614,7 @@ class TicketOverviewTest < ActiveSupport::TestCase
     assert(result[2][:tickets].empty?)
 
     overview2.order = {
-      by: 'created_at',
+      by: 'id',
       direction: 'DESC',
     }
     overview2.save!


### PR DESCRIPTION
The order was random if objects were created in the same second.