### PR TITLE
Fix Travis CI build failures (by switching to containerized CI environment)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 dist: trusty
-sudo: required
-group: deprecated
+sudo: false
 notifications:
   email:
     - me+tv@zammad.com
@@ -11,6 +10,31 @@ addons:
   postgresql: "9.4"
   apt:
     packages:
+    - curl
+    - git-core
+    - patch
+    - build-essential
+    - bison
+    - zlib1g-dev
+    - libssl-dev
+    - libxml2-dev
+    - sqlite3
+    - libsqlite3-dev
+    - autotools-dev
+    - libxslt1-dev
+    - libyaml-0-2
+    - autoconf
+    - automake
+    - libreadline6-dev
+    - libyaml-dev
+    - libtool
+    - libgmp-dev
+    - libgdbm-dev
+    - libncurses5-dev
+    - pkg-config
+    - libffi-dev
+    - libmysqlclient-dev
+    - postfix
     - mysql-server-5.6
     - mysql-client-core-5.6
     - mysql-client-5.6
@@ -22,8 +46,6 @@ rvm:
   - 2.4.2
 before_install:
   - git fetch --unshallow
-  - sudo apt-get -qq update
-  - sudo apt-get install -y curl git-core patch build-essential bison zlib1g-dev libssl-dev libxml2-dev libxml2-dev sqlite3 libsqlite3-dev autotools-dev libxslt1-dev libyaml-0-2 autoconf automake libreadline6-dev libyaml-dev libtool libgmp-dev libgdbm-dev libncurses5-dev pkg-config libffi-dev libmysqlclient-dev postfix
   - if [ "${DB}" = "mysql" ]; then mysql -u root -e "CREATE USER 'some_user'@'localhost' IDENTIFIED BY 'some_pass';"; fi
   - if [ "${DB}" = "mysql" ]; then mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'some_user'@'localhost';"; fi
   - if [ "${DB}" = "mysql" ]; then cp config/database.yml.test-mysql config/database.yml; fi


### PR DESCRIPTION
@thorsteneckel, here is the PR we discussed.

Original (virtualized) CI environment led to a test failure that I could not reproduce in development. Using the containerized CI environment instead (now the default on Travis) [fixed the error on my fork](https://travis-ci.org/rlue/zammad/jobs/357753511). ([See here for an overview of Travis Build Environments](https://docs.travis-ci.com/user/reference/overview/).)

An added benefit is that containerized Travis builds can be [reproduced on a local development machine (via Docker) for debugging/troubleshooting](https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image).

### Notes

1. Travis’ containerized environments have [fewer resources than virtualized environments](https://docs.travis-ci.com/user/reference/overview/#Virtualisation-Environment-vs-Operating-System), so this change leads to 34% longer build time (~25:00 to ~33:30).

   As such, it might be worth exploring ways to reduce overall build time (_e.g.,_ by running tests in DB transactions rather than dropping, migrating, and re-seeding the database multiple times per build). 

2. I moved all packages from the `apt-get install` line to the `addons.apt.packages` section. Most packages are installed in the Docker image already (with the exception of postfix), but including them here ensures that the CI build will always be working against the most recent versions. Is that important, or can some of these package install directives be removed?