### PR TITLE
Ticket zoom: do not toggle detail view when deselecting text (fixes #2589)

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
@@ -293,6 +293,11 @@ class ArticleViewItem extends App.ObserverController
     # by adding a delay to the toggle
     delay = 300
 
+    article = $(e.target).closest('.ticket-article-item')
+    if @elementContainsSelection(article.get(0))
+      @stopPropagation(e)
+      return false
+
     if @lastClick and +new Date - @lastClick < delay
       clearTimeout(@toggleMetaTimeout)
     else


### PR DESCRIPTION
My attempt at fixing #2589. I've just duplicated the `@elementContainsSelection` code from `toggleMeta` into `toggleMetaWithDelay` (moving it completely didn't work, it has to be in both methods), and that seems to improve the behaviour.

I've tested the following situations, and they all work:
- single click into the article: toggles detail view, as expected
- select text by mouse down -> drag -> mouse up: doesn't toggle detail view
- selecting a single word by double click: doesn't toggle detail view
- selecting a range of words by double click -> mouse down -> drag -> mouse up: doesn't toggle detail view
- deselecting any selection by clicking it: doesn't toggle detail view
- deselecting any selection by clicking anywhere in the article: this is still a bit wonky. It won't toggle the detail view when I select everything in the article, but it will toggle the detail view when I only select a part of the article. Not sure why? https://i.imgur.com/DOxgOVN.mp4