### PR TITLE
[Task-#1410] Add option to make email header info visible by default

### DIFF
--- a/app/assets/javascripts/app/controllers/_profile/email_header.coffee
+++ b/app/assets/javascripts/app/controllers/_profile/email_header.coffee
@@ -1,0 +1,87 @@
+class Index extends App.ControllerSubContent
+  requiredPermission: 'user_preferences.email_header'
+  header: 'EmailHeader'
+  events:
+    'submit form': 'update'
+
+  constructor: ->
+    super
+    @header_pre_val = true
+    @getHeaderPre()
+    
+
+  render: =>
+    html    = $( App.view('profile/email_header')() )
+    options = {}
+    locales = ["Yes", "No"]
+    for locale in locales
+      options[locale] = locale
+    configure_attributes = [
+      { name: 'header_pre', display: '', tag: 'select', null: false, class: 'select', options: options, default: @header_pre_val },
+    ]
+
+    @form = new App.ControllerForm(
+      el: html.find('.header_pre')
+      model:     { configure_attributes: configure_attributes }
+      autofocus: false
+    )
+    @html html
+
+  getHeaderPre: =>
+    @ajax(
+      id: 'header_pre'
+      type: 'GET'
+      url:  "#{@apiPath}/users/get_preferences"
+      processData: true
+      success: (data, status, xhr) =>
+        console.log("data----", data)
+        @header_pre_val = data.header_pre
+        @render()
+    )
+
+
+
+  update: (e) =>
+    e.preventDefault()
+    params = @formParam(e.target)
+    error  = @form.validate(params)
+    if error
+      @formValidate( form: e.target, errors: error )
+      return false
+
+    @formDisable(e)
+
+    # get data
+    @locale = params['header_pre']
+    @ajax(
+      id:          'header_pre'
+      type:        'PUT'
+      url:         "#{@apiPath}/users/preferences"
+      data:        JSON.stringify({user:params})
+      processData: true
+      success:     @success
+      error:       @error
+    )
+
+  success: (data, status, xhr) =>
+    App.User.full(
+      App.Session.get('id'),
+      =>
+        App.Event.trigger('ui:rerender')
+        @notify(
+          type: 'success'
+          msg:  App.i18n.translateContent('Successful!')
+        )
+      ,
+      true
+    )
+
+  error: (xhr, status, error) =>
+    @render()
+    data = JSON.parse(xhr.responseText)
+    @notify(
+      type: 'error'
+      msg:  App.i18n.translateContent(data.message)
+    )
+
+App.Config.set('EmailHeader', { prio: 1000, name: 'EmailHeader', parent: '#profile', target: '#profile/email_header', controller: Index, permission: ['user_preferences.header_pre'] }, 'NavBarProfile')

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
@@ -179,6 +179,7 @@ class ArticleViewItem extends App.ObserverController
     @html App.view('ticket_zoom/article_view')(
       ticket:     @ticket
       article:    article
+      user:       App.Session.get()
       isCustomer: @permissionCheck('ticket.customer')
     )
 
@@ -192,6 +193,7 @@ class ArticleViewItem extends App.ObserverController
       el:              @$('.js-article-actions')
       ticket:          @ticket
       article:         article
+      user:            "A"
       lastAttributres: @lastAttributres
     )
 
@@ -216,7 +218,7 @@ class ArticleViewItem extends App.ObserverController
 
     @measureSeeMore()
 
-  measureSeeMore: =>
+  measureSeeMore: (e) =>
     maxHeight               = 560
     minHeight               = 90
     bubbleContent           = @textBubbleContent
@@ -251,7 +253,9 @@ class ArticleViewItem extends App.ObserverController
       markerHeight = offsetTop.top
 
     # if signature marker exists and heigth is within maxHeight
-    if markerHeight && markerHeight < maxHeight
+    if (markerHeight && markerHeight < maxHeight) || bubbleOverflowContainer.hasClass('Yes')
+      # @toggleMetaTimeout = setTimeout(@toggleMeta, 120, e)
+
       newHeigth = markerHeight + 30
       if newHeigth < minHeight
         newHeigth = minHeight
@@ -260,6 +264,7 @@ class ArticleViewItem extends App.ObserverController
       bubbleContent.attr('data-height-origin', newHeigth)
       bubbleContent.css('height', "#{newHeigth}px")
       bubbleOverflowContainer.removeClass('hide')
+      @toggleMeta(false, {target: bubbleOverflowContainer})
 
     # if heigth is higher then maxHeight
     else if bubbleContentHeigth > maxHeight
@@ -284,11 +289,14 @@ class ArticleViewItem extends App.ObserverController
       @toggleMetaTimeout = setTimeout(@toggleMeta, delay, e)
       @lastClick = +new Date
 
-  toggleMeta: (e) =>
-    e.preventDefault()
-
+  toggleMeta: (e, option = {}) =>
+    if(e)
+      e.preventDefault()
+      target = e.target
+    else
+      target = option['target']
     animSpeed      = 300
-    article        = $(e.target).closest('.ticket-article-item')
+    article        = $(target).closest('.ticket-article-item')
     metaTopClip    = article.find('.article-meta-clip.top')
     metaBottomClip = article.find('.article-meta-clip.bottom')
     metaTop        = article.find('.article-content-meta.top')

--- a/app/assets/javascripts/app/views/profile/email_header.jst.eco
+++ b/app/assets/javascripts/app/views/profile/email_header.jst.eco
@@ -1,0 +1,12 @@
+<div class="page-header">
+  <div class="page-header-title">
+    <h1><%- @T('Language') %></h1>
+  </div>
+</div>
+<div class="page-content">
+  <p><%- @T('Change your language.') %></p>
+  <form class="settings-entry horizontal end">
+    <div class="form-item header_pre flex"></div>
+    <button type="submit" class="btn btn--primary"><%- @T('Submit') %></button>
+  </form>
+</div>

--- a/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
+++ b/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
@@ -47,7 +47,7 @@
         <div class="bubble-arrow"></div>
         <div class="textBubble-content" id="article-content-<%= @article.id %>" data-id="<%= @article.id %>">
           <div class="richtext-content"><%- @article.html %></div>
-          <div class="textBubble-overflowContainer hide">
+          <div class="textBubble-overflowContainer hide <%= @user.preferences['header_pre'] %>">
             <div class="btn btn--text js-toggleFold"><%- @T('See more') %></div>
           </div>
         </div>

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -815,6 +815,12 @@ curl http://localhost/api/v1/users/preferences -v -u #{login}:#{password} -H "Co
     render json: { message: 'ok' }, status: :ok
   end
 
+  def get_preferences
+    raise Exceptions::UnprocessableEntity, 'No current user!' if !current_user
+    user = User.find(current_user.id)
+    render json: { message: 'ok', header_pre:  user.preferences[:header_pre]}, status: :ok
+  end
+
 =begin
 
 Resource:

--- a/config/routes/user.rb
+++ b/config/routes/user.rb
@@ -7,6 +7,7 @@ Zammad::Application.routes.draw do
   match api_path + '/users/password_reset',        to: 'users#password_reset_send',   via: :post
   match api_path + '/users/password_reset_verify', to: 'users#password_reset_verify', via: :post
   match api_path + '/users/password_change',       to: 'users#password_change',       via: :post
+  match api_path + '/users/get_preferences',       to: 'users#get_preferences',       via: :get
   match api_path + '/users/preferences',           to: 'users#preferences',           via: :put
   match api_path + '/users/out_of_office',         to: 'users#out_of_office',         via: :put
   match api_path + '/users/account',               to: 'users#account_remove',        via: :delete


### PR DESCRIPTION
- We have added email header coffee controller and email_header.jst.eco view file. So that admin/agent are able to see Email Header Link.
- In UsersController we have added get_prefrences API, and also added rails routes for them.
- And in the ticket_zoom/article_view.coffee we have passed the user to the view from the session.
- And according to selected value into the email_header preference, we are showing email header information such as FROM, TO, SUBJECT and CHANNEL.

