### PR TITLE
allow agents to always reopen tickets, regardless of group.follow_up_possible

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -659,6 +659,7 @@ class TicketsController < ApplicationController
   def follow_up_possible_check
     ticket = Ticket.find(params[:id])
 
+    return true if current_user.permissions?('ticket.agent') # agents can always reopen tickets, regardless of group configuration
     return true if ticket.group.follow_up_possible != 'new_ticket' # check if the setting for follow_up_possible is disabled
     return true if ticket.state.name != 'closed' # check if the ticket state is already closed
 


### PR DESCRIPTION
As discussed in the community: https://community.zammad.org/t/allow-only-agent-to-re-open-the-ticket-follow-up-possible/1906

This commit changes the behavior of the option group.follow_up_possible
(admin -> manage -> groups -> <group> -> follow up possible). Before this
commit, setting this option to "do not reopen ticket but create a new ticket"
meant that _both_ agents and customers weren't allowed to reopen closed
tickets. This is problematic because it means that an agent who accidentally
closed a ticket has no way to undo this, which I believe wasn't the intention
of this option.

This commit changes the behavior so that agents are now exempt from this
limitation and can close and reopen tickets at whim.

As I said in the community thread, I see no reason to add a separate option for this new behavior, because I believe this is how it's supposed to work; preventing agents from reopening tickets just doesn't seem to be very useful to me. If this is not acceptable, I could of course still change that :)