### PR TITLE
fixed description typo of systemd script

### DIFF
--- a/script/systemd/zammad-rails.service
+++ b/script/systemd/zammad-rails.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Zammad railsserver
+Description=Zammad rails server
 After=syslog.target
 After=network.target
 After=zammad.service


### PR DESCRIPTION
just a small fix description typo of systemd script. @monotek 