### PR TITLE
Fix detection of local elasticsearch service

### DIFF
--- a/contrib/packager.io/functions
+++ b/contrib/packager.io/functions
@@ -248,7 +248,7 @@ function setup_elasticsearch () {
 
   yes | /usr/share/elasticsearch/bin/elasticsearch-plugin -s install ingest-attachment
 
-  if [ "${ES_CONNECTION}" == "http://127.0.0.1:9200" ]; then
+  if [ "${ES_CONNECTION}" == "http://127.0.0.1:9200" ] || [ "${ES_CONNECTION}" == "http://localhost:9200" ]; then
     ${INIT_CMD} restart elasticsearch
   else
     echo -e "\n It seems you're running an external Elasticsearch server on ${ES_CONNECTION}"


### PR DESCRIPTION
If elasticsearch is local and the URL was set via rake cli to "localhost" instead of "127.0.0.1", the service is not restarted.
This results in a broken state (search does not work, background tasks fail, etc.) if zammad is updated together with elasticsearch.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
