### PR TITLE
FIX: Ticket list in customer and org view now sorted by 'created_at'

### DIFF
--- a/app/controllers/concerns/ticket_stats.rb
+++ b/app/controllers/concerns/ticket_stats.rb
@@ -8,6 +8,8 @@ module TicketStats
       limit: limit,
       condition: condition,
       current_user: current_user,
+      sort_by: 'created_at',
+      order_by: 'desc',
     )
     assets_of_tickets(tickets, assets)
   end

--- a/spec/requests/ticket_spec.rb
+++ b/spec/requests/ticket_spec.rb
@@ -2078,5 +2078,22 @@ RSpec.describe 'Ticket', type: :request do
       expect(json_response).to be_a_kind_of(Hash)
       expect(json_response['tickets']).to eq([ticket2.id, ticket1.id])
     end
+
+    it 'does ticket stats order by created_at' do
+      organization = create(:organization, shared: false)
+      customer = create(:customer_user, organization: organization)
+      ticket1 = create(:ticket, customer: customer, organization: organization)
+      ticket2 = create(:ticket, customer: customer, organization: organization)
+      ticket3 = create(:ticket, customer: customer, organization: organization)
+      ticket2.update(title: 'Updated title')
+
+      authenticated_as(admin_user)
+      get '/api/v1/ticket_stats', params: { organization_id: organization.id, user_id: customer.id }, as: :json
+
+      expect(response).to have_http_status(200)
+      expect(json_response).to be_a_kind_of(Hash)
+      expect(json_response['user']['open_ids']).to eq([ticket3.id, ticket2.id, ticket1.id])
+      expect(json_response['organization']['open_ids']).to eq([ticket3.id, ticket2.id, ticket1.id])
+    end
   end
 end

--- a/test/browser/agent_organization_profile_test.rb
+++ b/test/browser/agent_organization_profile_test.rb
@@ -92,13 +92,41 @@ class AgentOrganizationProfileTest < TestCase
       }
     )
 
-    # create new ticket
+    # create new ticket 1
     ticket_create(
       data: {
         customer: 'nico',
         group: 'Users',
-        title: 'org profile check ' + message,
-        body: 'org profile check ' + message,
+        title: 'org profile check 1 ' + message,
+        body: 'org profile check 1 ' + message,
+      },
+    )
+
+    # create new ticket 2
+    ticket_create(
+      data: {
+        customer: 'nico',
+        group: 'Users',
+        title: 'org profile check 2 ' + message,
+        body: 'org profile check 2 ' + message,
+      },
+    )
+
+    # create new ticket 3
+    ticket_create(
+      data: {
+        customer: 'nico',
+        group: 'Users',
+        title: 'org profile check 3 ' + message,
+        body: 'org profile check 3 ' + message,
+      },
+    )
+
+    #switch to second ticket and update
+    ticket_open_by_title(title: 'org profile check 2 ' + message,)
+    ticket_update(
+      data: {
+        body: 'updated ticket'
       },
     )
 
@@ -108,8 +136,23 @@ class AgentOrganizationProfileTest < TestCase
     )
     watch_for(
       css: '.active .profile-window',
-      value: 'org profile check ' + message,
+      value: 'org profile check 1 ' + message,
     )
+
+    # check if tickets are ordered by "created_at:desc" and not "updated_at"
+    match(
+      css: '.js-org-open-tickets .tasks .task:nth-child(1) .task-text',
+      value: 'org profile check 3 ' + message,
+    )
+    match(
+      css: '.js-org-open-tickets .tasks .task:nth-child(2) .task-text',
+      value: 'org profile check 2 ' + message,
+    )
+    match(
+      css: '.js-org-open-tickets .tasks .task:nth-child(3) .task-text',
+      value: 'org profile check 1 ' + message,
+    )
+
     tasks_close_all()
 
     # work with two browser windows

--- a/test/browser/agent_user_profile_test.rb
+++ b/test/browser/agent_user_profile_test.rb
@@ -88,22 +88,65 @@ class AgentUserProfileTest < TestCase
       }
     )
 
-    # create new ticket
+    # create new ticket 1
     ticket_create(
       data: {
         customer: 'nico',
         group: 'Users',
-        title: 'user profile check ' + message,
-        body: 'user profile check ' + message,
+        title: 'user profile check 1 ' + message,
+        body: 'user profile check 1 ' + message,
       },
     )
 
-    # switch to org tab, verify if ticket is shown
+    # create new ticket 2
+    ticket_create(
+      data: {
+        customer: 'nico',
+        group: 'Users',
+        title: 'user profile check 2 ' + message,
+        body: 'user profile check 2 ' + message,
+      },
+    )
+
+    # create new ticket 3
+    ticket_create(
+      data: {
+        customer: 'nico',
+        group: 'Users',
+        title: 'user profile check 3 ' + message,
+        body: 'user profile check 3 ' + message,
+      },
+    )
+
+    #switch to second ticket and update
+    ticket_open_by_title(title: 'user profile check 2 ' + message,)
+    ticket_update(
+      data: {
+        body: 'updated ticket'
+      },
+    )
+
+    # switch to user tab, verify if ticket is shown
     user_open_by_search(value: 'Braun')
     watch_for(
       css: '.active .profile-window',
-      value: 'user profile check ' + message,
+      value: 'user profile check 1 ' + message,
     )
+
+    # check if tickets are ordered by "created_at:desc" and not "updated_at"
+    match(
+      css: '.js-user-open-tickets .tasks .task:nth-child(1) .task-text',
+      value: 'user profile check 3 ' + message,
+    )
+    match(
+      css: '.js-user-open-tickets .tasks .task:nth-child(2) .task-text',
+      value: 'user profile check 2 ' + message,
+    )
+    match(
+      css: '.js-user-open-tickets .tasks .task:nth-child(3) .task-text',
+      value: 'user profile check 1 ' + message,
+    )
+
     tasks_close_all()
 
     # work with two browser windows


### PR DESCRIPTION
Fixes https://github.com/zammad/zammad/issues/2296
Continues the work done in https://github.com/zammad/zammad/pull/2300 and also adds two browser tests for it.
@thorsteneckel 

- [x] ticket stats are now ordered by `created_at`
- [x] added a request spec for testing if the tickets are returned by `/api/v1/ticket_stats` in the correct order
- [x] added a browser test in `agent_user_profile_test.rb`
- [x] added a browser test in `agent_organization_profile_test.rb`