### PR TITLE
change character length limit in "note" column in both organizations …

### DIFF
--- a/db/migrate/20120101000001_create_base.rb
+++ b/db/migrate/20120101000001_create_base.rb
@@ -36,7 +36,7 @@ class CreateBase < ActiveRecord::Migration[4.2]
       t.boolean :vip,                                         default: false
       t.boolean :verified,                        null: false, default: false
       t.boolean :active,                          null: false, default: true
-      t.string :note,                 limit: 250, null: true, default: ''
+      t.string :note,                 limit: 5000, null: true, default: ''
       t.timestamp :last_login,        limit: 3,   null: true
       t.string :source,               limit: 200, null: true
       t.integer :login_failed,                    null: false, default: 0
@@ -147,7 +147,7 @@ class CreateBase < ActiveRecord::Migration[4.2]
       t.string :domain,                 limit: 250, null: true,  default: ''
       t.boolean :domain_assignment,                 null: false, default: false
       t.boolean :active,                            null: false, default: true
-      t.string :note,                   limit: 250, null: true,  default: ''
+      t.string :note,                   limit: 5000, null: true,  default: ''
       t.integer :updated_by_id,                     null: false
       t.integer :created_by_id,                     null: false
       t.timestamps limit: 3,   null: false

--- a/db/migrate/20171002091043_change_note_char_limit_for_users_and_organizations.rb
+++ b/db/migrate/20171002091043_change_note_char_limit_for_users_and_organizations.rb
@@ -1,11 +1,20 @@
 class ChangeNoteCharLimitForUsersAndOrganizations < ActiveRecord::Migration[5.1]
   def up
+    # return if it's a new setup to avoid running the migration
+    return if !Setting.find_by(name: 'system_init_done')
+
     change_column :organizations, :note, :string, limit: 5000
     change_column :users, :note, :string, limit: 5000
+
+    object_id = ObjectLookup.by_name('User')
+    attribute = ObjectManager::Attribute.find_by(object_lookup_id: object_id, name: 'note')
+    attribute.data_option[:maxlength] = 5000
+    attribute.save!
+
+    object_id = ObjectLookup.by_name('Organization')
+    attribute = ObjectManager::Attribute.find_by(object_lookup_id: object_id, name: 'note')
+    attribute.data_option[:maxlength] = 5000
+    attribute.save!
   end
 
-  def down
-    change_column :organizations, :note, :string, limit: 250
-    change_column :users, :note, :string, limit: 250
-  end
 end

--- a/db/migrate/20171002091043_change_note_char_limit_for_users_and_organizations.rb
+++ b/db/migrate/20171002091043_change_note_char_limit_for_users_and_organizations.rb
@@ -1,0 +1,11 @@
+class ChangeNoteCharLimitForUsersAndOrganizations < ActiveRecord::Migration[5.1]
+  def up
+    change_column :organizations, :note, :string, limit: 5000
+    change_column :users, :note, :string, limit: 5000
+  end
+
+  def down
+    change_column :organizations, :note, :string, limit: 250
+    change_column :users, :note, :string, limit: 250
+  end
+end

--- a/db/seeds/object_manager_attributes.rb
+++ b/db/seeds/object_manager_attributes.rb
@@ -1077,7 +1077,7 @@ ObjectManager::Attribute.add(
   data_type: 'richtext',
   data_option: {
     type: 'text',
-    maxlength: 250,
+    maxlength: 5000,
     null: true,
     note: 'Notes are visible to agents only, never to customers.',
   },
@@ -1329,7 +1329,7 @@ ObjectManager::Attribute.add(
   data_type: 'richtext',
   data_option: {
     type: 'text',
-    maxlength: 250,
+    maxlength: 5000,
     null: true,
     note: 'Notes are visible to agents only, never to customers.',
   },


### PR DESCRIPTION
…and users #1495

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

Current column limit is 250 characters for "note" column field in both organizations and users table. This migration will increase that to 5000 with a way to rollback to 250 characters, if needed.