### PR TITLE
Some adjustments with regard to #698

### DIFF
--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -121,7 +121,7 @@ a.create {
 }
 
 small {
-  color: #c6c6c5;
+  color: hsl(198,4%,56%);
   font-size: 12px;
 }
 
@@ -889,7 +889,7 @@ table {
 }
 
 .table--light {
-  color: hsl(198,19%,72%);
+  color: hsl(198,4%,56%);
 }
 
 .table-fluid {


### PR DESCRIPTION
This replaces some very light text colors with the default #585856 color, which passes the [W3C recommendation](http://leaverou.github.io/contrast-ratio/) for text readability.

This is not a complete fix of the problem, there are still places where the text is too light, but the two places where I changed it are the ones I mentioned in #698 (ticket overview table, ticket entry timestamps).