### PR TITLE
Device mails: make profile link clickable

### DIFF
--- a/app/views/mailer/user_device_new/cs.html.erb
+++ b/app/views/mailer/user_device_new/cs.html.erb
@@ -12,7 +12,7 @@ Vaše IP: #{user_device.ip}<br>
 <br>
 <div>Vaše zařízení bylo přidáno do vašeho seznamu známých zařízení, jenž si můžete prohlédnout na níže zmíněném odkazu:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>Pokud se nejedná o Vás, respektive o tom nic nevíte, odstraňte toto zařízení ze seznamu, změňte své heslo, případně smažte osobní přístupové tokeny a co nejdříve kontaktujte Vašeho administrátora. Takže nikdo jiný nebude mít neautorizovaný přístup do Vašeho účtu.</div>
 <br>

--- a/app/views/mailer/user_device_new/de.html.erb
+++ b/app/views/mailer/user_device_new/de.html.erb
@@ -12,7 +12,7 @@ Deine IP: #{user_device.ip}<br>
 <br>
 <div>Das Gerät wurde in die Liste der bekannten Geräte hinzugefügt, diese Liste kannst Du hier einsehen:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>Wenn dies nicht Du warst, entferne das Gerät aus der Liste, ändere Dein Account-Passwort und kontaktieren Deinen Administrator. Jemand könnte unberechtigten Zugriff auf Dein Konto bekommen haben.</div>
 <br>

--- a/app/views/mailer/user_device_new/en.html.erb
+++ b/app/views/mailer/user_device_new/en.html.erb
@@ -12,7 +12,7 @@ Your IP: #{user_device.ip}<br>
 <br>
 <div>Your device has been added to your list of known devices, which you can view here:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>If this wasn't you, remove the device, changing your account password, and contacting your administrator. Somebody might have gained unauthorized access to your account.</div>
 <br>

--- a/app/views/mailer/user_device_new/fr.html.erb
+++ b/app/views/mailer/user_device_new/fr.html.erb
@@ -12,7 +12,7 @@ Votre IP: #{user_device.ip}<br>
 <br>
 <div>Votre appareil a été ajouté à votre liste d'appareils connus, que vous pouvez consulter ici:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>Si ce n'était pas vous, supprimez l'appareil, modifiez le mot de passe de votre compte et contactez votre administrateur. Quelqu'un a peut-être obtenu un accès non autorisé à votre compte.</div>
 <br>

--- a/app/views/mailer/user_device_new/pt-br.html.erb
+++ b/app/views/mailer/user_device_new/pt-br.html.erb
@@ -12,7 +12,7 @@ Seu IP: #{user_device.ip}<br>
 <br>
 <div>Seu dispositivo foi adicionado na lista de dispositivos conhecidos, qual você pode ver aqui:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>Se não foi você, remova o dispositivo, altere sua senha e entre em contato com o Administrador. Alguém pode ter ganho acesso não autorizado à sua conta.</div>
 <br>

--- a/app/views/mailer/user_device_new/zh-cn.html.erb
+++ b/app/views/mailer/user_device_new/zh-cn.html.erb
@@ -12,7 +12,7 @@ IP 地址: #{user_device.ip}<br>
 <br>
 <div>您可以点击如下连接查看那些设备被添加到已知清单里:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>如果这不是您的设备, 请删除该设备, 更改该帐号的密码, 并马上向系统管理员报告. 有可能是有人未经授权登录了您的帐号.</div>
 <br>

--- a/app/views/mailer/user_device_new/zh-tw.html.erb
+++ b/app/views/mailer/user_device_new/zh-tw.html.erb
@@ -12,7 +12,7 @@ IP 位址: #{user_device.ip}<br>
 <br>
 <div>你可以登入下面的網址查看有那些裝置被添加到已知的清單里:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>如果發現不是你熟悉的裝置, 請刪除這個裝置, 然后更改賬號密碼, 并立即向系統管理員報告, 有可能是別人未經許可登入了你的賬號.</div>
 <br>

--- a/app/views/mailer/user_device_new_location/cs.html.erb
+++ b/app/views/mailer/user_device_new_location/cs.html.erb
@@ -12,7 +12,7 @@ Vaše IP: #{user_device.ip}<br>
 <br>
 <div>Tento stát bude přidán do seznamu známých zařízení, jenž můžete shlédnout v níže zmíněném odkazu:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>Pokud se nejedná o Vás, respektive o tom nic nevíte, odstraňte toto zařízení ze seznamu, změňte své heslo, případně smažte osobní přístupové tokeny a co ne$
 <br>

--- a/app/views/mailer/user_device_new_location/de.html.erb
+++ b/app/views/mailer/user_device_new_location/de.html.erb
@@ -12,7 +12,7 @@ Deine IP: #{user_device.ip}<br>
 <br>
 <div>Das neue Land wurde in die Liste der bekannten Geräte hinzugefügt, diese Liste kannst Du hier einsehen:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>Wenn dies nicht Du warst, entferne die neue Lokation aus der Liste, ändere Dein Account-Passwort und kontaktieren Deinen Administrator. Jemand könnte unberechtigten Zugriff auf Dein Konto bekommen haben.</div>
 <br>

--- a/app/views/mailer/user_device_new_location/en.html.erb
+++ b/app/views/mailer/user_device_new_location/en.html.erb
@@ -12,7 +12,7 @@ Your IP: #{user_device.ip}<br>
 <br>
 <div>The country has been added to your list of known devices, which you can view here:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>If this wasn't you, remove the device, changing your account password, and contacting your administrator. Somebody might have gained unauthorized access to your account.</div>
 <br>

--- a/app/views/mailer/user_device_new_location/fr.html.erb
+++ b/app/views/mailer/user_device_new_location/fr.html.erb
@@ -12,7 +12,7 @@ Votre IP: #{user_device.ip}<br>
 <br>
 <div>Le pays a été ajouté à votre liste d'appareils connus, que vous pouvez l'afficher ici:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>Si ce n'était pas vous, supprimez l'appareil, modifiez le mot de passe de votre compte et contactez votre administrateur. Quelqu'un a peut-être obtenu un accès non autorisé à votre compte.</div>
 <br>

--- a/app/views/mailer/user_device_new_location/pt-br.html.erb
+++ b/app/views/mailer/user_device_new_location/pt-br.html.erb
@@ -12,7 +12,7 @@ Seu IP: #{user_device.ip}<br>
 <br>
 <div>O País foi adicionado na sua lista de dispositivos conhecidos, que pode ser visto aqui:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>If this wasn't you, remove the device, changing your account password, and contacting your administrator. Somebody might have gained unauthorized access to your account.</div>
 <div>Se não foi você, remova o dispositivo, altere sua senha e entre em contato com o Administrador. Alguém pode ter ganho acesso não autorizado à sua conta.</div>

--- a/app/views/mailer/user_device_new_location/zh-cn.html.erb
+++ b/app/views/mailer/user_device_new_location/zh-cn.html.erb
@@ -12,7 +12,7 @@ IP地址: #{user_device.ip}<br>
 <br>
 <div>您可以点击如下连接查看那些设备被添加到已知清单里:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>如果这不是您的设备, 请删除该设备, 更改该帐号的密码, 并马上向系统管理员报告. 有可能是有人未经授权登录了您的帐号.</div>
 <br>

--- a/app/views/mailer/user_device_new_location/zh-tw.html.erb
+++ b/app/views/mailer/user_device_new_location/zh-tw.html.erb
@@ -12,7 +12,7 @@ IP 位址: #{user_device.ip}<br>
 <br>
 <div>你可以登入下面的網址查看有那些裝置被添加到已知的清單里:</div>
 <br>
-<div>#{config.http_type}://#{config.fqdn}/#profile/devices</div>
+<div><a href="#{config.http_type}://#{config.fqdn}/#profile/devices">#{config.http_type}://#{config.fqdn}/#profile/devices</a></div>
 <br>
 <div>如果發現不是你熟悉的裝置, 請刪除這個裝置, 然后更改賬號密碼, 并立即向系統管理員報告, 有可能是別人未經許可登入了你的賬號.</div>
 <br>


### PR DESCRIPTION
I noticed the link to the user profile in the device notifications was not clickable in all mail clients because it was not wrapped in an `<a>` tag.
