### PR TITLE
#1695 prevent disable of admin users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < ApplicationModel
 
   before_validation :check_name, :check_email, :check_login, :check_mail_delivery_failed, :ensure_uniq_email, :ensure_password, :ensure_roles, :ensure_identifier
   before_create   :check_preferences_default, :validate_ooo, :domain_based_assignment, :set_locale
-  before_update   :check_preferences_default, :validate_ooo, :reset_login_failed, :validate_agent_limit_by_attributes, :last_admin_check_by_attribute
+  before_update   :check_preferences_default, :validate_ooo, :reset_login_failed, :validate_agent_limit_by_attributes, :last_admin_check_by_attribute, :check_admin_active
   after_create    :avatar_for_email_check
   after_update    :avatar_for_email_check
   after_destroy   :avatar_destroy, :user_device_destroy
@@ -987,6 +987,23 @@ returns
     raise Exceptions::UnprocessableEntity, 'out of office end is before start' if out_of_office_start_at > out_of_office_end_at
     raise Exceptions::UnprocessableEntity, 'out of office replacement user is required' if out_of_office_replacement_id.blank?
     raise Exceptions::UnprocessableEntity, 'out of office no such replacement user' if !User.find_by(id: out_of_office_replacement_id)
+    true
+  end
+
+=begin
+
+checks if the user is admin before disabling the user. if the user is admin, raise error.
+
+Raises
+
+raise 'Admin user cannot be deactivated'
+
+=end
+
+  def check_admin_active
+    return true if !will_save_change_to_attribute?('active')
+    return true if active != false
+    raise Exceptions::UnprocessableEntity, 'Admin user cannot be deactivated.' if permissions?(['admin', 'admin.user'])
     true
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -188,4 +188,12 @@ RSpec.describe User do
       }
     end
   end
+
+  context 'admin' do
+    it "does not allow admin user to be deactivated" do
+      user = create(:user)
+      user.roles = Role.where(name: 'Admin')
+      expect{user.update!(active: false)}.to raise_error(Exceptions::UnprocessableEntity, 'Admin user cannot be deactivated.')
+    end
+  end
 end


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

Currently, the admin user can be deactivated by rails console (or LDAP imports) which can be by accident. This fix ensures that admin user can never be deactivated by rails console or LDAP imports by checking on the record update.