### PR TITLE
Do not fail Zendesk import if subject is not set

### DIFF
--- a/lib/import/zendesk/ticket.rb
+++ b/lib/import/zendesk/ticket.rb
@@ -39,7 +39,7 @@ module Import
 
         {
           id:                       ticket.id,
-          title:                    ticket.subject,
+          title:                    ticket.subject || ticket.description || "No title",
           owner_id:                 Import::Zendesk::UserFactory.local_id( ticket.assignee ) || 1,
           note:                     ticket.description,
           group_id:                 Import::Zendesk::GroupFactory.local_id( ticket.group_id ) || 1,


### PR DESCRIPTION
Fall back to description or hard-coded title "No title" instead if ticket has no subject in Zendesk (which is allowed).