### PR TITLE
Exclude tmp, log, cache dirs from backups

### DIFF
--- a/contrib/backup/functions
+++ b/contrib/backup/functions
@@ -40,7 +40,7 @@ function backup_dir_create () {
 
 function backup_files () {
   echo "creating file backup..."
-  tar -C / -czf ${BACKUP_DIR}/${TIMESTAMP}_zammad_files.tar.gz ${ZAMMAD_DIR#/}
+  tar -C / -czf ${BACKUP_DIR}/${TIMESTAMP}_zammad_files.tar.gz --exclude='tmp' ${ZAMMAD_DIR#/}
   ln -sfn ${BACKUP_DIR}/${TIMESTAMP}_zammad_files.tar.gz ${BACKUP_DIR}/latest_zammad_files.tar.gz
 }
 


### PR DESCRIPTION
Exclude `tmp`, `log`, `.bundle` and `vendor` dirs from backups. See also discussion in #2021

`.bundle` might be present in your zammad installation directory depending on how you installed it. For example the default from source installation documentation puts the home directory of the zammad user in the root of the zammad installation dir https://docs.zammad.org/en/latest/install-source.html#add-user

`vendor` might be present depending on how you install gems. Those can be recreated by running `bundle install` again, so it's no necessary to back them up, and they're quite large (355MB out of the 776MB of the whole zammad install in our case).

I'll be happy to make any necessary changes based on comments, thank you.