### PR TITLE
change working directory

### DIFF
--- a/contrib/backup/zammad_backup.sh
+++ b/contrib/backup/zammad_backup.sh
@@ -6,6 +6,9 @@
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:
 BACKUP_SCRIPT_PATH="$(dirname $(realpath $0))"
 
+# chdir to run as Cron
+cd $BACKUP_SCRIPT_PATH;
+
 if [ -f "${BACKUP_SCRIPT_PATH}/config" ]; then
   # import config
   . ${BACKUP_SCRIPT_PATH}/config

--- a/contrib/backup/zammad_backup.sh
+++ b/contrib/backup/zammad_backup.sh
@@ -6,10 +6,9 @@
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:
 BACKUP_SCRIPT_PATH="$(dirname $(realpath $0))"
 
-# chdir to run as Cron
-cd $BACKUP_SCRIPT_PATH;
-
 if [ -f "${BACKUP_SCRIPT_PATH}/config" ]; then
+  # chdir to run as Cron
+  cd "${BACKUP_SCRIPT_PATH}"
   # import config
   . ${BACKUP_SCRIPT_PATH}/config
 else


### PR DESCRIPTION
fixes #2508

When running as cron, pg_dump might complain about permissions in the current working directory.

changing directory to the BACKUP_SCRIPT_PATH solves this.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
