### PR TITLE
fix IPv6 binding problem for eventmachine websockets

### DIFF
--- a/app/assets/javascripts/app/controllers/chat.coffee
+++ b/app/assets/javascripts/app/controllers/chat.coffee
@@ -441,7 +441,8 @@ class ChatWindow extends App.Controller
         tags: params.tags
     )
 
-    @metaName.text(params.name)
+    if !_.isEmpty(params.name)
+      @metaName.text(params.name)
 
   render: ->
     @html App.view('customer_chat/chat_window')(

--- a/script/websocket-server.rb
+++ b/script/websocket-server.rb
@@ -120,9 +120,8 @@ end
 @clients = {}
 Rails.configuration.interface = 'websocket'
 EventMachine.run do
- 
-  available_addr = Socket.ip_address_list.collect { |address| address.ip_address } # fetch all available IPs on machine
-  available_addr += ["0.0.0.0", "::"] # add IP binding for all interfaces
+  available_addr = Socket.ip_address_list.collect(&:ip_address) # fetch all available IPs on machine
+  available_addr += ['0.0.0.0', '::'] # add IP binding for all interfaces
   @options[:b] = IPAddr.new @options[:b] # check if it is valid IPv4 or IPv6 address
   raise Exceptions::UnprocessableEntity, 'IP address is not available on this machine.' if available_addr.exclude? @options[:b].to_s # raise if IP Address is not available
 

--- a/script/websocket-server.rb
+++ b/script/websocket-server.rb
@@ -120,11 +120,12 @@ end
 @clients = {}
 Rails.configuration.interface = 'websocket'
 EventMachine.run do
-    if /(\[(?:[:0-9A-Fa-f]+)\])/.match(@options[:b])
-      @options[:b] = @options[:b].tr('[]', '') 
-    end
 
-    EventMachine::WebSocket.start( host: @options[:b], port: @options[:p], secure: @options[:s], tls_options: tls_options ) do |ws|
+  if /(\[(?:[:0-9A-Fa-f]+)\])/.match?(@options[:b])
+    @options[:b] = @options[:b].tr('[]', '')
+  end
+
+  EventMachine::WebSocket.start(host: @options[:b], port: @options[:p], secure: @options[:s], tls_options: tls_options) do |ws|
 
     # register client connection
     ws.onopen do |handshake|

--- a/script/websocket-server.rb
+++ b/script/websocket-server.rb
@@ -120,7 +120,11 @@ end
 @clients = {}
 Rails.configuration.interface = 'websocket'
 EventMachine.run do
-  EventMachine::WebSocket.start( host: @options[:b], port: @options[:p], secure: @options[:s], tls_options: tls_options ) do |ws|
+    if /(\[(?:[:0-9A-Fa-f]+)\])/.match(@options[:b])
+      @options[:b] = @options[:b].tr('[]', '') 
+    end
+
+    EventMachine::WebSocket.start( host: @options[:b], port: @options[:p], secure: @options[:s], tls_options: tls_options ) do |ws|
 
     # register client connection
     ws.onopen do |handshake|

--- a/script/websocket-server.rb
+++ b/script/websocket-server.rb
@@ -120,11 +120,9 @@ end
 @clients = {}
 Rails.configuration.interface = 'websocket'
 EventMachine.run do
-
-  if /(\[(?:[:0-9A-Fa-f]+)\])/.match?(@options[:b]) # check if there is an IPv6 Address
-    @options[:b] = @options[:b].tr('[]', '') # remove square brackets
-  end
-  EventMachine::WebSocket.start(host: @options[:b], port: @options[:p], secure: @options[:s], tls_options: tls_options) do |ws|
+ 
+  @options[:b] = IPAddr.new @options[:b]
+  EventMachine::WebSocket.start(host: @options[:b].to_s, port: @options[:p], secure: @options[:s], tls_options: tls_options) do |ws|
 
     # register client connection
     ws.onopen do |handshake|

--- a/script/websocket-server.rb
+++ b/script/websocket-server.rb
@@ -122,9 +122,9 @@ Rails.configuration.interface = 'websocket'
 EventMachine.run do
  
   available_addr = Socket.ip_address_list.collect { |address| address.ip_address } # fetch all available IPs on machine
-  available_addr += ["0.0.0.0", "[::]"] # add IP binding for all interfaces
+  available_addr += ["0.0.0.0", "::"] # add IP binding for all interfaces
   @options[:b] = IPAddr.new @options[:b] # check if it is valid IPv4 or IPv6 address
-  raise Exceptions::UnprocessableEntity, 'IP address is not available on this machine.' if available_addr.exclude? @options[:b] # raise if IP Address is not available
+  raise Exceptions::UnprocessableEntity, 'IP address is not available on this machine.' if available_addr.exclude? @options[:b].to_s # raise if IP Address is not available
 
   EventMachine::WebSocket.start(host: @options[:b].to_s, port: @options[:p], secure: @options[:s], tls_options: tls_options) do |ws|
 

--- a/script/websocket-server.rb
+++ b/script/websocket-server.rb
@@ -121,7 +121,11 @@ end
 Rails.configuration.interface = 'websocket'
 EventMachine.run do
  
-  @options[:b] = IPAddr.new @options[:b]
+  available_addr = Socket.ip_address_list.collect { |address| address.ip_address } # fetch all available IPs on machine
+  available_addr += ["0.0.0.0", "[::]"] # add IP binding for all interfaces
+  @options[:b] = IPAddr.new @options[:b] # check if it is valid IPv4 or IPv6 address
+  raise Exceptions::UnprocessableEntity, 'IP address is not available on this machine.' if available_addr.exclude? @options[:b] # raise if IP Address is not available
+
   EventMachine::WebSocket.start(host: @options[:b].to_s, port: @options[:p], secure: @options[:s], tls_options: tls_options) do |ws|
 
     # register client connection


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

Problem is that eventmachine does not accept IPv6 address with square brackets, (eg. [::1]). Only without it (eg ::1)

This PR checks if there is an IPv6 address with square brackets in the binding port flag and removes the square brackets.