### PR TITLE
Password hashing: upgrade to argon2 2.x (argon2id), fix non-unique salt bug (fixes #2462)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
-    argon2 (1.1.4)
+    argon2 (2.0.1)
       ffi (~> 1.9)
       ffi-compiler (~> 0.1)
     ast (2.4.0)
@@ -380,7 +380,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     raindrops (0.19.0)
-    rake (12.3.1)
+    rake (12.3.2)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -616,4 +616,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1227,24 +1227,20 @@ raise 'Minimum one user need to have admin permissions'
   end
 
   def ensure_password
-    return true if password_empty?
-    return true if PasswordHash.crypted?(password)
+    # don't accidentally hash the empty string
+    # see https://github.com/zammad/zammad/issues/2462
+    if password == ''
+      self.password = nil
+    end
 
-    self.password = PasswordHash.crypt(password)
-    true
-  end
-
-  def password_empty?
-    # set old password again if not given
-    return if password.present?
-
-    # skip if it's not desired to set a password (yet)
+    # don't attempt to hash nil
     return true if !password
 
-    # get current record
-    return if !id
+    # don't re-hash an already hashed passsword
+    return true if PasswordHash.crypted?(password)
 
-    self.password = password_was
+    # hash a plaintext password
+    self.password = PasswordHash.crypt(password)
     true
   end
 

--- a/lib/password_hash.rb
+++ b/lib/password_hash.rb
@@ -37,8 +37,9 @@ module PasswordHash
     # (#2462), we'll use this opportunity to replace the old argon2i hashes
     # (which might have duplicate salts) with new argon2id hashes.
     return true if hashed_argon2i?(pw_hash) &&
-        Argon2::Password.verify_password(password, pw_hash, secret)
-    return false
+                   Argon2::Password.verify_password(password, pw_hash, secret)
+
+    false
   end
 
   def hashed_sha2?(pw_hash)
@@ -46,7 +47,7 @@ module PasswordHash
   end
 
   def hashed_argon2?(pw_hash)
-    return Argon2::Password::valid_hash?(pw_hash)
+    Argon2::Password.valid_hash?(pw_hash)
   end
 
   def hashed_argon2i?(pw_hash)

--- a/lib/password_hash.rb
+++ b/lib/password_hash.rb
@@ -6,6 +6,10 @@ module PasswordHash
   extend self
 
   def crypt(password)
+    # https://github.com/zammad/zammad/issues/2462
+    # Do not reuse Argon2::Password instances, the salt is only randomized on
+    # instantiation!
+    argon2 = Argon2::Password.new(secret: secret)
     argon2.create(password)
   end
 
@@ -27,7 +31,14 @@ module PasswordHash
     return false if pw_hash.blank?
     return false if !password
 
-    sha2?(pw_hash, password)
+    return true if sha2?(pw_hash, password)
+    # Since argon2 >= 2.0.0, we can use the argon2id hash instead of the
+    # argon2i hash. As older Zammad versions accidentally reused the same salt
+    # (#2462), we'll use this opportunity to replace the old argon2i hashes
+    # (which might have duplicate salts) with new argon2id hashes.
+    return true if hashed_argon2i?(pw_hash) &&
+        Argon2::Password.verify_password(password, pw_hash, secret)
+    return false
   end
 
   def hashed_sha2?(pw_hash)
@@ -35,6 +46,10 @@ module PasswordHash
   end
 
   def hashed_argon2?(pw_hash)
+    return Argon2::Password::valid_hash?(pw_hash)
+  end
+
+  def hashed_argon2i?(pw_hash)
     # taken from: https://github.com/technion/ruby-argon2/blob/7e1f4a2634316e370ab84150e4f5fd91d9263713/lib/argon2.rb#L33
     pw_hash =~ /^\$argon2i\$.{,112}/
   end
@@ -50,10 +65,6 @@ module PasswordHash
     return false if !hashed_sha2?(pw_hash)
 
     pw_hash == sha2(password)
-  end
-
-  def argon2
-    @argon2 ||= Argon2::Password.new(secret: secret)
   end
 
   def secret

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe User do
 
           expect { user.save }
             .to change { user.password }.to(nil)
-          puts(user.inspect)
         end
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe User do
         end
       end
 
-
       context 'when set to SHA2 digest (to facilitate OTRS imports)' do
         it 'does not re-hash before saving' do
           user.password = "{sha2}#{Digest::SHA2.hexdigest('password')}"


### PR DESCRIPTION
Here's my attempt at solving #2462 :)

Please review this carefully, I'm new to Ruby, Rails, RSpec and the Zammad codebase :)

Especially the removal of  `password_empty?` and the therein contained logic might be controversial; if this change is not acceptable, I can revert it.

A note about argon2 >= 2.x: this upgrade breaks the old code in `lib/password_hash.rb`! This is because argon2 >= 2.x creates `argon2id` hashes by default, but `lib/password_hash.rb` can only identify `argon2i` hashes, and will therefore misinterpret an `argon2id` hash as a plaintext password, and hash it again, thereby breaking it. If you checkout this branch and then return to develop, make sure that you downgrade `argon2` back to 1.x before authenticating against Zammad!

Another note about the way that `user.rb` currently handles the password hashing: I'm not very fond about the way this happens automagically in the `before_validation` callback. The way it currently works it has two significant disadvantages:
- If the hashing algorithm creates a new kind of hash that `lib/password_hash.rb` cannot identify (e.g. as outlined above with `argon2id`), `user.rb` will misinterpret the hash as a plaintext password and cause it to be hashed again, thereby breaking it.
- Due to the fact that Zammad supports SHA256 hashes for legacy purposes, users can exploit it to set a password that breaks the password policy. E.g. to set the password `a`, do the following:
	```
	martin@martin ~ % echo -n 'a' | sha256sum | sed 's/^/{sha2}/'
	{sha2}ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb  -
	```
	
	Then change your Zammad password to `{sha2}ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb`. As this is a valid password hash, Zammad will not attempt to hash it, and will instead put it directly into the database, where it'll get upgraded to an `argon2id` hash on the next login. As Zammad has never seen the plaintext password while setting it, it cannot validate the password against the password policy.
	
	(Only SHA256 hashes can be abused this way, as the user cannot create a useable argon2 hash without knowledge of the Zammad secret. He'll be able to get it into the database, but he won't be able to login afterwards.)
	
I feel like separate methods to set plaintext passwords (subject to password policies and therefore allowed for users) and hashed passwords (not subject to password policies and therefore only allowed for admins) might be the cleaner solution here.

From the commit message:

- Gemfile.lock: upgraded to argon2 (2.0.1)
- app/models/user.rb:
  - ensure_password will now replace an empty string with nil, to ensure that
    unset passwords are stored as NULL in the database, and not as a hash of
    the empty string.
  - removed password_empty?, and thereby also the special logic that actually
    conserved the old password hash when a caller tried to set it to '' or to
    nil. This might very well be controversial, but I found the difference
    in behavior to be very confusing.

    This did what you would expect:

      x = User.create(login: "foobar", password: "", created_by_id:1, updated_by_id:1)

    It creates a user without a password. But this IMO did not do what you
    would expect:

      x = User.create(login: "foobar", password: "barfoo", created_by_id:1, updated_by_id:1)
      x.password = ''
      x.save

    I would have expected the `x.password = ''` to clear the password, but
    instead it was just silently ignored. Until now, it was actually impossible
    to remove a user password.
    As far as I can tell, the frontend will not submit a password key in its
    JSON request when creating or editing a user without typing anything in the
    password field, so this _probably_ shouldn't break anything.
- lib/password_hash.rb:
  - crypt will now no longer reuse Argon2 instances, and will therefore now use
    unique salts for hashing passwords.
  - legacy? will now consider argon2i password hashes as legacy hashes, so that
    they will be upgraded to argon2id hashes. This has the added benefit that
    it automatically gets rid of passwords with non-unique salts.
  - hashed_argon2? now just calls Argon2::Password::valid_hash? instead of
    using a copy-pasted regex. This might be vital when a future update of
    Argon2 introduces a new hash - the old code only matched specifically
    argon2i hashes. This had the very dangerous side effect that it would have
    attempted to re-hash argon2id hashes because they would'nt match the regex,
    thereby corrupting the hashes in the database.
  - added hashed_argon2i? which now uses the copy-pasted regex to identify
    legacy argon2i hashes.
  - removed the argon2 method as storing Argon2 instances was a bad idea
    anyways :)
- spec/models/user_spec.rb:
  - when set to plaintext password -> hashes password before saving to DB:
    fixed the test not to rely on identical hashes.
  - when changed to empty string -> sets password to nil (#2462)
    added this test to ensure that app/models/user.rb overwrites the current
    password with nil when it is changed to an empty string.
  - when changed to nil -> sets password to nil
    added this test to ensure that app/models/user.rb overwrites the current
    password with nil when it is changed to nil.
  - when a user is created with an empty string as password ->
      sets password to nil
    added this test to ensure that a user created with an empty string password
    stores nil instead of a hash of the empty string.
  - when a user is created with nil as password -> sets password to nil
    added this test to ensure that a user created with a nil password
    stores nil. This was never actually broken, but I thought having it
    formally defined in a spec wouldn't hurt :)
  - when creating two users with the same password (#2462) ->
      does not generate the same password hash
    added this test to ensure that two users with the same password won't have
    the same password hash.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
