### PR TITLE
Tell Internet Explorer to display content in the highest mode available.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=1024">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title><%= Setting.get('product_name') %></title>
   <%= stylesheet_link_tag "application", :media => 'all' %>
   <%= stylesheet_link_tag "application-print", :media => 'print' %>

--- a/config/initializers/html_email_style.rb
+++ b/config/initializers/html_email_style.rb
@@ -6,6 +6,7 @@ Rails.application.config.html_email_body = <<HERE
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <style type="text/css">
       body {
         #{Rails.application.config.html_email_css_font};

--- a/config/initializers/html_email_style.rb
+++ b/config/initializers/html_email_style.rb
@@ -6,7 +6,7 @@ Rails.application.config.html_email_body = <<HERE
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <style type="text/css">
       body {
         #{Rails.application.config.html_email_css_font};


### PR DESCRIPTION
This shall solve issues like Company Profiles setting to a lower document mode per default, that prevents the page to be loaded  for e.g.  IE document mode 7 etc.