### PR TITLE
Make create Ticket button intuitive

### DIFF
--- a/app/assets/javascripts/app/controllers/customer_ticket_create.coffee
+++ b/app/assets/javascripts/app/controllers/customer_ticket_create.coffee
@@ -189,4 +189,4 @@ class Index extends App.ControllerContent
       )
 
 App.Config.set('customer_ticket_new', Index, 'Routes')
-App.Config.set('CustomerTicketNew', { prio: 8003, parent: '#new', name: 'New Ticket', translate: true, target: '#customer_ticket_new', permission: ['ticket.customer'], divider: true }, 'NavBarRight')
+App.Config.set('CustomerTicketNew', { prio: 8003, parent: '#new', name: 'New Customer Ticket', translate: true, target: '#customer_ticket_new', permission: ['ticket.customer'], divider: true }, 'NavBarRight')


### PR DESCRIPTION
Changed '#create_customer_ticket' button name 'New Ticket' to 'New Customer Ticket' to make button intuitive.