### PR TITLE
Show email address in user autocomplete (#2436)

### DIFF
--- a/app/assets/javascripts/app/views/generic/object_search/item_object.jst.eco
+++ b/app/assets/javascripts/app/views/generic/object_search/item_object.jst.eco
@@ -8,6 +8,9 @@
     <% else: %>
       <%= @object.displayName() %>
     <% end %>
+    <% if @object.email: %>
+      <span class="recipientList-email">- <%= @object.email %></span>
+    <% end %>
     <% if @object.organization: %>
       <span class="recipientList-detail">- <%= @object.organization.displayName() %></span>
     <% end %>

--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -6857,6 +6857,10 @@ footer {
     opacity: 1;
   }
 
+  .recipientList-email {
+    opacity: 0.5;
+  }
+
   .recipientList-detail {
     opacity: 0.5;
   }


### PR DESCRIPTION
As discussed [in the community](https://community.zammad.org/t/new-send-e-mail-ticket-show-customer-e-mail-address/1838) and in #2436 - when choosing a user/customer, Zammad currently only shows the user name, but not the email address:

![image](https://user-images.githubusercontent.com/6863569/55279289-46483000-5317-11e9-9985-7ed1824e65dc.png)

It'll only show the user's email address after you've chosen a user from the list. This is annoying when you have multiple users with the same name, and you know which address you want to write to; you might have to repeatedly choose a user, check if it's the right one, and if not, choose another one.

This MR changes to behaviour of the user selection list to also show the email address:

![image](https://user-images.githubusercontent.com/6863569/55280193-50bbf700-5322-11e9-93f5-a0d16edf86ae.png)

It does _not_ completely fix #2436 though, as it only modifies the user selection list (e.g. "customer" when creating a new ticket, or "specific user" in triggers/schedulers/macros), but not the email address selection list (To and CC fields when writing emails).