### PR TITLE
hidden form on small screen/smartphone

### DIFF
--- a/public/assets/form/form.css
+++ b/public/assets/form/form.css
@@ -59,7 +59,8 @@
     background: white;
     border-radius: 5px;
     padding: 24px 24px 22px;
-    width: 26em;
+    width: 90%;
+    max-width: 26em;
     margin: 0 auto;
     box-sizing: border-box;
     position: relative;


### PR DESCRIPTION
I noticed that on small screen/smartphone the modal of the contact form does not show up. So I added max-width to the css class.