### PR TITLE
the old branch of forked composite key gem is no longer available, us…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,8 +53,7 @@ gem 'mime-types'
 
 gem 'biz'
 
-# temporary till pull request gets merged: https://github.com/composite-primary-keys/composite_primary_keys/pull/404
-gem 'composite_primary_keys', git: 'https://github.com/jkowens/composite_primary_keys.git', branch: 'rails-5_1'
+gem 'composite_primary_keys', github: 'composite-primary-keys/composite_primary_keys', tag: 'v10.0.0'
 gem 'delayed_job_active_record'
 gem 'daemons'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
-  remote: https://github.com/jkowens/composite_primary_keys.git
-  revision: 7f4670b54b3c6e94992161b4efe2c8717d7c0e71
-  branch: rails-5_1
+  remote: git://github.com/composite-primary-keys/composite_primary_keys.git
+  revision: d0ba96d4f44b008496cf891bfb964b54d28c1e8b
+  tag: v10.0.0
   specs:
-    composite_primary_keys (9.0.7)
+    composite_primary_keys (10.0.0)
       activerecord (~> 5.1.0)
 
 GIT
@@ -554,4 +554,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.2


### PR DESCRIPTION
…e the official gem with tag v10.0.0 for rails 5.1

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

The composite_key gem from it's official repository has already released an official version to support Rails 5.1 (v10.0.0) and the forked repo branch that zammad uses for composite_key is no longer available (and travis build fails).