### PR TITLE
Addition to zammad_ssl.conf

### DIFF
--- a/contrib/apache2/zammad_ssl.conf
+++ b/contrib/apache2/zammad_ssl.conf
@@ -46,6 +46,12 @@
     ProxyPass /robots.txt !
     ProxyPass /ws ws://localhost:6042/
     ProxyPass / http://localhost:3000/
+    
+    # Use settings below if proxying does not work and you receive HTTP-Errror 404
+    # if you use the settings below, make sure to comment out the above two options
+    # This may not apply to all systems, applies to openSuse
+    #ProxyPass /ws ws://localhost:6042/ "retry=1 acque=3000 timeout=600 keepalive=On"
+    #ProxyPass / http://localhost:3000/ "retry=1 acque=3000 timeout=600 keepalive=On"
 
     DocumentRoot "/opt/zammad/public"
 


### PR DESCRIPTION
Added commented-out Proxy-Pass-settings that make the options work on openSuse and maybe other systems too. My apache 2.4 did not proxy without " "retry=1 acque=3000 timeout=600 keepalive=On" " and just threw 404. Might need testing if this is new in general. I know Ubuntu systems that work the same way.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
