### PR TITLE
fixed shortcut key typo in translation

### DIFF
--- a/app/assets/javascripts/app/views/translation/index.jst.eco
+++ b/app/assets/javascripts/app/views/translation/index.jst.eco
@@ -12,7 +12,7 @@
 
   <div class="box box--message">
     <h2><%- @T('Inline translation') %></h2>
-    <p><%- @T('To make translations easier you can enable and disable the inline translation feature by pressing "%s".', 'ctrl+alt+t') %></p>
+    <p><%- @T('To make translations easier you can enable and disable the inline translation feature by pressing "%s".', 'shift+ctrl+t') %></p>
     <p><%- @T('Text with disabled inline translations looks like') %> <button class="btn btn-primary"><%- @Ti('Some Text') %></button></p>
     <p><%- @T('Text with enabled inline translations looks like') %> <button class="btn btn-primary"><span class="translation" contenteditable="true"><%- @Ti('Some Text') %></button></span></p>
     <p><%- @T('Just click into the marker and update the words just in place. Enjoy!') %></p>


### PR DESCRIPTION
ctrl+alt+t -> shift+ctrl+t