### PR TITLE
Fixed Issue #1259 and Issue #1598

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -711,7 +711,7 @@ class TicketsController < ApplicationController
         raise Exceptions::UnprocessableEntity, "Missing required attribute #{attribute.display}!"
       end
 
-      if attribute.data_type == 'datetime'
+      if attribute.data_type == 'datetime' # rubocop:disable Style/Next
         allow_past = attribute.data_option[:past]
         allow_future = attribute.data_option[:future]
         is_past = Time.zone.parse( params[attribute.name] ) < DateTime.current


### PR DESCRIPTION
This fixes two separate issues:

#1259 is fixed by adding backend checks for required attributes during ticket creation/updates. All attributes types are covered by this.

#1598 is fixed by parsing and validating any incoming datetime attributes against any existing allow_past and allow_future flags.

This patch adds backend logic only, so the user is only informed of the error after they submit the request. I will submit a separate pull request later this week that adds the same validation codes on the frontend for a better UX.  

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
