### PR TITLE
Increased timeout for big attachments

### DIFF
--- a/lib/sequencer/unit/import/zendesk/ticket/comment/attachment/request.rb
+++ b/lib/sequencer/unit/import/zendesk/ticket/comment/attachment/request.rb
@@ -36,8 +36,8 @@ class Sequencer
                       resource.content_url,
                       {},
                       {
-                        open_timeout: 10,
-                        read_timeout: 60,
+                        open_timeout: 20,
+                        read_timeout: 240,
                       },
                     )
                   end


### PR DESCRIPTION
My migration from Zendesk failed with '504 Gateway Timeout'. I found this for comments that have big attachments. After fix in test environment migration competed successfully
