### PR TITLE
2264 - Prevent modal close on clicking outside

### DIFF
--- a/app/assets/javascripts/app/lib/app_post/user_organization_autocompletion.coffee
+++ b/app/assets/javascripts/app/lib/app_post/user_organization_autocompletion.coffee
@@ -36,6 +36,7 @@ class UserNew extends App.ControllerModal
   buttonSubmit: true
   head: 'User'
   headPrefix: 'New'
+  backdrop: 'static'
 
   content: ->
     @controller = new App.ControllerForm(


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
Fixes https://github.com/zammad/zammad/issues/2264

Actually the issue happens when we click outside while trying to scroll, I think this is normal behavior of the modal, disabled closing of model on clicking out side of the modal by adding `backdrop: 'static'`.