### PR TITLE
Fixed issue #2020 - Incorrect reset after deleting single object-selection

### DIFF
--- a/app/models/object_manager/attribute.rb
+++ b/app/models/object_manager/attribute.rb
@@ -799,8 +799,11 @@ to send no browser reload event, pass false
       if !data_option.key?(:maxlength)
         data_option[:maxlength] = 255
       end
-      if !data_option.key?(:nulloption) && data_option[:default].empty?
+      if !data_option.key?(:nulloption)
         data_option[:nulloption] = true
+      end
+      if data_type == 'select' && data_option[:default].present?
+        data_option[:nulloption] = false
       end
     end
 


### PR DESCRIPTION
This fixes issue #2020 by removing recently-deleted select attribute options and replacing them with defaults during ObjectManager migrations. There are two possible scenarios:

1. If the new options have a default, then all the recently-deleted options are migrated to this default.

2. If the new options does not have a default specified, then all recently-deleted options are migrated to `nil`, which is shown as the "-" empty choice in the UI. For this reason, all select attributes without a default specified will now have its `:nulloption` flag set to `true`.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
