### PR TITLE
Implement STARTTLS for IMAP

### DIFF
--- a/app/assets/javascripts/app/controllers/_channel/email.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/email.coffee
@@ -578,7 +578,7 @@ class App.ChannelEmailAccountWizard extends App.WizardModal
       { name: 'options::host',            display: 'Host',     tag: 'input',  type: 'text', limit: 120, null: false, autocapitalize: false },
       { name: 'options::user',            display: 'User',     tag: 'input',  type: 'text', limit: 120, null: false, autocapitalize: false, autocomplete: 'off' },
       { name: 'options::password',        display: 'Password', tag: 'input',  type: 'password', limit: 120, null: false, autocapitalize: false, autocomplete: 'new-password', single: true },
-      { name: 'options::ssl',             display: 'SSL',      tag: 'boolean', null: true, options: { true: 'yes', false: 'no'  }, default: true, translate: true, item_class: 'formGroup--halfSize' },
+      { name: 'options::ssl',             display: 'SSL/STARTTLS',      tag: 'boolean', null: true, options: { true: 'yes', false: 'no'  }, default: true, translate: true, item_class: 'formGroup--halfSize' },
       { name: 'options::port',            display: 'Port',     tag: 'input',  type: 'text', limit: 6,   null: true, autocapitalize: false,  default: '993', item_class: 'formGroup--halfSize' },
       { name: 'options::folder',          display: 'Folder',   tag: 'input',  type: 'text', limit: 120, null: true, autocapitalize: false, item_class: 'formGroup--halfSize' },
       { name: 'options::keep_on_server',  display: 'Keep messages on server', tag: 'boolean', null: true, options: { true: 'yes', false: 'no' }, translate: true, default: false, item_class: 'formGroup--halfSize' },
@@ -598,7 +598,7 @@ class App.ChannelEmailAccountWizard extends App.WizardModal
       return if !params.options
       currentPort = @$('[name="options::port"]').val()
       if params.options.ssl is true
-        if !currentPort || currentPort is '143'
+        if !currentPort
           @$('[name="options::port"]').val('993')
         return
       if params.options.ssl is false

--- a/app/assets/javascripts/app/controllers/getting_started.coffee
+++ b/app/assets/javascripts/app/controllers/getting_started.coffee
@@ -673,7 +673,7 @@ class ChannelEmail extends App.WizardFullScreen
       { name: 'options::host',            display: 'Host',     tag: 'input',  type: 'text', limit: 120, null: false, autocapitalize: false },
       { name: 'options::user',            display: 'User',     tag: 'input',  type: 'text', limit: 120, null: false, autocapitalize: false, autocomplete: 'off', },
       { name: 'options::password',        display: 'Password', tag: 'input',  type: 'password', limit: 120, null: false, autocapitalize: false, autocomplete: 'off', single: true },
-      { name: 'options::ssl',             display: 'SSL',      tag: 'boolean', null: true, options: { true: 'yes', false: 'no'  }, default: true, translate: true, item_class: 'formGroup--halfSize' },
+      { name: 'options::ssl',             display: 'SSL/STARTTLS', tag: 'boolean', null: true, options: { true: 'yes', false: 'no'  }, default: true, translate: true, item_class: 'formGroup--halfSize' },
       { name: 'options::port',            display: 'Port',     tag: 'input',  type: 'text', limit: 6,   null: true, autocapitalize: false,  default: '993', item_class: 'formGroup--halfSize' },
       { name: 'options::folder',          display: 'Folder',   tag: 'input',  type: 'text', limit: 120, null: true, autocapitalize: false, item_class: 'formGroup--halfSize' },
       { name: 'options::keep_on_server',  display: 'Keep messages on server', tag: 'boolean', null: true, options: { true: 'yes', false: 'no' }, translate: true, default: false, item_class: 'formGroup--halfSize' },
@@ -693,7 +693,7 @@ class ChannelEmail extends App.WizardFullScreen
       return if !params.options
       currentPort = @$('.base-inbound-settings [name="options::port"]').val()
       if params.options.ssl is true
-        if !currentPort || currentPort is '143'
+        if !currentPort
           @$('.base-inbound-settings [name="options::port"]').val('993')
         return
       if params.options.ssl is false

--- a/app/models/channel/driver/imap.rb
+++ b/app/models/channel/driver/imap.rb
@@ -62,29 +62,51 @@ example
 
   def fetch(options, channel, check_type = '', verify_string = '')
     ssl            = true
+    starttls       = false
     port           = 993
     keep_on_server = false
     folder         = 'INBOX'
     if options[:keep_on_server] == true || options[:keep_on_server] == 'true'
       keep_on_server = true
     end
-    if options.key?(:ssl) && options[:ssl] == false
-      ssl  = false
-      port = 143
+    if options.key?(:ssl) && options[:ssl] == true
+      ssl = true
+    else
+      ssl = false
     end
     if options.key?(:port) && options[:port].present?
       port = options[:port]
-
-      # disable ssl for non ssl ports
-      if port == 143 && !options.key?(:ssl)
-        ssl = false
+    else
+      if ssl == true
+        port = 993
+      else
+        port = 143
       end
     end
+
+    if ssl == true && port != 993
+      ssl = false
+      starttls = true
+    end
+
+    #if options.key?(:ssl) && options[:ssl] == false
+    #  ssl  = false
+    #  port = 143
+    #end
+    #if options.key?(:port) && options[:port].present?
+    #  port = options[:port]
+
+    #  # disable ssl for non ssl ports
+    #  if port == 143 && !options.key?(:ssl)
+    #    ssl = false
+    #  end
+    #end
+
     if options[:folder].present?
       folder = options[:folder]
     end
 
-    Rails.logger.info "fetching imap (#{options[:host]}/#{options[:user]} port=#{port},ssl=#{ssl},folder=#{folder},keep_on_server=#{keep_on_server})"
+    Rails.logger.info "fetching imap (#{options[:host]}/#{options[:user]} port=#{port},ssl=#{ssl},starttls=#{starttls},folder=#{folder},keep_on_server=#{keep_on_server})"
 
     # on check, reduce open_timeout to have faster probing
     timeout = 45
@@ -94,6 +116,9 @@ example
 
     Timeout.timeout(timeout) do
       @imap = Net::IMAP.new(options[:host], port, ssl, nil, false)
+      if starttls
+        @imap.starttls()
+      end
     end
 
     @imap.login(options[:user], options[:password])

--- a/app/models/channel/driver/imap.rb
+++ b/app/models/channel/driver/imap.rb
@@ -69,38 +69,21 @@ example
     if options[:keep_on_server] == true || options[:keep_on_server] == 'true'
       keep_on_server = true
     end
-    if options.key?(:ssl) && options[:ssl] == true
-      ssl = true
-    else
-      ssl = false
-    end
-    if options.key?(:port) && options[:port].present?
-      port = options[:port]
-    else
-      if ssl == true
-        port = 993
-      else
-        port = 143
-      end
-    end
+
+    ssl = options.key?(:ssl) && options[:ssl] == true
+
+    port = if options.key?(:port) && options[:port].present?
+             options[:port]
+           elsif ssl == true
+             993
+           else
+             143
+           end
 
     if ssl == true && port != 993
       ssl = false
       starttls = true
     end
-
-    #if options.key?(:ssl) && options[:ssl] == false
-    #  ssl  = false
-    #  port = 143
-    #end
-    #if options.key?(:port) && options[:port].present?
-    #  port = options[:port]
-
-    #  # disable ssl for non ssl ports
-    #  if port == 143 && !options.key?(:ssl)
-    #    ssl = false
-    #  end
-    #end
 
     if options[:folder].present?
       folder = options[:folder]


### PR DESCRIPTION
This PR adds support for STARTTLS when using IMAP incoming channels.

Fixes #769.

Implementation details:

Removes the additional check against port 143 in the web frontend.
Renames the fieldname to SSL/STARTTLS in the web frontent.

If the backend receives `ssl=true` and `port != 993` it will attempt to use starttls in favor of SSL.

