### PR TITLE
Add support for Signal as a channel

### DIFF
--- a/app/assets/javascripts/app/controllers/_channel/signal.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/signal.coffee
@@ -1,0 +1,202 @@
+class Index extends App.ControllerSubContent
+  requiredPermission: 'admin.channel_signal'
+  events:
+    'click .js-new':       'new'
+    'click .js-edit':      'edit'
+    'click .js-delete':    'delete'
+    'click .js-disable':   'disable'
+    'click .js-enable':    'enable'
+
+  constructor: ->
+    super
+
+    #@interval(@load, 60000)
+    @load()
+
+  load: =>
+    @startLoading()
+    @ajax(
+      id:   'signal_index'
+      type: 'GET'
+      url:  "#{@apiPath}/channels_signal"
+      processData: true
+      success: (data) =>
+        @stopLoading()
+        App.Collection.loadAssets(data.assets)
+        @render(data)
+    )
+
+  render: (data) =>
+
+    channels = []
+    for channel_id in data.channel_ids
+      channel = App.Channel.find(channel_id)
+      if channel && channel.options
+        displayName = '-'
+        if channel.group_id
+          group = App.Group.find(channel.group_id)
+          displayName = group.displayName()
+        channel.options.groupName = displayName
+      channels.push channel
+    @html App.view('signal/index')(
+      channels: channels
+    )
+
+  new: (e) =>
+    e.preventDefault()
+    new BotAdd(
+      container: @el.parents('.content')
+      load: @load
+    )
+
+  edit: (e) =>
+    e.preventDefault()
+    id = $(e.target).closest('.action').data('id')
+    channel = App.Channel.find(id)
+    new BotEdit(
+      channel: channel
+      container: @el.parents('.content')
+      load: @load
+    )
+
+  delete: (e) =>
+    e.preventDefault()
+    id   = $(e.target).closest('.action').data('id')
+    new App.ControllerConfirm(
+      message: 'Sure?'
+      callback: =>
+        @ajax(
+          id:   'signal_delete'
+          type: 'DELETE'
+          url:  "#{@apiPath}/channels_signal"
+          data: JSON.stringify(id: id)
+          processData: true
+          success: =>
+            @load()
+        )
+      container: @el.closest('.content')
+    )
+
+  disable: (e) =>
+    e.preventDefault()
+    id   = $(e.target).closest('.action').data('id')
+    @ajax(
+      id:   'signal_disable'
+      type: 'POST'
+      url:  "#{@apiPath}/channels_signal_disable"
+      data: JSON.stringify(id: id)
+      processData: true
+      success: =>
+        @load()
+    )
+
+  enable: (e) =>
+    e.preventDefault()
+    id   = $(e.target).closest('.action').data('id')
+    @ajax(
+      id:   'signal_enable'
+      type: 'POST'
+      url:  "#{@apiPath}/channels_signal_enable"
+      data: JSON.stringify(id: id)
+      processData: true
+      success: =>
+        @load()
+    )
+
+class BotAdd extends App.ControllerModal
+  head: 'Add Signal Bot'
+  shown: true
+  button: 'Add'
+  buttonCancel: true
+  small: true
+
+  content: ->
+    content = $(App.view('signal/bot_add')())
+    createGroupSelection = (selected_id) ->
+      return App.UiElement.select.render(
+        name: 'group_id'
+        multiple: false
+        limit: 100
+        null: false
+        relation: 'Group'
+        nulloption: true
+        value: selected_id
+        class: 'form-control--small'
+      )
+
+    content.find('.js-select').on('click', (e) =>
+      @selectAll(e)
+    )
+    content.find('.js-messagesGroup').replaceWith createGroupSelection(1)
+    content
+
+  onClosed: =>
+    return if !@isChanged
+    @isChanged = false
+    @load()
+
+  onSubmit: (e) =>
+    @formDisable(e)
+    @ajax(
+      id:   'signal_app_verify'
+      type: 'POST'
+      url:  "#{@apiPath}/channels_signal"
+      data: JSON.stringify(@formParams())
+      processData: true
+      success: =>
+        @isChanged = true
+        @close()
+      error: (xhr) =>
+        data = JSON.parse(xhr.responseText)
+        @formEnable(e)
+        @el.find('.alert').removeClass('hidden').text(data.error || 'Unable to save Bot.')
+    )
+
+class BotEdit extends App.ControllerModal
+  head: 'Signal Account'
+  shown: true
+  buttonCancel: true
+
+  content: ->
+    content = $(App.view('signal/bot_edit')(channel: @channel))
+
+    createGroupSelection = (selected_id) ->
+      return App.UiElement.select.render(
+        name: 'group_id'
+        multiple: false
+        limit: 100
+        null: false
+        relation: 'Group'
+        nulloption: true
+        value: selected_id
+        class: 'form-control--small'
+      )
+
+    content.find('.js-messagesGroup').replaceWith createGroupSelection(@channel.group_id)
+    content
+
+  onClosed: =>
+    return if !@isChanged
+    @isChanged = false
+    @load()
+
+  onSubmit: (e) =>
+    @formDisable(e)
+    params = @formParams()
+    @channel.options = params
+    @ajax(
+      id:   'channel_signal_update'
+      type: 'PUT'
+      url:  "#{@apiPath}/channels_signal/#{@channel.id}"
+      data: JSON.stringify(@formParams())
+      processData: true
+      success: =>
+        @isChanged = true
+        @close()
+      error: (xhr) =>
+        data = JSON.parse(xhr.responseText)
+        @formEnable(e)
+        @el.find('.alert').removeClass('hidden').text(data.error || 'Unable to save changes.')
+    )
+
+App.Config.set('Signal', { prio: 5100, name: 'Signal', parent: '#channels', target: '#channels/signal', controller: Index, permission: ['admin.channel_signal'] }, 'NavBarAdmin')

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/signal.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/signal.coffee
@@ -1,11 +1,11 @@
-class SmsReply
+class SignalReply
   @action: (actions, ticket, article, ui) ->
     return actions if ui.permissionCheck('ticket.customer')
 
-    if article.sender.name is 'Customer' && article.type.name is 'sms'
+    if article.sender.name is 'Customer' && article.type.name is 'signal personal-message'
       actions.push {
         name: 'reply'
-        type: 'smsMessageReply'
+        type: 'signalPersonalMessageReply'
         icon: 'reply'
         href: '#'
       }
@@ -13,7 +13,7 @@ class SmsReply
     actions
 
   @perform: (articleContainer, type, ticket, article, ui) ->
-    return true if type isnt 'smsMessageReply'
+    return true if type isnt 'signalPersonalMessageReply'
 
     ui.scrollToCompose()
 
@@ -21,7 +21,7 @@ class SmsReply
     type = App.TicketArticleType.find(article.type_id)
 
     articleNew = {
-      to:          article.from
+      to:          ''
       cc:          ''
       body:        ''
       in_reply_to: ''
@@ -49,31 +49,31 @@ class SmsReply
 
     articleTypeCreate = App.TicketArticleType.find(ticket.create_article_type_id).name
 
-    return articleTypes if articleTypeCreate isnt 'sms'
+    return articleTypes if articleTypeCreate isnt 'signal personal-message'
     articleTypes.push {
-      name:              'sms'
-      icon:              'sms'
-      attributes:        ['to']
+      name:              'signal personal-message'
+      icon:              'signal'
+      attributes:        []
       internal:          false,
-      features:          ['body:limit']
-      maxTextLength:     160
-      warningTextLength: 30
+      features:          ['attachment']
+      maxTextLength:     10000
+      warningTextLength: 5000
     }
     articleTypes
 
   @setArticleTypePost: (type, ticket, ui) ->
-    return if type isnt 'telegram personal-message' and type isnt 'signal personal-message'
+    return if type isnt 'signal personal-message'
     rawHTML = ui.$('[data-name=body]').html()
     cleanHTML = App.Utils.htmlRemoveRichtext(rawHTML)
     if cleanHTML && cleanHTML.html() != rawHTML
       ui.$('[data-name=body]').html(cleanHTML)
 
   @params: (type, params, ui) ->
-    if type is 'sms'
+    if type is 'signal personal-message'
       App.Utils.htmlRemoveRichtext(ui.$('[data-name=body]'), false)
       params.content_type = 'text/plain'
       params.body = App.Utils.html2text(params.body, true)
 
     params
 
-App.Config.set('300-SmsReply', SmsReply, 'TicketZoomArticleAction')
+App.Config.set('300-SignalReply', SignalReply, 'TicketZoomArticleAction')

--- a/app/assets/javascripts/app/views/signal/bot_add.jst.eco
+++ b/app/assets/javascripts/app/views/signal/bot_add.jst.eco
@@ -1,0 +1,41 @@
+<div class="alert alert--danger hidden" role="alert"></div>
+<p>
+  <%- @T('The tutorial on how to manage a %s is hosted on our [online documentation](https://docs.zammad.org/en/latest/channel-signal.html).', 'Sigarillo Bot') %>
+</p>
+<fieldset>
+  <h2><%- @T('Enter your %s API Key', 'Sigarillo') %></h2>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="api_token"><%- @T('%s Api Token', 'Sigarillo') %> <span>*</span></label>
+    </div>
+    <div class="controls">
+      <input id="api_token" type="text" name="api_token" value="" class="form-control" required autocomplete="off">
+    </div>
+  </div>
+  <div class="input form-group">
+      <div class="formGroup-label">
+        <label for="api_url"><%- @T('Sigarillo API URL') %> <span>*</span></label>
+      </div>
+      <div class="controls">
+      <input id="api_url" type="text" name="api_url" value="" placeholder="https://" class="form-control" required autocomplete="off">
+    </div>
+  </div>
+
+  <h2><%- @T('Settings') %></h2>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="welcome"><%- @T('Welcome message') %> <span>*</span></label>
+    </div>
+    <div class="controls">
+      <input id="welcome" type="text" name="welcome" value="" placeholder="<%- @Ti('You are welcome! Just ask me something!') %>" class="form-control" required autocomplete="off">
+    </div>
+  </div>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for=""><%- @T('Choose which group %s will get added to.', 'messages') %> <span>*</span></label>
+    </div>
+    <div class="controls">
+      <div class="js-messagesGroup"></div>
+    </div>
+  </div>
+</fieldset>

--- a/app/assets/javascripts/app/views/signal/bot_edit.jst.eco
+++ b/app/assets/javascripts/app/views/signal/bot_edit.jst.eco
@@ -1,0 +1,37 @@
+<div class="alert alert--danger hidden" role="alert"></div>
+<fieldset>
+  <h2><%- @T('Enter your %s API Key', 'Sigarillo') %></h2>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="api_token"><%- @T('%s Api Token', 'Sigarillo') %> <span>*</span></label>
+    </div>
+    <div class="controls">
+      <input id="api_token" type="text" name="api_token" value="<%= @channel.options.api_token %>" class="form-control" required autocomplete="off">
+    </div>
+  </div>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="api_url"><%- @T('Sigarillo API URL') %> <span>*</span></label>
+    </div>
+    <div class="controls">
+      <input id="api_url" type="text" name="api_url" value="<%= @channel.options.api_url %>" placeholder="https://" class="form-control" required autocomplete="off">
+    </div>
+  </div>
+  <h2><%- @T('Settings') %></h2>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="welcome"><%- @T('welcome message') %> <span>*</span></label>
+    </div>
+    <div class="controls">
+      <input id="welcome" type="text" name="welcome" value="<%= @channel.options.welcome %>" placeholder="<%- @Ti('You are welcome! Just ask me something!') %>" class="form-control" required autocomplete="off">
+    </div>
+  </div>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for=""><%- @T('Choose which group %s will get added to.', 'messages') %> <span>*</span></label>
+    </div>
+    <div class="controls">
+      <div class="js-messagesGroup"></div>
+    </div>
+  </div>
+</fieldset>

--- a/app/assets/javascripts/app/views/signal/index.jst.eco
+++ b/app/assets/javascripts/app/views/signal/index.jst.eco
@@ -1,0 +1,48 @@
+<div class="page-header">
+  <div class="page-header-title">
+    <h1><%- @T('Sigarillo') %> <small><%- @T('Bots') %></small></h1>
+  </div>
+
+  <div class="page-header-meta">
+    <a class="btn btn--success js-new"><%- @T('Add Bot') %></a>
+  </div>
+</div>
+
+<div class="page-content">
+
+<% if _.isEmpty(@channels): %>
+  <div class="page-description">
+    <p><%- @T('You have no configured %s right now.', 'Sigarillo Bot') %></p>
+  </div>
+<% else: %>
+
+<% for channel in @channels: %>
+  <div class="action <% if channel.active isnt true: %>is-inactive<% end %>" data-id="<%= channel.id %>">
+    <div class="action-block action-row">
+      <h2><%- @Icon('status', 'supergood-color inline') %> <%= channel.options.bot.number%></h2>
+    </div>
+    <div class="action-flow action-flow--row">
+      <div class="action-block">
+        <h3><%- @T('Messages') %></h3>
+        <%= channel.options.bot.number %>
+      </div>
+      <%- @Icon('arrow-right', 'action-flow-icon') %>
+      <div class="action-block">
+        <h3><%- @T('Group') %></h3>
+        <% if channel.options: %>
+          <%= channel.options.groupName %>
+        <% end %>
+      </div>
+    </div>
+    <div class="action-controls">
+      <div class="btn btn--danger btn--secondary js-delete"><%- @T('Delete') %></div>
+      <% if channel.active is true: %>
+        <div class="btn btn--secondary js-disable"><%- @T('Disable') %></div>
+      <% else: %>
+        <div class="btn btn--secondary js-enable"><%- @T('Enable') %></div>
+      <% end %>
+      <div class="btn js-edit"><%- @T('Edit') %></div>
+    </div>
+  </div>
+<% end %>
+</div>

--- a/app/controllers/channels_signal_controller.rb
+++ b/app/controllers/channels_signal_controller.rb
@@ -1,0 +1,57 @@
+# Copyright (C) 2012-2016 Zammad Foundation, http://zammad-foundation.org/
+
+class ChannelsSignalController < ApplicationController
+  prepend_before_action -> { authentication_check(permission: 'admin.channel_signal') }
+
+  def index
+    assets = {}
+    channel_ids = []
+    Channel.where(area: 'Sigarillo::Account').order(:id).each do |channel|
+      assets = channel.assets(assets)
+      channel_ids.push channel.id
+    end
+    render json: {
+      assets:      assets,
+      channel_ids: channel_ids
+    }
+  end
+
+  def add
+    begin
+      channel = Sigarillo.create_or_update_channel(params[:api_url], params[:api_token], params)
+    rescue => e
+      raise Exceptions::UnprocessableEntity, e.message
+    end
+    render json: channel
+  end
+
+  def update
+    channel = Channel.find_by(id: params[:id], area: 'Sigarillo::Account')
+    begin
+      channel = Sigarillo.create_or_update_channel(params[:api_url], params[:api_token], params, channel)
+    rescue => e
+      raise Exceptions::UnprocessableEntity, e.message
+    end
+    render json: channel
+  end
+
+  def enable
+    channel = Channel.find_by(id: params[:id], area: 'Sigarillo::Account')
+    channel.active = true
+    channel.save!
+    render json: {}
+  end
+
+  def disable
+    channel = Channel.find_by(id: params[:id], area: 'Sigarillo::Account')
+    channel.active = false
+    channel.save!
+    render json: {}
+  end
+
+  def destroy
+    channel = Channel.find_by(id: params[:id], area: 'Sigarillo::Account')
+    channel.destroy
+    render json: {}
+  end
+end

--- a/app/models/channel/driver/sigarillo.rb
+++ b/app/models/channel/driver/sigarillo.rb
@@ -1,0 +1,113 @@
+# Copyright (C) 2012-2015 Zammad Foundation, http://zammad-foundation.org/
+
+class Channel::Driver::Sigarillo
+
+=begin
+
+  Channel::Driver::Sigarillo.fetchable?
+
+returns
+
+  true|false
+
+=end
+  def fetchable?(_channel)
+    Rails.logger.debug { 'sigarillo fetchable? YES!' }
+    return true if Rails.env.test?
+
+    # only fetch once in 30 minutes
+    # return true if !channel.preferences
+    # return true if !channel.preferences[:last_fetch]
+    # return false if channel.preferences[:last_fetch] > Time.zone.now - 20.minutes
+
+    true
+  end
+
+=begin
+
+fetch messages from signal
+
+  options = {}
+
+  instance = Channel::Driver::Sigarillo.new
+  result = instance.fetch(options, channel)
+
+returns
+
+  {
+    result: 'ok',
+  }
+
+=end
+  def fetch(options, channel)
+    Rails.logger.debug { 'sigarillo fetch called' }
+
+    options = check_external_credential(options)
+    @sigarillo = ::Sigarillo.new(channel.options[:api_url], channel.options[:api_token])
+
+    Rails.logger.debug { 'sigarillo fetch started' }
+    @sigarillo.fetch_messages(channel.group_id, channel)
+    Rails.logger.debug { 'sigarillo fetch completed' }
+    {
+      result: 'ok',
+      notice: '',
+    }
+  end
+
+  def disconnect; end
+
+=begin
+
+  instance = Channel::Driver::Sigarillo.new
+  instance.send(
+    {
+      adapter: 'signal',
+      auth: {
+        api_key:       api_key
+      },
+    },
+    signal_attributes,
+    notification
+  )
+
+=end
+
+  def send(options, article, _notification = false)
+    # return if we run import mode
+    return if Setting.get('import_mode')
+
+    options = check_external_credential(options)
+
+    Rails.logger.debug { 'sigarillo send started' }
+    Rails.logger.debug { options.inspect }
+    @sigarillo = ::Sigarillo.new(options[:api_url], options[:api_token])
+    @sigarillo.from_article(article)
+  end
+
+=begin
+
+  Channel::Driver::Sigarillo.streamable?
+
+returns
+
+  true|false
+
+=end
+
+  def self.streamable?
+    false
+  end
+
+  private
+
+  def check_external_credential(options)
+    if options[:auth] && options[:auth][:external_credential_id]
+      external_credential = ExternalCredential.find_by(id: options[:auth][:external_credential_id])
+      raise "No such ExternalCredential.find(#{options[:auth][:external_credential_id]})" if !external_credential
+
+      options[:auth][:api_key] = external_credential.credentials['api_key']
+    end
+    options
+  end
+
+end

--- a/app/models/observer/ticket/article/communicate_signal.rb
+++ b/app/models/observer/ticket/article/communicate_signal.rb
@@ -1,0 +1,27 @@
+# Copyright (C) 2018 Zammad Foundation, http://zammad-foundation.org/
+
+class Observer::Ticket::Article::CommunicateSignal < ActiveRecord::Observer
+  observe 'ticket::_article'
+
+  def after_create(record)
+
+    # return if we run import mode
+    return true if Setting.get('import_mode')
+
+    # if sender is customer, do not communicate
+    return true if !record.sender_id
+
+    sender = Ticket::Article::Sender.lookup(id: record.sender_id)
+    return true if sender.nil?
+    return true if sender.name == 'Customer'
+
+    # only apply on signal messages
+    return true if !record.type_id
+
+    type = Ticket::Article::Type.lookup(id: record.type_id)
+    return true if type.name !~ /\Asignal/i
+
+    Delayed::Job.enqueue(Observer::Ticket::Article::CommunicateSignal::BackgroundJob.new(record.id))
+  end
+
+end

--- a/app/models/observer/ticket/article/communicate_signal/background_job.rb
+++ b/app/models/observer/ticket/article/communicate_signal/background_job.rb
@@ -1,0 +1,111 @@
+class Observer::Ticket::Article::CommunicateSignal::BackgroundJob
+  def initialize(id)
+    @article_id = id
+  end
+
+  def perform
+    article = Ticket::Article.find(@article_id)
+
+    # set retry count
+    article.preferences['delivery_retry'] ||= 0
+    article.preferences['delivery_retry'] += 1
+
+    ticket = Ticket.lookup(id: article.ticket_id)
+    Rails.logger.debug { 'SIGNAL BACKGROUND JOB ' }
+    Rails.logger.debug { ticket.inspect }
+    Rails.logger.debug { article.inspect }
+    log_error(article, "Can't find ticket.preferences for Ticket.find(#{article.ticket_id})") if !ticket.preferences
+    log_error(article, "Can't find ticket.preferences['sigarillo'] for Ticket.find(#{article.ticket_id})") if !ticket.preferences['sigarillo']
+    log_error(article, "Can't find ticket.preferences['sigarillo']['chat_id'] for Ticket.find(#{article.ticket_id})") if !ticket.preferences['sigarillo']['chat_id']
+    log_error(article, "Can't find ticket.preferences['sigarillo']['bot_id'] for Ticket.find(#{article.ticket_id})") if !ticket.preferences['sigarillo']['bot_id']
+
+    channel = Sigarillo.bot_by_bot_id(ticket.preferences['sigarillo']['bot_id'])
+    Rails.logger.debug { "sigarillo got channel for #{channel.inspect}" }
+
+    if !channel
+      channel = Channel.lookup(id: ticket.preferences['channel_id'])
+    end
+    log_error(article, "No such channel for bot #{ticket.preferences['sigarillo']['bot_id']} or channel id #{ticket.preferences['channel_id']}") if !channel
+    log_error(article, "Channel.find(#{channel.id}) has no sigarillo api token!") if channel.options[:api_token].blank?
+
+    begin
+      result = channel.deliver(
+        to:   ticket.preferences[:sigarillo][:chat_id],
+        body: article.body,
+      )
+    rescue => e
+      log_error(article, e.message)
+      return
+    end
+
+    Rails.logger.debug { "send result: #{result}" }
+
+    if result.nil? || result[:error].present?
+      log_error(article, 'Delivering sigarillo message failed!')
+      return
+    end
+
+    article.to = result['result']['recipient']
+    article.from = result['result']['source']
+
+    message_id = format('%<source>s@%<timestamp>s', source: result['result']['source'], timestamp: result['result']['timestamp'])
+    article.preferences['sigarillo'] = {
+      timestamp:  result['result']['timestamp'],
+      message_id: message_id,
+      from:       result['result']['source'],
+      to:         result['result']['recipient'],
+    }
+
+    # set delivery status
+    article.preferences['delivery_status_message'] = nil
+    article.preferences['delivery_status'] = 'success'
+    article.preferences['delivery_status_date'] = Time.zone.now
+
+    article.message_id = "sigarillo.#{message_id}"
+
+    article.save!
+
+    Rails.logger.info "Sent signal message to: '#{article.to}' (from #{article.from})"
+
+    article
+  end
+
+  def log_error(local_record, message)
+    local_record.preferences['delivery_status'] = 'fail'
+    local_record.preferences['delivery_status_message'] = message.encode!('UTF-8', 'UTF-8', invalid: :replace, replace: '?')
+    local_record.preferences['delivery_status_date'] = Time.zone.now
+    local_record.save
+    Rails.logger.error message
+
+    if local_record.preferences['delivery_retry'] > 3
+      Ticket::Article.create(
+        ticket_id:     local_record.ticket_id,
+        content_type:  'text/plain',
+        body:          "Unable to send signal message: #{message}",
+        internal:      true,
+        sender:        Ticket::Article::Sender.find_by(name: 'System'),
+        type:          Ticket::Article::Type.find_by(name: 'note'),
+        preferences:   {
+          delivery_article_id_related: local_record.id,
+          delivery_message:            true,
+        },
+        updated_by_id: 1,
+        created_by_id: 1,
+      )
+    end
+
+    raise message
+  end
+
+  def max_attempts
+    4
+  end
+
+  def reschedule_at(current_time, attempts)
+    if Rails.env.production?
+      return current_time + attempts * 120.seconds
+    end
+
+    current_time + 5.seconds
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module Zammad
       'observer::_ticket::_article::_communicate_sms',
       'observer::_ticket::_article::_communicate_twitter',
       'observer::_ticket::_article::_communicate_telegram',
+      'observer::_ticket::_article::_communicate_signal',
       'observer::_ticket::_reset_new_state',
       'observer::_ticket::_ref_object_touch',
       'observer::_ticket::_online_notification_seen',

--- a/config/routes/channel_signal.rb
+++ b/config/routes/channel_signal.rb
@@ -1,0 +1,11 @@
+Zammad::Application.routes.draw do
+  api_path = Rails.configuration.api_path
+
+  match api_path + '/channels_signal',                         to: 'channels_signal#index',    via: :get
+  match api_path + '/channels_signal',                         to: 'channels_signal#add',      via: :post
+  match api_path + '/channels_signal/:id',                     to: 'channels_signal#update',   via: :put
+  match api_path + '/channels_signal_disable',                 to: 'channels_signal#disable',  via: :post
+  match api_path + '/channels_signal_enable',                  to: 'channels_signal#enable',   via: :post
+  match api_path + '/channels_signal',                         to: 'channels_signal#destroy',  via: :delete
+
+end

--- a/db/migrate/20181127105539_signal_support.rb
+++ b/db/migrate/20181127105539_signal_support.rb
@@ -1,0 +1,23 @@
+class SignalSupport < ActiveRecord::Migration[5.1]
+  def up
+
+    # return if it's a new setup
+    return if !Setting.find_by(name: 'system_init_done')
+
+    Permission.create_if_not_exists(
+      name:        'admin.channel_signal',
+      note:        'Manage %s',
+      preferences: {
+        translations: ['Channel - Signal']
+      },
+    )
+
+    Ticket::Article::Type.create_if_not_exists(
+      name:          'signal personal-message',
+      communication: true,
+      updated_by_id: 1,
+      created_by_id: 1,
+    )
+
+  end
+end

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -137,6 +137,13 @@ Permission.create_if_not_exists(
   },
 )
 Permission.create_if_not_exists(
+  name:        'admin.channel_signal',
+  note:        'Manage %s',
+  preferences: {
+    translations: ['Channel - Signal']
+  },
+)
+Permission.create_if_not_exists(
   name:        'admin.channel_sms',
   note:        'Manage %s',
   preferences: {

--- a/db/seeds/ticket_article_types.rb
+++ b/db/seeds/ticket_article_types.rb
@@ -10,3 +10,4 @@ Ticket::Article::Type.create_if_not_exists(id: 9, name: 'facebook feed comment',
 Ticket::Article::Type.create_if_not_exists(id: 10, name: 'note', communication: false)
 Ticket::Article::Type.create_if_not_exists(id: 11, name: 'web', communication: true)
 Ticket::Article::Type.create_if_not_exists(id: 12, name: 'telegram personal-message', communication: true)
+Ticket::Article::Type.create_if_not_exists(id: 13, name: 'signal personal-message', communication: true)

--- a/lib/sigarillo.rb
+++ b/lib/sigarillo.rb
@@ -1,0 +1,395 @@
+# Copyright (C) 2012-2015 Zammad Foundation, http://zammad-foundation.org/
+
+require 'sigarillo_api'
+
+class Sigarillo
+
+  attr_accessor :client
+
+=begin
+
+check token and return bot attributes of token
+
+  bot = Signal.check_token('token')
+
+=end
+
+  def self.check_token(api_url, token)
+
+    api = SigarilloAPI.new(api_url, token)
+    begin
+      bot = api.fetch_self()
+    rescue => e
+      raise 'invalid api token: ' + e.message
+    end
+    bot
+  end
+
+=begin
+
+create or update channel, store bot attributes and verify token
+
+  channel = Signal.create_or_update_channel('token', params)
+
+returns
+
+  channel # instance of Channel
+
+=end
+
+  def self.create_or_update_channel(api_url, token, params, channel = nil)
+
+    # verify token
+    bot = Sigarillo.check_token(api_url, token)
+
+    if !channel
+      if Sigarillo.bot_duplicate?(bot['id'])
+        raise 'Bot already exists!'
+      end
+    end
+
+    if params[:group_id].blank?
+      raise 'Group needed!'
+    end
+
+    group = Group.find_by(id: params[:group_id])
+    if !group
+      raise 'Group invalid!'
+    end
+
+    if !channel
+      channel = Sigarillo.bot_by_bot_id(bot['id'])
+      if !channel
+        channel = Channel.new
+      end
+    end
+    channel.area = 'Sigarillo::Account'
+    channel.options = {
+      adapter:   'sigarillo',
+      bot:       {
+        id:     bot['id'],
+        number: bot['number'],
+      },
+      api_token: token,
+      api_url:   api_url,
+      welcome:   params[:welcome],
+    }
+    channel.group_id = group.id
+    channel.active = true
+    channel.save!
+    channel
+  end
+
+=begin
+
+check if bot already exists as channel
+
+  success = Signal.bot_duplicate?(bot_id)
+
+returns
+
+  channel # instance of Channel
+
+=end
+
+  def self.bot_duplicate?(bot_id, channel_id = nil)
+    Channel.where(area: 'Sigarillo::Account').each do |channel|
+      next if !channel.options
+      next if !channel.options[:bot]
+      next if !channel.options[:bot][:id]
+      next if channel.options[:bot][:id] != bot_id
+      next if channel.id.to_s == channel_id.to_s
+
+      return true
+    end
+    false
+  end
+
+=begin
+
+get channel by bot_id
+
+  channel = Signal.bot_by_bot_id(bot_id)
+
+returns
+
+  true|false
+
+=end
+
+  def self.bot_by_bot_id(bot_id)
+    Channel.where(area: 'Sigarillo::Account').each do |channel|
+      next if !channel.options
+      next if !channel.options[:bot]
+      next if !channel.options[:bot][:id]
+      return channel if channel.options[:bot][:id].to_s == bot_id.to_s
+    end
+    nil
+  end
+
+=begin
+
+  date = Sigarillo.timestamp_to_date('1543414973285')
+
+returns
+
+  2018-11-28T14:22:53.285Z
+
+=end
+
+  def self.timestamp_to_date(timestamp_str)
+    Time.at(timestamp_str.to_i).utc.to_datetime
+  end
+
+  def self.message_id(message_raw)
+    format('%<source>s@%<timestamp>s', source: message_raw['source'], timestamp: message_raw['timestamp'])
+  end
+
+=begin
+
+  client = Signal.new('token')
+
+=end
+
+  def initialize(api_url, token)
+    @token = token
+    @api_url = api_url
+    @api = SigarilloAPI.new(api_url, token)
+  end
+
+=begin
+
+Fetch AND import messages for the bot
+
+  client.fetch_messages(group_id, channel)
+
+returns an updated ticket
+
+=end
+
+  def fetch_messages(group_id, channel)
+
+    older_import = 0
+    older_import_max = 20
+    @api.fetch().each do |message_raw|
+      Rails.logger.debug { 'processing message ' }
+      Rails.logger.debug { message_raw.inspect }
+      message = {
+        source:     message_raw['source'],
+        timestamp:  message_raw['timestamp'],
+        created_at: Sigarillo.timestamp_to_date(message_raw['timestamp']),
+        id:         Sigarillo.message_id(message_raw),
+        message:    {
+          body:       message_raw['message']['body'],
+          profileKey: message_raw['message']['profileKey'],
+        }
+      }
+
+      if (channel.created_at - 15.days) > message[:created_at] || older_import >= older_import_max
+        older_import += 1
+        Rails.logger.debug { "signal msg too old: #{message[:id]}/#{message[:created_at]}" }
+        next
+      end
+
+      next if Ticket::Article.find_by(message_id: message[:id])
+
+      to_group(message, group_id, channel)
+    end
+  end
+
+=begin
+
+  client.send_message(chat_id, 'some message')
+
+=end
+
+  def send_message(recipient, message)
+    return if Rails.env.test?
+
+    @api.send_message(recipient, message)
+  end
+
+  def user(number)
+    {
+      # id:         params[:message][:from][:id],
+      id:       number,
+      username: number,
+      # first_name: params[:message][:from][:first_name],
+      # last_name:  params[:message][:from][:last_name]
+    }
+  end
+
+  def to_user(message)
+    Rails.logger.debug { 'Create user from message...' }
+    Rails.logger.debug { message.inspect }
+
+    # do message_user lookup
+    message_user = user(message[:source])
+
+    # create or update user
+    login = message_user[:username] || message_user[:id]
+
+    auth = Authorization.find_by(uid: message[:source], provider: 'sigarillo')
+
+    user_data = {
+      login:  login,
+      mobile: message[:source],
+    }
+
+    user = if auth
+             User.find(auth.user_id)
+           else
+             User.where(mobile: message[:source]).order(:updated_at).first
+           end
+    if user
+      user.update!(user_data)
+    else
+      user = User.create!(
+        firstname: message[:source],
+        mobile:    message[:source],
+        note:      "Signal #{message_user[:username]}",
+        active:    true,
+        role_ids:  Role.signup_role_ids
+      )
+    end
+
+    # create or update authorization
+    auth_data = {
+      uid:      message_user[:id],
+      username: login,
+      user_id:  user.id,
+      provider: 'signal'
+    }
+    if auth
+      auth.update!(auth_data)
+    else
+      Authorization.create(auth_data)
+    end
+
+    user
+  end
+
+  def to_ticket(message, user, group_id, channel)
+    UserInfo.current_user_id = user.id
+
+    Rails.logger.debug { 'Create ticket from message...' }
+    Rails.logger.debug { message.inspect }
+    Rails.logger.debug { user.inspect }
+    Rails.logger.debug { group_id.inspect }
+
+    # prepare title
+    title = '-'
+    if !message[:message][:body].nil?
+      title = message[:message][:body]
+    end
+    if title.length > 60
+      title = "#{title[0, 60]}..."
+    end
+
+    # find ticket or create one
+    state_ids = Ticket::State.where(name: %w[closed merged removed]).pluck(:id)
+    ticket = Ticket.where(customer_id: user.id).where.not(state_id: state_ids).order(:updated_at).first
+    if ticket
+
+      # check if title need to be updated
+      if ticket.title == '-'
+        ticket.title = title
+      end
+      new_state = Ticket::State.find_by(default_create: true)
+      if ticket.state_id != new_state.id
+        ticket.state = Ticket::State.find_by(default_follow_up: true)
+      end
+      ticket.save!
+      return ticket
+    end
+
+    ticket = Ticket.new(
+      group_id:    group_id,
+      title:       title,
+      state_id:    Ticket::State.find_by(default_create: true).id,
+      priority_id: Ticket::Priority.find_by(default_create: true).id,
+      customer_id: user.id,
+      preferences: {
+        channel_id: channel.id,
+        sigarillo:  {
+          bot_id:  channel.options[:bot][:id],
+          chat_id: message[:source]
+        }
+      }
+    )
+    ticket.save!
+    ticket
+  end
+
+  def to_article(message, user, ticket, channel)
+
+    Rails.logger.debug { 'Create article from message...' }
+    Rails.logger.debug { message.inspect }
+    Rails.logger.debug { user.inspect }
+    Rails.logger.debug { ticket.inspect }
+
+    UserInfo.current_user_id = user.id
+
+    article = Ticket::Article.new(
+      from:         message[:source],
+      to:           channel[:options][:bot][:number],
+      body:         message[:message][:body],
+      content_type: 'text/plain',
+      message_id:   "sigarillo.#{message[:id]}",
+      ticket_id:    ticket.id,
+      type_id:      Ticket::Article::Type.find_by(name: 'signal personal-message').id,
+      sender_id:    Ticket::Article::Sender.find_by(name: 'Customer').id,
+      internal:     false,
+      preferences:  {
+        sigarillo: {
+          timestamp:  message[:timestamp],
+          message_id: message[:id],
+          from:       message[:source],
+        }
+      }
+    )
+
+    # TODO: attachments
+    # TODO voice
+    # TODO emojis
+    #
+    if message[:message][:body]
+      Rails.logger.debug { article.inspect }
+      article.save!
+      return article
+    end
+    raise 'invalid action'
+  end
+
+  def to_group(message, group_id, channel)
+    # begin import
+    Rails.logger.debug { 'sigarillo import message' }
+
+    # TODO: handle messages in group chats
+
+    return if Ticket::Article.find_by(message_id: message[:id])
+
+    ticket = nil
+    # use transaction
+    Transaction.execute(reset_user_id: true) do
+      user = to_user(message)
+      ticket = to_ticket(message, user, group_id, channel)
+      to_article(message, user, ticket, channel)
+    end
+
+    ticket
+  end
+
+  def from_article(article)
+    # sends a message from a zammad article
+
+    Rails.logger.debug { "Create signal personal message from article to '#{article[:to]}'..." }
+
+    @api.send_message(article[:to], article[:body])
+  end
+
+  def download_file(file_id)
+    # TODO: attachments
+  end
+
+end

--- a/lib/sigarillo_api.rb
+++ b/lib/sigarillo_api.rb
@@ -1,0 +1,53 @@
+require 'json'
+require 'net/http'
+require 'net/https'
+require 'uri'
+require 'rest-client'
+
+class SigarilloAPI
+  def initialize(api_url, token)
+    @token = token
+    @last_update = 0
+    @api = api_url
+  end
+
+  def parse_hash(hash)
+    ret = {}
+    hash.map do |k, v|
+      ret[k] = CGI.encode(v.to_s.gsub('\\\'', '\''))
+    end
+    ret
+  end
+
+  def get(api)
+    url = @api + '/bot/' + @token + '/' + api
+    ret = JSON.parse(RestClient.get(url, { accept: :json }).body)
+    ret
+  end
+
+  def post(api, params = {})
+    url = @api + '/bot/' + @token + '/' + api
+    ret = JSON.parse(RestClient.post(url, params, { accept: :json }).body)
+    ret
+  end
+
+  def fetch_self
+    get('')
+  end
+
+  def send_message(recipient, text, options = {})
+    post('send', { recipient: recipient.to_s, message: text }.merge(parse_hash(options)))
+  end
+
+  def fetch
+    results = get('receive')
+    if results['messages'].nil?
+      Rails.logger.error { 'sigarillo fetch failed' }
+      Rails.logger.debug { results.inspect }
+      return []
+    end
+
+    messages = results['messages']
+    messages
+  end
+end

--- a/test/data/sigarillo/message1_inbound1_response.json
+++ b/test/data/sigarillo/message1_inbound1_response.json
@@ -1,0 +1,21 @@
+{
+  "messages": [
+    {
+      "source": "+15555555551",
+      "timestamp": "1541265073894",
+      "message": {
+        "body": "Hello there, can you help me?",
+        "profileKey": "XXTXQ=="
+      }
+    }
+  ],
+  "bot": {
+    "id": "129f1757-e706-452e-aa1c-4994a95e1092",
+    "number": "+15555555552",
+    "user_id": "845ae4d0-f2c3-5342-91a2-5b45cb8db57c",
+    "token": "valid_token",
+    "is_verified": true,
+    "created_at": "2018-11-02T11:36:24.273Z",
+    "updated_at": "2018-11-02T11:36:24.273Z"
+  }
+}

--- a/test/data/sigarillo/message1_outbound1_content.json
+++ b/test/data/sigarillo/message1_outbound1_content.json
@@ -1,0 +1,1 @@
+recipient=%2B15555555551&message=Yes%21+I+can+help.

--- a/test/data/sigarillo/message1_outbound1_response.json
+++ b/test/data/sigarillo/message1_outbound1_response.json
@@ -1,0 +1,8 @@
+{
+  "result": {
+    "recipient": "+15555555551",
+    "source": "+15555555552",
+    "status": "sent",
+    "timestamp": "1543420505142"
+  }
+}

--- a/test/integration/sigarillo_test.rb
+++ b/test/integration/sigarillo_test.rb
@@ -1,0 +1,136 @@
+require 'test_helper'
+require 'rexml/document'
+require 'webmock/minitest'
+
+class SigarilloTest < ActionDispatch::IntegrationTest
+
+  token = 'valid_token'
+  api_url = 'https://sigarillo.foo'
+  bot_number = '+15555555552'
+  bot_id = '129f1757-e706-452e-aa1c-4994a95e1092'
+  customer_number = '+15555555551'
+  group_id = Group.find_by(name: 'Users').id
+  channel = nil
+
+  setup do
+    @headers = { 'ACCEPT' => 'application/json', 'CONTENT_TYPE' => 'application/json' }
+    # configure sigarillo channel
+    UserInfo.current_user_id = 1
+    # try check with valid token
+    stub_request(:get, "#{api_url}/bot/#{token}/")
+        .to_return(status: 200, body: "{
+  \"id\": \"129f1757-e706-452e-aa1c-4994a95e1092\",
+  \"number\": \"#{bot_number}\",
+  \"user_id\": \"845ae4d0-f2c3-5342-91a2-5b45cb8db57c\",
+  \"token\": \"#{token}\",
+  \"is_verified\": true,
+  \"created_at\": \"2018-11-02T11:36:24.273Z\",
+  \"updated_at\": \"2018-11-02T11:36:24.273Z\"
+}", headers: {})
+    Sigarillo.create_or_update_channel(api_url, token, { group_id: group_id, welcome: 'hi!' })
+
+    channel = Sigarillo.bot_by_bot_id(bot_id)
+
+    assert(channel, 'Sigarillo channel created')
+  end
+
+  teardown do
+    Channel.where(area: 'Sigarillo::Account').destroy_all
+  end
+
+  test 'check token validity works' do
+    # try check with invalid token
+    stub_request(:get, "#{api_url}/bot/not_existing/")
+        .to_return(status: 404, body: '{"ok":false,"error_code":404,"description":"Not Found"}', headers: {})
+
+    assert_raises(RuntimeError) do
+      Sigarillo.check_token(api_url, 'not_existing')
+    end
+
+    # try check with valid token
+    stub_request(:get, "#{api_url}/bot/#{token}/")
+        .to_return(status: 200, body: "{
+  \"id\": \"129f1757-e706-452e-aa1c-4994a95e1092\",
+  \"number\": \"#{bot_number}\",
+  \"user_id\": \"845ae4d0-f2c3-5342-91a2-5b45cb8db57c\",
+  \"token\": \"#{token}\",
+  \"is_verified\": true,
+  \"created_at\": \"2018-11-02T11:36:24.273Z\",
+  \"updated_at\": \"2018-11-02T11:36:24.273Z\"
+}", headers: {})
+
+    bot = Sigarillo.check_token(api_url, token)
+    assert_equal(bot_number, bot['number'])
+  end
+
+  test 'inbound new ticket and reply' do
+    Ticket.destroy_all
+
+    # create the inbound signal message, and stub the API call
+    inbound_response = read_message('message1_inbound1_response')
+    inbound_message = JSON.parse(inbound_response)['messages'][0]
+    stub_request(:get, "#{api_url}/bot/#{token}/receive")
+        .to_return(status: 200, body: inbound_response, headers: {})
+
+    # stub the API response for sending a message
+    outbound_content = read_message('message1_outbound1_content')
+    outbound_response = read_message('message1_outbound1_response')
+    stub_request(:post, "#{api_url}/bot/#{token}/send")
+        .with(body: outbound_content)
+        .to_return(status: 200, body: outbound_response, headers: {})
+
+    message_id = 'sigarillo.+15555555551@1541265073894'
+
+    # Fetch the messages from the channel, hitting our inbound stub
+    Channel.fetch
+
+    # check if follow up article has been created
+    article = Ticket::Article.find_by(message_id: message_id)
+
+    assert(article, "article message '#{message_id}' imported")
+    assert_equal("#{customer_number} ", article.from, 'ticket article from')
+    assert_equal(bot_number, article.to, 'ticket article to')
+    assert_equal(message_id, article.message_id, 'ticket article inbound message_id')
+    assert_equal(1, article.ticket.articles.count, 'ticket article inbound count')
+    assert_equal(inbound_message['message']['body'], article.body, 'ticket article inbound body')
+    assert_equal('new', article.ticket.reload.state.name)
+
+    ticket = article.ticket
+
+    channel = Channel.find(channel.id)
+    # assert_equal('', channel.last_log_out)
+    # assert_equal('ok', channel.status_out)
+    assert_equal('', channel.last_log_in)
+    assert_equal('ok', channel.status_in)
+
+    # send the reply
+    reply_text = 'Yes! I can help.'
+    article = Ticket::Article.create!(
+      ticket_id:     ticket.id,
+      body:          reply_text,
+      type:          Ticket::Article::Type.find_by(name: 'signal personal-message'),
+      sender:        Ticket::Article::Sender.find_by(name: 'Agent'),
+      internal:      false,
+      updated_by_id: 1,
+      created_by_id: 1,
+    )
+
+    message_id = 'sigarillo.+15555555552@1543420505142'
+
+    # Start the worker to send our outgoing message to the oubound stub
+    Scheduler.worker(true)
+    assert_equal('open', ticket.reload.state.name)
+    article = Ticket::Article.find(article.id)
+    assert(article, "article message '#{message_id}' imported")
+    assert_equal(bot_number, article.from, 'ticket article from')
+    assert_equal(customer_number, article.to, 'ticket article to')
+    assert_equal(message_id, article.message_id, 'ticket article outbound message_id')
+    assert_equal(2, article.ticket.articles.count, 'ticket article outbound count')
+    assert_equal(reply_text, article.body, 'ticket article outbound body')
+
+  end
+
+  def read_message(file)
+    File.read(Rails.root.join('test', 'data', 'sigarillo', "#{file}.json"))
+  end
+end


### PR DESCRIPTION
Here is an implementation of Signal to be used as a channel in Zammad. Fixes #804

It does not use Signal's API servers directly, instead, the Signal specific code (encryption, key handling, registration, etc) is handled via a bridge service created specifically for this project: [Sigarillo](https://gitlab.com/digiresilience/link/sigarillo/).

[Sigarillo](https://gitlab.com/digiresilience/link/sigarillo/) is a simple node.js application that provides a few basic HTTP endpoints for registering and verifying a Signal number. It also provides two endpoints for sending and receiving messages. It uses Postgres to store state (account keys, session keys, and so on). Messages are only fetched when the receive endpoint is called, and are not persisted to disk. Under the hood Sigarillo uses the same javascript library as the signal desktop application. Sigarillo is straightforward to host and also comes with a docker image to easily get up and running.

**Why Sigarillo?** Why not just implement Signal directly into Zammad? Because there are no Signal libraries available for Ruby. Implementing the [Signal specifications](https://signal.org/docs/) (double ratchet, x3dh, sesame, et al) would take an incredibly significant amount of effort. Hence, the decision to use existing, vetted libraries to build Sigarillo.

This makes the implementation in Zammad very simple (as you can see in this PR). Assuming a user has a Sigarillo instance available, and a number registered and verified, to add the channel to Zammad a user simply must provide the Sigarillo URI for the number and the secret API token (provided by Sigarillo).

We've been using this channel in several production deployments since November, and it is working great.

Circle CI Builds: https://circleci.com/gh/digiresilience/zammad