### PR TITLE
Fix user search input background-color

### DIFF
--- a/app/assets/javascripts/app/views/generic/object_search/input.jst.eco
+++ b/app/assets/javascripts/app/views/generic/object_search/input.jst.eco
@@ -3,7 +3,7 @@
   <% if @attribute.multiple: %>
     <%- @tokens %>
   <% end %>
-  <input name="<%- @attribute.name %>_completion" class="user-select token-input js-objectSelect" autocapitalize="off" placeholder="<%- @Ti(@attribute.placeholder) %>" autocomplete="off" <%= @attribute.autofocus %> role="textbox" aria-autocomplete="list" value="<%= @name %>" aria-haspopup="true">
+  <input name="<%- @attribute.name %>_completion" class="user-select token-input js-objectSelect form-control" autocapitalize="off" placeholder="<%- @Ti(@attribute.placeholder) %>" autocomplete="off" <%= @attribute.autofocus %> role="textbox" aria-autocomplete="list" value="<%= @name %>" aria-haspopup="true">
   <% if @attribute.disableCreateObject isnt true: %><%- @Icon('arrow-down', 'dropdown-arrow') %><% end %>
 </div>
 


### PR DESCRIPTION
Ensure the a background-color is set. In current version the font color is #333 form the body and no background. If you use an dark system theme the input can get the background-color fro your system near #333.
The user inpur is the only field without form-control (sets a color and background). Worked on my system.