### PR TITLE
bugfix: added missing join table

### DIFF
--- a/app/models/ticket/search.rb
+++ b/app/models/ticket/search.rb
@@ -162,8 +162,9 @@ returns
                           .order('tickets.created_at DESC')
                           .limit(limit)
     else
-      query_condition, bind_condition = selector2sql(condition)
+      query_condition, bind_condition, tables = selector2sql(condition)
       tickets_all = Ticket.select('DISTINCT(tickets.id), tickets.created_at')
+                          .from("tickets#{tables}")
                           .where(access_condition)
                           .where(query_condition, *bind_condition)
                           .order('tickets.created_at DESC')


### PR DESCRIPTION
```ruby
Ticket.search condition: { "organization.customer_number" => { operator: 'is', value: "1234" }}, current_user: User.find(3)
```
->
```sql
SELECT  DISTINCT(tickets.id), tickets.created_at FROM `tickets` WHERE (group_id IN (1)) AND (tickets.organization_id = organizations.id AND organizations.customer_number IN ('1234'))  ORDER BY tickets.created_at DESC LIMIT 12
```
->
```ruby
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown column 'organizations.id' in 'where clause': SELECT  DISTINCT(tickets.id), tickets.created_at FROM `tickets` WHERE (group_id IN (1)) AND (tickets.organization_id = organizations.id AND organizations.customer_number IN ('1234'))  ORDER BY tickets.created_at DESC LIMIT 12
```
The problem is that the 'organizations' table is missing in the from-clause. Luckily it gets returned by selector2sql, so i only had to add it to the active_record call.