### PR TITLE
Fixed issue #2016 - Scheduler will stop after removing own ticket attribute but overview with condition which is including attribute git dropped

### DIFF
--- a/app/assets/javascripts/app/controllers/object_manager.coffee
+++ b/app/assets/javascripts/app/controllers/object_manager.coffee
@@ -143,12 +143,17 @@ class Items extends App.ControllerSubContent
     e.preventDefault()
     id   = $(e.target).closest('tr').data('id')
     item = App.ObjectManagerAttribute.find(id)
+    ui = @
     @ajax(
       id:    "object_manager_attributes/#{id}"
       type:  'DELETE'
       url:   "#{@apiPath}/object_manager_attributes/#{id}"
       success: (data) =>
         @render()
+      error: (jqXHR, textStatus, errorThrown) =>
+        ui.log 'errors'
+        # this code is unreachable so alert will do fine 
+        alert(jqXHR.responseJSON.error)
     )
 
   discard: (e) ->

--- a/app/assets/javascripts/app/views/object_manager/index.jst.eco
+++ b/app/assets/javascripts/app/views/object_manager/index.jst.eco
@@ -71,8 +71,12 @@
             <%- @T('will be deleted') %>
           <% else if item.to_migrate is true || item.to_config is true: %>
             <%- @T('has changed') %>
-          <% else if item.editable isnt false: %>
-            <a href="#" class="js-delete" title="<%- @Ti('Delete') %>"><%- @Icon('trash') %></a>
+          <% else if item.editable: %>
+            <% if item.deletable: %>
+              <a href="#" class="js-delete" title="<%- @Ti('Delete') %>"><%- @Icon('trash') %></a>
+            <% else: %>
+              <span class="is-disabled" title="<%= item.not_deletable_reason %>"><%- @Icon('trash') %></span>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -9562,3 +9562,8 @@ body.fit {
 .flex-spacer {
   flex: 1;
 }
+
+span.is-disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/app/controllers/object_manager_attributes_controller.rb
+++ b/app/controllers/object_manager_attributes_controller.rb
@@ -77,6 +77,9 @@ class ObjectManagerAttributesController < ApplicationController
       name: object_manager_attribute.name,
     )
     model_destroy_render_item
+  rescue => e
+    logger.error e
+    raise Exceptions::UnprocessableEntity, e
   end
 
   # POST /object_manager_attributes_discard_changes

--- a/test/browser_test_helper.rb
+++ b/test/browser_test_helper.rb
@@ -1683,13 +1683,22 @@ wait untill text in selector disabppears
         mute_log: true,
       )
       sleep 0.5
-      select(
-        browser:      instance,
-        css:          '.modal .ticket_selector .js-value select',
-        value:        value,
-        deselect_all: true,
-        mute_log:     true,
-      )
+      if data.key?('text_input')
+        set(
+          browser:  instance,
+          css:      '.modal .ticket_selector .js-value input',
+          value:    value,
+          mute_log: true,
+        )
+      else
+        select(
+          browser:      instance,
+          css:          '.modal .ticket_selector .js-value select',
+          value:        value,
+          deselect_all: true,
+          mute_log:     true,
+        )
+      end
     end
 
     if data['order::direction']


### PR DESCRIPTION
This fixes issue #2016 by adding frontend and backend checks to ensure that ticket attributes with outstanding object references (trigger, overview, or scheduler) cannot be deleted.

Ticket attributes with outstanding object references will have its delete button grayed out and disabled. The mouseover text of the disabled delete button will list all the objects that reference the attribute, basically hinting to the user that all dependent objects need to be deleted first in order to delete the attribute. 

![asdaasdasdsd](https://user-images.githubusercontent.com/7030950/40268475-60141590-5ba0-11e8-92e0-a1f8de332495.png)

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
