### PR TITLE
Ticket zoom: increased double-click/metaToggle timeout (fixes #2586)

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
@@ -291,7 +291,7 @@ class ArticleViewItem extends App.ObserverController
   toggleMetaWithDelay: (e) =>
     # allow double click select
     # by adding a delay to the toggle
-    delay = 120
+    delay = 300
 
     if @lastClick and +new Date - @lastClick < delay
       clearTimeout(@toggleMetaTimeout)


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

Increase the double-click timeout in the ticket zoom from 120ms too 300ms. This makes it easier to select words via double-click without accidentally triggering the detail view.

This fixes #2586.