### PR TITLE
Knowledge base: Use existing translation for "Attached files"

### DIFF
--- a/app/views/knowledge_base/public/answers/show.html.erb
+++ b/app/views/knowledge_base/public/answers/show.html.erb
@@ -14,7 +14,7 @@ data-available-locales='<%= @object_locales.map(&:locale).join(',') %>'>
       <% if (attachments = @object.attachments_sorted) && attachments.present? %>
         <div class="attachments">
           <%= icon 'paperclip' %>
-          <div class="attachments-title"><%= zt('Attached files') %></div>
+          <div class="attachments-title"><%= zt('Attached Files') %></div>
           <% attachments.each do |attachment| %>
             <%= link_to custom_path_if_needed(attachment_path(attachment)), class: 'attachment', download: true do %>
               <span class="attachment-name u-highlight"><%= attachment.filename %></span>


### PR DESCRIPTION
The "Attached files" string in the knowledge base is currently not translated. The easiest way should be to do the spelling as in other menus.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
