### PR TITLE
Support Importing from Zendesk for plans lower than Team.

### DIFF
--- a/lib/sequencer/unit/import/zendesk/sub_sequence/base.rb
+++ b/lib/sequencer/unit/import/zendesk/sub_sequence/base.rb
@@ -39,6 +39,10 @@ class Sequencer
 
             def resource_iteration(&block)
               resource_collection.public_send(resource_iteration_method, &block)
+            rescue ZendeskAPI::Error::NetworkError => e
+              return if e.response.status.to_s == '403' && %w[UserField OrganizationField].include?(resource_klass)
+
+              raise
             end
 
             def resource_collection


### PR DESCRIPTION
Fixes #2262, 
It rescues the error which is raised while importing a plan lower than "Team", which is "Essential" from Zendesk while importing into Zammad. It checks for the error being a forbidden response and the current resource being imported as `UserFields` and `OrganizationFields` and then skips and goes ahead to import everything else. I've not added a new intergration test to handle this edge case because I feel it will bloat our test suite, But what we could do is to refactor and improve the existing intergration test to go from testing a particular account to testing multiple account types. I would love to hear your thoughts on this and if I should add this in. 

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
