### PR TITLE
Update pkgr.yml for consensisty with Ubuntu 18.04

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -56,7 +56,9 @@ targets:
       - nginx|apache2
       - postgresql|mysql-server|mariadb-server|sqlite
       - libimlib2
+      - libimlib2-dev
     build_dependencies:
+      - libimlib2
       - libimlib2-dev
   sles-12:
     dependencies:


### PR DESCRIPTION
This patch updates pkgr.yml as it seems to be inconsistent.
Ubuntu 18.04 is currently the only system missing "- libimlib2-dev" for installation dependency and "- libimlib2" for build dependency.
This looks wrong.

If you don't install libimlib2-dev manually, zammad will not start cleanly.

This is going to address https://github.com/zammad/zammad/issues/2489

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
