### PR TITLE
Make it possible to only send with agent name

### DIFF
--- a/app/models/observer/ticket/article/fillup_from_email.rb
+++ b/app/models/observer/ticket/article/fillup_from_email.rb
@@ -59,6 +59,10 @@ class Observer::Ticket::Article::FillupFromEmail < ActiveRecord::Observer
       sender      = User.find(record.created_by_id)
       realname    = "#{sender.firstname} #{sender.lastname} #{separator} #{email_address.realname}"
       record.from = Channel::EmailBuild.recipient_line(realname, email_address.email)
+    elsif Setting.get('ticket_define_email_from') == 'AgentName'
+      sender      = User.find(record.created_by_id)
+      realname    = "#{sender.firstname} #{sender.lastname}"
+      record.from = Channel::EmailBuild.recipient_line(realname, email_address.email)
     else
       record.from = Channel::EmailBuild.recipient_line(email_address.realname, email_address.email)
     end

--- a/db/migrate/20190226000001_setting_add_sender_format_agent_name.rb
+++ b/db/migrate/20190226000001_setting_add_sender_format_agent_name.rb
@@ -1,0 +1,12 @@
+class SettingAddSenderFormatAgentName < ActiveRecord::Migration[5.1]
+  def up
+    # return if it's a new setup
+    return if !Setting.find_by(name: 'system_init_done')
+
+    setting = Setting.find_by(name: 'ticket_define_email_from')
+    return if !setting
+
+    setting.options[:form][0][:options][:AgentName] = 'Agent Name Name'
+    setting.save!
+  end
+end

--- a/db/migrate/20190226000001_setting_add_sender_format_agent_name.rb
+++ b/db/migrate/20190226000001_setting_add_sender_format_agent_name.rb
@@ -6,7 +6,7 @@ class SettingAddSenderFormatAgentName < ActiveRecord::Migration[5.1]
     setting = Setting.find_by(name: 'ticket_define_email_from')
     return if !setting
 
-    setting.options[:form][0][:options][:AgentName] = 'Agent Name Name'
+    setting.options[:form][0][:options][:AgentName] = 'Agent Name'
     setting.save!
   end
 end

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -2393,6 +2393,7 @@ Setting.create_if_not_exists(
         options: {
           SystemAddressName:          'System Address Display Name',
           AgentNameSystemAddressName: 'Agent Name + FromSeparator + System Address Display Name',
+          AgentName: 'Agent Name',
         },
       },
     ],


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

Hi

I have added Agent Name as a 'Sender Format' option.

It is requested here: https://community.zammad.org/t/custom-sender-formats/1839 and of course by me.

What is does is make it possible for the user to select: "Agent name" in 'Sender Format' and when an agent sends an outgoing message the "From" header is set to the agents full name.

How to use:

1. Go to Settings
2. Under 'Channels' select 'Email'
3. Select 'Settings'
4. Scroll to 'Sender Format' and select 'Agent name'
5. Send a test mail

I hope it can be useful. :-)