### PR TITLE
Update the call for participation in JS console

### DIFF
--- a/app/assets/javascripts/app/controllers/widget/hello_banner.coffee
+++ b/app/assets/javascripts/app/controllers/widget/hello_banner.coffee
@@ -10,9 +10,9 @@ class Widget
 |
 | Hi there, nice to meet you!
 |
-| Visit %chttp://zammad.com/jobs%c to learn about our current job openings.
+| Visit %chttps://zammad.org/participate%c and let's make Zammad better.
 |
-| Your Zammad Team!
+| The Zammad Team.
 |
 """
     console.log(banner, 'text-decoration: underline;', 'text-decoration: none;')


### PR DESCRIPTION
Previously, if opened in developer mode, an hello banner
advertised job opportunities at Zammad.

As this isn't a priority anymore, switch to Zammad Commnity
participate invitation instead to serve a 404 error page.