### PR TITLE
No longer raise exception when scheduler job fails to run

### DIFF
--- a/app/assets/javascripts/app/controllers/monitoring.coffee
+++ b/app/assets/javascripts/app/controllers/monitoring.coffee
@@ -4,6 +4,7 @@ class Index extends App.ControllerSubContent
   events:
     'click .js-resetToken': 'resetToken'
     'click .js-select': 'selectAll'
+    'click .js-restartDeadJobs': 'restartDeadJobs'
 
   constructor: ->
     super
@@ -29,7 +30,10 @@ class Index extends App.ControllerSubContent
     )
 
   render: =>
-    @html App.view('monitoring')(data: @data)
+    @html App.view('monitoring')(
+      data: @data
+      job_restart_count: @job_restart_count
+    )
 
   resetToken: (e) =>
     e.preventDefault()
@@ -40,6 +44,17 @@ class Index extends App.ControllerSubContent
       url:   "#{@apiPath}/monitoring/token"
       success: (data) =>
         @load()
+    )
+
+  restartDeadJobs: (e) =>
+    e.preventDefault()
+    @ajax(
+      id:    'restart_dead_jobs_request'
+      type:  'POST'
+      url:   "#{@apiPath}/monitoring/restart_dead_jobs"
+      success: (data) =>
+        @job_restart_count = data.job_restart_count
+        @render()
     )
 
 App.Config.set('Monitoring', { prio: 3600, name: 'Monitoring', parent: '#system', target: '#system/monitoring', controller: Index, permission: ['admin.monitoring'] }, 'NavBarAdmin')

--- a/app/assets/javascripts/app/views/monitoring.jst.eco
+++ b/app/assets/javascripts/app/views/monitoring.jst.eco
@@ -34,6 +34,15 @@
         <% end %>
       <% end %>
     </ul>
+    <% if !_.isEmpty(@data.issues): %>
+      <button class="btn btn--primary js-restartDeadJobs"><%- @T('Restart Dead Jobs') %></button>
+      <% if !_.isUndefined(@job_restart_count): %>
+        <p>
+          <%- @T('Detected %s dead job(s) available for restart', @job_restart_count) %>
+          <%- ', restarting...' if @job_restart_count > 0 %>
+        </p>
+      <% end %>
+    <% end %>
   </div>
 
 </div>

--- a/app/models/scheduler.rb
+++ b/app/models/scheduler.rb
@@ -169,8 +169,10 @@ class Scheduler < ApplicationModel
   end
 
   def self._start_job(job, try_count = 0, try_run_time = Time.zone.now)
-    job.last_run = Time.zone.now
-    job.pid      = Thread.current.object_id
+    job.last_run      = Time.zone.now
+    job.pid           = Thread.current.object_id
+    job.status        = 'ok'
+    job.error_message = ''
     job.save
     logger.info "execute #{job.method} (try_count #{try_count})..."
     eval job.method() # rubocop:disable Lint/Eval
@@ -197,7 +199,14 @@ class Scheduler < ApplicationModel
     if try_run_max > try_count
       _start_job(job, try_count, try_run_time)
     else
-      raise "STOP thread for #{job.method} after #{try_count} tries (#{e.inspect})"
+      @@jobs_started[ job.id ] = false
+      error = "Failed to run #{job.method} after #{try_count} tries #{e.inspect}"
+      logger.error error
+
+      job.error_message = error
+      job.status        = 'error'
+      job.active        = false
+      job.save
     end
   end
 

--- a/config/routes/monitoring.rb
+++ b/config/routes/monitoring.rb
@@ -1,8 +1,9 @@
 Zammad::Application.routes.draw do
   api_path = Rails.configuration.api_path
 
-  match api_path + '/monitoring/health_check',         to: 'monitoring#health_check', via: :get
-  match api_path + '/monitoring/status',               to: 'monitoring#status',       via: :get
-  match api_path + '/monitoring/token',                to: 'monitoring#token',        via: :post
+  match api_path + '/monitoring/health_check',         to: 'monitoring#health_check',      via: :get
+  match api_path + '/monitoring/status',               to: 'monitoring#status',            via: :get
+  match api_path + '/monitoring/token',                to: 'monitoring#token',             via: :post
+  match api_path + '/monitoring/restart_dead_jobs',    to: 'monitoring#restart_dead_jobs', via: :post
 
 end

--- a/db/migrate/20170515000001_scheduler_status.rb
+++ b/db/migrate/20170515000001_scheduler_status.rb
@@ -1,0 +1,8 @@
+class SchedulerStatus < ActiveRecord::Migration
+  def up
+    change_table :schedulers do |t|
+      t.string :error_message
+      t.string :status
+    end
+  end
+end


### PR DESCRIPTION
We have been experiencing some problems with errors occurring in scheduler jobs. We would for instance encounter something like this in our logs:

```
/opt/zammad/app/models/scheduler.rb:114:in `rescue in _start_job': STOP thread for HttpLog.cleanup after 10 tries (RuntimeError)
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:112:in `rescue in _start_job'
        from /opt/zammad/app/models/scheduler.rb:86:in `_start_job'
        from /opt/zammad/app/models/scheduler.rb:73:in `block in start_job'
```


After something like this happens the scheduler thread exits and future background jobs are no longer executed. This has happened quite a few times (not always the same error) since we have gone live with Zammad. Therefore we think it would be nice if the scheduler would no longer exit on an error occurring in a single job, but instead would only stop trying to start this specific job. This pull request contains a proposition to no longer raise an exception when an error occurs, but instead record the error and stop all attempts to start this job. The user is informed about failing jobs through the monitoring tool. To make it possible for an administrator to attempt to restart the job without having to edit database columns a button was added that appears when issues. Clicking this button will mark dead jobs for a restart if there are any.

So this pull request consists of two parts. The first is no longer throwing an exception when an error occurs in a scheduler to prevent the scheduler thread from exiting, which is our primary concern. The second is the button to restart dead jobs.

I'm curious to hear your thoughts on this.