### PR TITLE
Fixed issue #2046 - Special characters get HTML encoded when displayed in overviews

### DIFF
--- a/app/assets/javascripts/app/index.coffee
+++ b/app/assets/javascripts/app/index.coffee
@@ -308,6 +308,9 @@ class App extends Spine.Controller
           humanTime = App.PrettyDate.humanTime(resultLocal, escalation)
         resultLocal = "<time class=\"humanTimeFromNow #{cssClass}\" data-time=\"#{resultLocal}\" title=\"#{timestamp}\">#{humanTime}</time>"
 
+      else if attributeConfig.tag is 'select'
+        isHtmlEscape = true
+
       if !isHtmlEscape && typeof resultLocal is 'string'
         resultLocal = App.Utils.htmlEscape(resultLocal)
 

--- a/script/build/test_slice_tests.sh
+++ b/script/build/test_slice_tests.sh
@@ -37,6 +37,7 @@ if [ "$LEVEL" == '1' ]; then
   rm test/browser/agent_ticket_macro_test.rb
   rm test/browser/agent_ticket_merge_test.rb
   rm test/browser/agent_ticket_online_notification_test.rb
+  rm test/browser/agent_ticket_overview_group_by_organization_test.rb
   rm test/browser/agent_ticket_overview_level0_test.rb
   rm test/browser/agent_ticket_overview_level1_test.rb
   rm test/browser/agent_ticket_overview_tab_test.rb
@@ -111,6 +112,7 @@ elif [ "$LEVEL" == '2' ]; then
   rm test/browser/agent_ticket_macro_test.rb
   # test/browser/agent_ticket_merge_test.rb
   rm test/browser/agent_ticket_online_notification_test.rb
+  rm test/browser/agent_ticket_overview_group_by_organization_test.rb
   rm test/browser/agent_ticket_overview_level0_test.rb
   rm test/browser/agent_ticket_overview_level1_test.rb
   rm test/browser/agent_ticket_overview_tab_test.rb
@@ -185,6 +187,7 @@ elif [ "$LEVEL" == '3' ]; then
   # test/browser/agent_ticket_macro_test.rb
   rm test/browser/agent_ticket_merge_test.rb
   rm test/browser/agent_ticket_online_notification_test.rb
+  rm test/browser/agent_ticket_overview_group_by_organization_test.rb
   rm test/browser/agent_ticket_overview_level0_test.rb
   rm test/browser/agent_ticket_overview_level1_test.rb
   rm test/browser/agent_ticket_overview_tab_test.rb
@@ -259,6 +262,7 @@ elif [ "$LEVEL" == '4' ]; then
   rm test/browser/agent_ticket_macro_test.rb
   rm test/browser/agent_ticket_merge_test.rb
   # test/browser/agent_ticket_online_notification_test.rb
+  # test/browser/agent_ticket_overview_group_by_organization_test.rb
   # test/browser/agent_ticket_overview_level0_test.rb
   # test/browser/agent_ticket_overview_level1_test.rb
   # test/browser/agent_ticket_overview_tab_test.rb
@@ -332,6 +336,7 @@ elif [ "$LEVEL" == '5' ]; then
   rm test/browser/agent_ticket_macro_test.rb
   rm test/browser/agent_ticket_merge_test.rb
   rm test/browser/agent_ticket_online_notification_test.rb
+  rm test/browser/agent_ticket_overview_group_by_organization_test.rb
   rm test/browser/agent_ticket_overview_level0_test.rb
   rm test/browser/agent_ticket_overview_level1_test.rb
   rm test/browser/agent_ticket_overview_tab_test.rb
@@ -408,6 +413,7 @@ elif [ "$LEVEL" == '6' ]; then
   rm test/browser/agent_ticket_macro_test.rb
   rm test/browser/agent_ticket_merge_test.rb
   rm test/browser/agent_ticket_online_notification_test.rb
+  rm test/browser/agent_ticket_overview_group_by_organization_test.rb
   rm test/browser/agent_ticket_overview_level0_test.rb
   rm test/browser/agent_ticket_overview_level1_test.rb
   rm test/browser/agent_ticket_overview_tab_test.rb

--- a/test/browser/agent_ticket_overview_group_by_organization_test.rb
+++ b/test/browser/agent_ticket_overview_group_by_organization_test.rb
@@ -1,0 +1,69 @@
+
+require 'browser_test_helper'
+
+class AgentTicketOverviewGroupByOrganizationTest < TestCase
+
+=begin
+
+  Verify fix for Github issue #2046 - Special characters get HTML encoded when displayed in overviews...
+
+=end
+  def test_grouping_by_organzation_overview
+    random = rand(999_999).to_s
+    user_email = "user_#{random}@example.com"
+    overview_name = "overview_#{random}"
+
+    @browser = instance = browser_instance
+    login(
+      username: 'master@example.com',
+      password: 'test',
+      url: browser_url,
+    )
+    tasks_close_all()
+
+    # 1. Create a new test organization with special characters in its name
+    organization = organization_create(
+      data: {
+        name: 'äöüß & Test Organization',
+      }
+    )
+
+    # 2. Create a new user that belongs to the test organization
+    user = user_create(
+      data: {
+        login:     'test user',
+        firstname: 'Max',
+        lastname:  'Mustermann',
+        email:     user_email,
+        password:  'some-pass',
+        organization: 'äöüß & Test Organization',
+      }
+    )
+
+    # 3. Create a new ticket for the test user
+    ticket = ticket_create(
+      data: {
+        customer: user_email,
+        title:    'test ticket',
+        body:     'test ticket',
+      },
+    )
+
+    # 4. Create an overview grouping by organization
+    overview = overview_create(
+      data: {
+        name: overview_name,
+        roles: %w[Agent Admin Customer],
+        group_by: 'Organization',
+      }
+    )
+
+    # 5. Open the newly created overview and verify that the organization name is correctly rendered
+    location(url: "#{browser_url}/#ticket/view/#{overview_name}")
+    sleep 1
+    elements = instance.find_elements(xpath: '//b[contains(text(),"äöüß & Test Organization")]')
+    elements = elements.select { |x| x.text.present? }
+    assert elements
+    assert_equal 'äöüß & Test Organization', elements.first.text
+  end
+end

--- a/test/browser_test_helper.rb
+++ b/test/browser_test_helper.rb
@@ -1671,6 +1671,15 @@ wait untill text in selector disabppears
       )
     end
 
+    if data[:group_by]
+      select(
+        browser:  instance,
+        css:      '.modal select[name="group_by"]',
+        value:    data[:group_by],
+        mute_log: true,
+      )
+    end
+
     instance.find_elements(css: '.modal button.js-submit')[0].click
     modal_disappear(browser: instance)
     11.times do
@@ -2680,6 +2689,17 @@ wait untill text in selector disabppears
     element = instance.find_elements(css: '.modal input[name=password_confirm]')[0]
     element.clear
     element.send_keys(data[:password])
+    if data[:organization]
+      element = instance.find_elements(css: '.modal input.searchableSelect-main')[0]
+      element.clear
+      element.send_keys(data[:organization])
+      target = nil
+      until target
+        sleep 0.5
+        target = instance.find_elements(css: ".modal li[title='#{data[:organization]}']")[0]
+      end
+      target.click()
+    end
     check(
       browser: instance,
       css:     '.modal input[name=role_ids][value=3]',
@@ -2701,6 +2721,56 @@ wait untill text in selector disabppears
     )
 
     assert(true, 'user created')
+  end
+
+=begin
+
+  organization_create(
+    browser: browser2,
+    data: {
+      name: 'Test Organization',
+    }
+  )
+
+=end
+
+  def organization_create(params = {})
+    switch_window_focus(params)
+    log('organization_create', params)
+
+    instance = params[:browser] || @browser
+    data     = params[:data]
+
+    click(
+      browser: instance,
+      css:  'a[href="#manage"]',
+      mute_log: true,
+    )
+    click(
+      browser: instance,
+      css:  '.content.active a[href="#manage/organizations"]',
+      mute_log: true,
+    )
+    click(
+      browser: instance,
+      css:  '.content.active a[data-type="new"]',
+      mute_log: true,
+    )
+    modal_ready(browser: instance)
+    element = instance.find_elements(css: '.modal input[name=name]')[0]
+    element.clear
+    element.send_keys(data[:name])
+
+    instance.find_elements(css: '.modal button.js-submit')[0].click
+    modal_disappear(
+      browser: instance,
+      timeout: 5,
+    )
+    watch_for(
+      browser: instance,
+      css: 'body',
+      value: data[:name],
+    )
   end
 
 =begin


### PR DESCRIPTION
This fixes issue #2046. The actual fix is only two lines long: 
```
else if attributeConfig.tag is 'select'
      isHtmlEscape = true
```
Basically marking the target of `select` types as already HTML escaped so that it does not get unnecessarily HTML escaped again. 

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
