### PR TITLE
Adds customer_ticket_create requirement to enable form

### DIFF
--- a/app/controllers/form_controller.rb
+++ b/app/controllers/form_controller.rb
@@ -241,7 +241,7 @@ class FormController < ApplicationController
 
   def enabled?
     return true if params[:test] && current_user && current_user.permissions?('admin.channel_formular')
-    return true if Setting.get('form_ticket_create')
+    return true if Setting.get('form_ticket_create') && Setting.get('customer_ticket_create')
     response_access_deny
     false
   end

--- a/test/controllers/form_controller_test.rb
+++ b/test/controllers/form_controller_test.rb
@@ -244,4 +244,29 @@ class FormControllerTest < ActionDispatch::IntegrationTest
     assert(result['error'])
   end
 
+  test '06 - customer_ticket_create false disables form' do
+    Setting.set('form_ticket_create', true)
+    Setting.set('customer_ticket_create', false)
+
+    fingerprint = SecureRandom.hex(40)
+
+    post '/api/v1/form_config', params: { fingerprint: fingerprint }.to_json, headers: @headers
+
+    result = JSON.parse(@response.body)
+    token = result['token']
+    params = {
+        fingerprint: fingerprint,
+        token: token,
+        name: 'Bob Smith',
+        email: 'discard@znuny.com',
+        title: 'test',
+        body: 'hello'
+    }
+
+    post '/api/v1/form_submit', params: params.to_json, headers: @headers
+
+    assert_response(401)
+  end
+
+
 end


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

Fixes #1339 

Enable ticket creation at Admin -> Channels -> Web now enables/disables the web form.
Requires `customer_ticket_create` to be `true` to consider the Web form enabled. 