### PR TITLE
Check the correct hash array if the agent is present

### DIFF
--- a/app/controllers/time_accountings_controller.rb
+++ b/app/controllers/time_accountings_controller.rb
@@ -46,7 +46,7 @@ class TimeAccountingsController < ApplicationController
           end
         end
       end
-      if !customers[local_time_unit[:agent_id]]
+      if !agents[local_time_unit[:agent_id]]
         agent_user = User.lookup(id: local_time_unit[:agent_id])
         agent = '-'
         if agent_user


### PR DESCRIPTION
This is a bug that I encountered in Zammad 2.6.x when an agent is also a customer. An agent does not show up if it was found as a customer beforehand. 
Changing this to the correct array fixes this very unlikely but annoying bug.