### PR TITLE
Sessions::Event::Base: inherit @@database_connection for sub classes

### DIFF
--- a/lib/sessions/event/base.rb
+++ b/lib/sessions/event/base.rb
@@ -131,6 +131,10 @@ class Sessions::Event::Base
     @database_connection = true
   end
 
+  def self.inherited(subclass)
+    subclass.instance_variable_set(:@database_connection, @database_connection)
+  end
+
   def destroy
     return if !@is_web_socket
     return if !self.class.instance_variable_get(:@database_connection)


### PR DESCRIPTION
Manually inherit the @database_connection class level instance variable
so that database_connection_required actually works for sub classes of
Sessions::Event::ChatBase. (needed since class level instance variables
do not get inherited in Ruby)

Fixes #2353

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
