### PR TITLE
Add Rails 5 log to STDOUT env variable support

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,6 +54,12 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 


### PR DESCRIPTION
The default production environment settings for Rails, I think starting with Rails 5, have an env variable with which one can send the logs to STDOUT instead of the standard Rails logs, see https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt#L93-L97

In our case this is useful to send the logs to systemd/journald through STDOUT, allowing us to just set `RAILS_LOG_TO_STDOUT=1` in the `/etc/zammad/zammad.env` instead of mucking in the Zammad code itself.

This PR adds the code part copied from the Rails template linked to above.