### PR TITLE
Added possibility of creating an inbound smtp channel, which makes Za…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 
 # Ignore Rubymine config
 /.idea
+*.iml
 
 # Ignore .project files
 /.project

--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,8 @@ gem 'em-websocket'
 
 gem 'diffy'
 
+gem 'midi-smtp-server'
+
 # Gems used only for develop/test and not required
 # in production environments by default.
 group :development, :test do

--- a/app/models/channel/driver/facebook.rb
+++ b/app/models/channel/driver/facebook.rb
@@ -54,6 +54,7 @@ class Channel::Driver::Facebook
 
     # because of new page rate limit - https://developers.facebook.com/blog/post/2016/06/16/page-level-rate-limits/
     # only fetch once in 5 minutes
+    return true if channel.nil?
     return true if !channel.preferences
     return true if !channel.preferences[:last_fetch]
     return false if channel.preferences[:last_fetch] > Time.zone.now - 5.minutes

--- a/app/models/channel/driver/twitter.rb
+++ b/app/models/channel/driver/twitter.rb
@@ -80,6 +80,7 @@ returns
     return true if Rails.env.test?
 
     # only fetch once in 30 minutes
+    return true if channel.nil?
     return true if !channel.preferences
     return true if !channel.preferences[:last_fetch]
     return false if channel.preferences[:last_fetch] > Time.zone.now - 30.minutes

--- a/db/migrate/20170426075821_add_channel_listen_scheduler.rb
+++ b/db/migrate/20170426075821_add_channel_listen_scheduler.rb
@@ -1,0 +1,13 @@
+class AddChannelListenScheduler < ActiveRecord::Migration
+  def up
+    Scheduler.create_or_update(
+      name:          'Check listeners for Channel',
+      method:        'Channel.listen',
+      period:        60,
+      prio:          1,
+      active:        true,
+      updated_by_id: 1,
+      created_by_id: 1
+    )
+  end
+end

--- a/db/seeds/schedulers.rb
+++ b/db/seeds/schedulers.rb
@@ -40,6 +40,15 @@ Scheduler.create_if_not_exists(
   created_by_id: 1,
 )
 Scheduler.create_if_not_exists(
+  name: 'Check listeners for Channel',
+  method: 'Channel.listen',
+  period: 60,
+  prio: 1,
+  active: true,
+  updated_by_id: 1,
+  created_by_id: 1,
+)
+Scheduler.create_if_not_exists(
   name: 'Generate Session data',
   method: 'Sessions.jobs',
   period: 60.seconds,

--- a/lib/email_helper.rb
+++ b/lib/email_helper.rb
@@ -12,6 +12,7 @@ returns
     inbound: {
       imap: 'IMAP',
       pop3: 'POP3',
+      smtp: 'SMTP - configure SMTP server which listens for incoming emails',
     },
     outbound: {
       smtp: 'SMTP - configure your own outgoing SMTP settings',
@@ -27,6 +28,7 @@ returns
         inbound: {
           imap: 'IMAP',
           pop3: 'POP3',
+          smtp: 'SMTP - relay mails to Zammad via SMTP',
         },
         outbound: {
           smtp: 'SMTP - configure your own outgoing SMTP settings',
@@ -37,6 +39,7 @@ returns
       inbound: {
         imap: 'IMAP',
         pop3: 'POP3',
+        smtp: 'SMTP - relay mails to Zammad via SMTP',
       },
       outbound: {
         smtp: 'SMTP - configure your own outgoing SMTP settings',

--- a/lib/email_helper/probe.rb
+++ b/lib/email_helper/probe.rb
@@ -224,9 +224,18 @@ returns on fail
 
         require "channel/driver/#{adapter.to_filename}"
 
+        Rails.logger.debug "probing inbound driver #{adapter.to_classname}"
         driver_class    = Object.const_get("Channel::Driver::#{adapter.to_classname}")
         driver_instance = driver_class.new
-        result_inbound  = driver_instance.fetch(params[:options], nil, 'check')
+        result_inbound  =
+        if driver_instance.fetchable?(nil)
+          driver_instance.fetch(params[:options], nil, 'check')
+        else
+          {
+            result: 'ok',
+            notice: ''
+          }
+        end
 
       rescue => e
         return {

--- a/lib/email_helper/verify.rb
+++ b/lib/email_helper/verify.rb
@@ -86,9 +86,19 @@ or
         begin
           require "channel/driver/#{adapter.to_filename}"
 
+          Rails.logger.debug "verifying inbound driver #{adapter.to_classname}"
           driver_class    = Object.const_get("Channel::Driver::#{adapter.to_classname}")
           driver_instance = driver_class.new
-          fetch_result    = driver_instance.fetch(params[:inbound][:options], self, 'verify', subject)
+          fetch_result    =
+          if driver_instance.fetchable?(nil)
+            driver_instance.fetch(params[:inbound][:options], self, 'verify', subject)
+          else
+            {
+              result: 'ok',
+              source: 'inbound',
+              subject: subject,
+            }
+          end
         rescue => e
           result = {
             result: 'invalid',


### PR DESCRIPTION
As mentioned in #806 we (@ServicePlanet) like to see a feature which adds the possibility of creating inbound smtp email channels. Zammad would then listen on a port for smtp connections and incoming emails would be processed through this channel. As mentioned in the issue the idea is that this feature allows a frontend MTA to relay mails directly to Zammad. 

This pull request contains the current implementation of this feature and i was wondering whether you guys would consider merging this, and if not, if there are any changes that can be made to make you reconsider.

Currently it works by creating an email account and selecting SMTP as the type. After the account is created Zammad starts an smtp server that listens for incoming connections on the configured port. The host and user are still configured, because they seem to function like channel identifiers. The password has become optional because it is not used here. I feel that ideally fields would be optional or mandatory depending on the adapter type that was selected, but currently that is not the case. What do you think?

Any kind of feedback is certainly appreciated. Information about the problem this is supposed to solve can be found in issue #806.