### PR TITLE
Slack::Notifier::post (slack-notifier-2.3.1) returns an array of User…

### DIFF
--- a/app/models/transaction/slack.rb
+++ b/app/models/transaction/slack.rb
@@ -181,7 +181,7 @@ class Transaction::Slack
         result = notifier.ping result[:subject],
                                attachments: [attachment]
       end
-      if !result.success?
+      if !result.empty? && !result[0].success?
         if sent_value
           Cache.delete(cache_key)
         end


### PR DESCRIPTION
…Agent::Result

This is a patch of an error which showed up using the Slack integration.

This was the error in log/production.log:
ERROR: Transaction::Slack
ERROR: #<NoMethodError: undefined method `success?' for #<Slack::Notifier:0x...>

The reason is that Slack::Notifier::post (slack-notifier-2.3.1) returns an array of UserAgent::Result via the ".map" loop and not a single instance of UserAgent::Result.

ruby 2.5.0p0 (2017-12-25 revision 61468) [x86_64-linux] with debian stretch
