### PR TITLE
Use deliver_method :test for tests

### DIFF
--- a/app/models/channel/driver/sendmail.rb
+++ b/app/models/channel/driver/sendmail.rb
@@ -7,7 +7,7 @@ class Channel::Driver::Sendmail
     return if Setting.get('import_mode')
 
     mail = Channel::EmailBuild.build(attr, notification)
-    mail.delivery_method :sendmail
+    mail.delivery_method(Rails.env.test? ? :test : :sendmail)
     mail.deliver
   end
 end


### PR DESCRIPTION
This avoids flooding the screen with warnings on systems without MTA:

Please install an MTA on this system if you want to use sendmail!
Please install an MTA on this system if you want to use sendmail!
Please install an MTA on this system if you want to use sendmail!