### PR TITLE
Added option to make email header visible by default

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom.coffee
@@ -20,7 +20,18 @@ class App.TicketZoom extends App.Controller
     @ticket_id    = params.ticket_id
     @article_id   = params.article_id
     @sidebarState = {}
-
+    @expandArticle = false
+    role_ids = $.map App.Session.get('roles'), (a) ->
+                 a.id
+    for localRoleId in role_ids
+        role = App.Role.find(localRoleId)
+        if role
+          for permission_id in role.permission_ids
+            localPermission = App.Permission.find(permission_id)
+            if localPermission
+              if localPermission.name is 'user_preferences.email_header'
+                @expandArticle = true
+                break
     # if we are in init task startup, ignore overview_id
     if !params.init
       @overview_id = params.overview_id
@@ -229,6 +240,12 @@ class App.TicketZoom extends App.Controller
     @shortcutNavigationStart()
     return if !@attributeBar
     @attributeBar.start()
+
+    if @expandArticle
+      $('.textBubble').each (e, el) =>
+        if $(el).parents('.ticket-article-item').hasClass('state--folde-out')
+        else
+          $(el).click();
 
   pagePosition: (params = {}) =>
 

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -341,6 +341,11 @@ Permission.create_if_not_exists(
     not: ['cti.customer'],
   },
 )
+Permission.create_if_not_exists(
+  name: 'user_preferences.email_header',
+  note: 'Email header information visible by default',
+  preferences: {},
+)
 
 admin = Role.find_by(name: 'Admin')
 admin.permission_grant('user_preferences')


### PR DESCRIPTION
Add an entry to permissions table named: 'user_preferences.email_header'. And also added an option into Admin settings Page into roles tab's user_preferences section with heading 'Email header information visible by default'.