### PR TITLE
Make Check_MK integration more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,27 @@
 # Change Log
 
-## [3.1.0](https://github.com/zammad/zammad/tree/3.1.0) (2019-xx-xx)
+## [3.1.0](https://github.com/zammad/zammad/tree/3.1.0) (2019-07-10)
 [Full Changelog](https://github.com/zammad/zammad/compare/3.0.0...3.1.0)
 
 **Implemented enhancements:**
-
-
-
+- Enhance tag search to use fulltext search [2569](https://github.com/zammad/zammad/issues/2569) [[UX/UI](https://github.com/zammad/zammad/labels/UX/UI)] [[enhancement](https://github.com/zammad/zammad/labels/enhancement)] [[ticket](https://github.com/zammad/zammad/labels/ticket)]
+- translation strings wrong [1561](https://github.com/zammad/zammad/issues/1561) [[enhancement](https://github.com/zammad/zammad/labels/enhancement)] [[translation](https://github.com/zammad/zammad/labels/translation)]
+- Misleading 'Escalation' ticket attribute name in SLAs, Scheduler and Trigger should be named 'Escalation_at' [2615](https://github.com/zammad/zammad/issues/2615) [[enhancement](https://github.com/zammad/zammad/labels/enhancement)] [[trigger](https://github.com/zammad/zammad/labels/trigger)]
+- Add scroll bar to tag list if not enough room is available [2570](https://github.com/zammad/zammad/issues/2570) [[UX/UI](https://github.com/zammad/zammad/labels/UX/UI)] [[enhancement](https://github.com/zammad/zammad/labels/enhancement)]
+- Elasticsearch 6.x & 7.x support [1688](https://github.com/zammad/zammad/issues/1688) [[enhancement](https://github.com/zammad/zammad/labels/enhancement)]
 
 **Fixed bugs:**
-
-
-
-
+- SearchIndexBackend.remove() (ES) is not working correctly [2611](https://github.com/zammad/zammad/issues/2611) [[bug](https://github.com/zammad/zammad/labels/bug)] [[search](https://github.com/zammad/zammad/labels/search)]
+- Add Rails 5 log to STDOUT env variable support [2637](https://github.com/zammad/zammad/pull/2637)
+- Removed duplicate `Mailing-List` tag from postmaster match ui element [2639](https://github.com/zammad/zammad/pull/2639) [[bug](https://github.com/zammad/zammad/labels/bug)]
+- Integer minimal is ignored [2339](https://github.com/zammad/zammad/issues/2339) [[bug](https://github.com/zammad/zammad/labels/bug)] [[object manager attribute](https://github.com/zammad/zammad/labels/object manager attribute)]
+- Setup asks for FQDN, but doesn't write to DB [462](https://github.com/zammad/zammad/issues/462) [[bug](https://github.com/zammad/zammad/labels/bug)]
+- Concern 'CanLatestChange' returns wrong updated_at  [2624](https://github.com/zammad/zammad/issues/2624) [[bug](https://github.com/zammad/zammad/labels/bug)]
+- KB partly broken on IE11 - customer interface [2600](https://github.com/zammad/zammad/issues/2600) [[bug](https://github.com/zammad/zammad/labels/bug)] [[knowledge base](https://github.com/zammad/zammad/labels/knowledge base)]
+- missing OTRS.png asset in Import Wizard [2593](https://github.com/zammad/zammad/issues/2593) [[bug](https://github.com/zammad/zammad/labels/bug)] [[frontend / JS app](https://github.com/zammad/zammad/labels/frontend / JS app)] [[import](https://github.com/zammad/zammad/labels/import)]
+- Wrong date format in Excel Exports of reporting download [2594](https://github.com/zammad/zammad/issues/2594) [[bug](https://github.com/zammad/zammad/labels/bug)] [[reporting](https://github.com/zammad/zammad/labels/reporting)]
+- Tree Select shows empty value in ticket zoom after submit when value contains trailing spaces [2614](https://github.com/zammad/zammad/issues/2614) [[bug](https://github.com/zammad/zammad/labels/bug)] [[object manager attribute](https://github.com/zammad/zammad/labels/object manager attribute)]
+- Edit-Buttons on customer interface (as agent) has wrong link (Blank-Page) [2604](https://github.com/zammad/zammad/issues/2604) [[bug](https://github.com/zammad/zammad/labels/bug)] [[knowledge base](https://github.com/zammad/zammad/labels/knowledge base)]
+- Activation of Knowledgebase is impossible on IE11 - agent interface [2599](https://github.com/zammad/zammad/issues/2599) [[bug](https://github.com/zammad/zammad/labels/bug)] [[knowledge base](https://github.com/zammad/zammad/labels/knowledge base)]
+- Existing scheduler email notification without `body` will raise an exception. [2541](https://github.com/zammad/zammad/issues/2541) [[bug](https://github.com/zammad/zammad/labels/bug)]
+- trigger email notification UI defective on removal of recipient [2516](https://github.com/zammad/zammad/issues/2516) [[UX/UI](https://github.com/zammad/zammad/labels/UX/UI)] [[bug](https://github.com/zammad/zammad/labels/bug)] [[frontend / JS app](https://github.com/zammad/zammad/labels/frontend / JS app)]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,7 +299,7 @@ GEM
     net-ldap (0.16.1)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     notiffany (0.1.1)

--- a/app/assets/javascripts/app/controllers/_profile/linked_accounts.coffee
+++ b/app/assets/javascripts/app/controllers/_profile/linked_accounts.coffee
@@ -2,6 +2,7 @@ class Index extends App.ControllerSubContent
   requiredPermission: 'user_preferences.linked_accounts'
   header: 'Linked Accounts'
   events:
+    'click .js-add':    'add'
     'click .js-remove': 'remove'
 
   constructor: ->
@@ -19,6 +20,11 @@ class Index extends App.ControllerSubContent
       user:           App.Session.get()
       auth_providers: auth_providers
     )
+
+  add: (e) =>
+    e.preventDefault()
+    key = $(e.target).data('key')
+    @el.find(".js-addForm-#{key}").submit()
 
   remove: (e) =>
     e.preventDefault()

--- a/app/assets/javascripts/app/views/profile/linked_accounts.jst.eco
+++ b/app/assets/javascripts/app/views/profile/linked_accounts.jst.eco
@@ -7,8 +7,12 @@
   <ul>
     <% for key, provider of @auth_providers: %>
       <li> <%- @T( provider.name ) %>
-        <% if !@user['accounts'] || !@user['accounts'][key]: %><a href="<%= provider.url %>">
-          <%- @T('Add') %></a>
+        <% if !@user['accounts'] || !@user['accounts'][key]: %>
+          <form method="post" class="hidden js-addForm-<%= key %>" action="<%= provider.url %>">
+            <input type="hidden" name="authenticity_token" value="<%= Spine.Ajax.defaults.headers['X-CSRF-Token'] %>">
+          </form>
+
+          <a href="#" data-key="<%= key %>" class="js-add"><%- @T('Add') %></a>
         <% else: %>
           "<%= @user['accounts'][key]['username'] %>" <a href="#" data-uid="<%= @user['accounts'][key]['uid'] %>" data-provider="<%= key %>" class="js-remove"><%- @T('remove') %></a>
         <% end %>

--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -5608,13 +5608,13 @@ footer {
 
     &.is-open {
       &:before {
-        opacity: 0;
+        display: none;
       }
     }
 
     .btn {
-      padding-top: 17px;
-      padding-bottom: 17px;
+      padding-top: 15px;
+      padding-bottom: 15px;
       font-size: 10px;
     }
 
@@ -5626,7 +5626,7 @@ footer {
       top: -30px;
       height: 30px;
       background: linear-gradient(rgba(255,255,255,0), white);
-      transition: opacity 300ms;
+      pointer-events: none;
     }
   }
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -315,8 +315,9 @@ class ReportsController < ApplicationController
 
     if timezone.present?
       offset = time.in_time_zone(timezone).utc_offset
-      time -= offset
+      time += offset
     end
-    time.utc.iso8601.to_s.sub(/Z$/, '')
+    local_time = time.utc.iso8601.to_s.sub(/Z$/, '')
+    local_time.sub(/T/, ' ')
   end
 end

--- a/app/models/channel/email_parser.rb
+++ b/app/models/channel/email_parser.rb
@@ -420,7 +420,7 @@ returns
         end
 
         # only set value on _id if value/reference lookup exists
-        if mail[ header.to_sym ]
+        if mail[header.to_sym]
 
           Rails.logger.info "set_attributes_by_x_headers header #{header} found #{mail[header.to_sym]}"
           item_object.class.reflect_on_all_associations.map do |assoc|
@@ -429,13 +429,15 @@ returns
 
             Rails.logger.info "set_attributes_by_x_headers found #{assoc.class_name} lookup for '#{mail[header.to_sym]}'"
             item = assoc.class_name.constantize
-
             assoc_object = nil
-            if item.respond_to?(:name)
+            if item.new.respond_to?(:name)
               assoc_object = item.lookup(name: mail[header.to_sym])
             end
-            if !assoc_object && item.respond_to?(:login)
+            if !assoc_object && item.new.respond_to?(:login)
               assoc_object = item.lookup(login: mail[header.to_sym])
+            end
+            if !assoc_object && item.new.respond_to?(:email)
+              assoc_object = item.lookup(email: mail[header.to_sym])
             end
 
             if assoc_object.blank?

--- a/app/models/concerns/has_search_index_backend.rb
+++ b/app/models/concerns/has_search_index_backend.rb
@@ -128,11 +128,12 @@ reload search index with full data
 =end
 
     def search_index_reload
-      tolerance       = 5
+      tolerance       = 10
       tolerance_count = 0
       ids = all.order(created_at: :desc).pluck(:id)
       ids.each do |item_id|
-        item = find(item_id)
+        item = find_by(id: item_id)
+        next if !item
         next if item.ignore_search_indexing?(:destroy)
 
         begin
@@ -140,6 +141,7 @@ reload search index with full data
         rescue => e
           logger.error "Unable to send #{item.class}.find(#{item.id}).search_index_update_backend backend: #{e.inspect}"
           tolerance_count += 1
+          sleep 15
           raise "Unable to send #{item.class}.find(#{item.id}).search_index_update_backend backend: #{e.inspect}" if tolerance_count == tolerance
         end
       end

--- a/app/models/object_manager/attribute.rb
+++ b/app/models/object_manager/attribute.rb
@@ -895,13 +895,13 @@ is certain attribute used by triggers, overviews or schedulers
   def check_name
     return if !name
 
-    raise 'Name can\'t get used, *_id and *_ids are not allowed' if name.match?(/_(id|ids)$/i) || name.match?(/^id$/i)
+    raise 'Name can\'t get used, *_id and *_ids are not allowed' if name.match?(/.+?_(id|ids)$/i)
     raise 'Spaces in name are not allowed' if name.match?(/\s/)
     raise 'Only letters from a-z, numbers from 0-9, and _ are allowed' if !name.match?(/^[a-z0-9_]+$/)
     raise 'At least one letters is needed' if !name.match?(/[a-z]/)
 
     # do not allow model method names as attributes
-    reserved_words = %w[destroy true false integer select drop create alter index table varchar blob date datetime timestamp]
+    reserved_words = %w[destroy true false integer select drop create alter index table varchar blob date datetime timestamp url icon initials avatar permission validate subscribe unsubscribe translate search _type _doc _id id]
     raise "#{name} is a reserved word, please choose a different one" if name.match?(/^(#{reserved_words.join('|')})$/)
 
     # fixes issue #2236 - Naming an attribute "attribute" causes ActiveRecord failure

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require_relative 'issue_2656_workaround_for_rails_issue_33600'
 
 # DO NOT REMOVE THIS LINE - see issue #2037
 Bundler.setup

--- a/config/issue_2656_workaround_for_rails_issue_33600.rb
+++ b/config/issue_2656_workaround_for_rails_issue_33600.rb
@@ -1,0 +1,22 @@
+# This temporary workaround for issue #2656.
+# The root cause is an issue in Rails: https://github.com/rails/rails/issues/33600
+# It disables database connnection reaping by setting `reaping_frequency` to 0 for each environment in the config/database.yml file.
+# It restores the DB connection reaping behavior Rails > 5.2 had.
+# It was proposed in a comment on the Rails issue: https://github.com/rails/rails/issues/33600#issuecomment-415395901
+# It was confirmed by @matthewd (a Rails core maintainer) in another comment: https://github.com/rails/rails/issues/33600#issuecomment-415400522
+module Rails
+  class Application
+    class Configuration < ::Rails::Engine::Configuration
+
+      alias database_configuration_original database_configuration
+
+      def database_configuration
+        database_configuration_original&.transform_values do |config|
+          config.merge(
+            'reaping_frequency' => 0
+          )
+        end
+      end
+    end
+  end
+end

--- a/contrib/packager.io/functions
+++ b/contrib/packager.io/functions
@@ -303,6 +303,11 @@ function set_env_vars () {
   zammad config:set RUBY_GC_MALLOC_LIMIT_MAX=${ZAMMAD_RUBY_GC_MALLOC_LIMIT_MAX:=2177216}
   zammad config:set RUBY_GC_OLDMALLOC_LIMIT=${ZAMMAD_RUBY_GC_OLDMALLOC_LIMIT:=2177216}
   zammad config:set RUBY_GC_OLDMALLOC_LIMIT_MAX=${ZAMMAD_RUBY_GC_OLDMALLOC_LIMIT_MAX:=3000100}
+  if [[ "$(zammad config:get RAILS_LOG_TO_STDOUT)" == "enabled" ]];then
+    echo 'Setting default Logging to file, set via "zammad config:set RAILS_LOG_TO_STDOUT=true" if you want to log to STDOUT!'
+    zammad config:set RAILS_LOG_TO_STDOUT=
+  fi
+
 }
 
 function final_message () {

--- a/db/migrate/20190408000001_issue_2541_fix_notification_email_without_body.rb
+++ b/db/migrate/20190408000001_issue_2541_fix_notification_email_without_body.rb
@@ -4,6 +4,10 @@ class Issue2541FixNotificationEmailWithoutBody < ActiveRecord::Migration[5.1]
     # return if it's a new setup
     return if !Setting.find_by(name: 'system_init_done')
 
+    # there might be Job/Trigger selectors referencing the current user
+    # that get e.g. validated in callbacks
+    UserInfo.current_user_id = 1
+
     # update jobs and triggers
     [::Job, ::Trigger].each do |model|
       model.where(active: true).each do |record|

--- a/lib/core_ext/string.rb
+++ b/lib/core_ext/string.rb
@@ -284,6 +284,7 @@ class String
         chr_orig
       end
     end
+    string = string.utf8_encode(fallback: :read_as_sanitized_binary)
 
     # remove tailing empty spaces
     string.gsub!(/[[:blank:]]+$/, '')

--- a/lib/html_sanitizer.rb
+++ b/lib/html_sanitizer.rb
@@ -1,6 +1,6 @@
 class HtmlSanitizer
   LINKABLE_URL_SCHEMES = URI.scheme_list.keys.map(&:downcase) - ['mailto'] + ['tel']
-  PROCESSING_TIMEOUT = 10
+  PROCESSING_TIMEOUT = 20
   UNPROCESSABLE_HTML_MSG = 'This message cannot be displayed due to HTML processing issues. Download the raw message below and open it via an Email client if you still wish to view it.'.freeze
 
 =begin
@@ -205,6 +205,7 @@ satinize html string based on whiltelist
       Loofah.fragment(string).scrub!(scrubber_link).to_s
     end
   rescue Timeout::Error
+    Rails.logger.error "Could not process string via HtmlSanitizer.strict in #{PROCESSING_TIMEOUT} seconds. Current state: #{string}"
     UNPROCESSABLE_HTML_MSG
   end
 
@@ -237,6 +238,7 @@ cleanup html string:
       string
     end
   rescue Timeout::Error
+    Rails.logger.error "Could not process string via HtmlSanitizer.cleanup in #{PROCESSING_TIMEOUT} seconds. Current state: #{string}"
     UNPROCESSABLE_HTML_MSG
   end
 

--- a/lib/search_index_backend.rb
+++ b/lib/search_index_backend.rb
@@ -21,7 +21,7 @@ info about used search index machine
       {
         json:         true,
         open_timeout: 8,
-        read_timeout: 12,
+        read_timeout: 14,
         user:         Setting.get('es_user'),
         password:     Setting.get('es_password'),
       }
@@ -84,7 +84,7 @@ update processors
             {
               json:         true,
               open_timeout: 8,
-              read_timeout: 12,
+              read_timeout: 60,
               user:         Setting.get('es_user'),
               password:     Setting.get('es_password'),
             }
@@ -108,7 +108,7 @@ update processors
           {
             json:         true,
             open_timeout: 8,
-            read_timeout: 12,
+            read_timeout: 60,
             user:         Setting.get('es_user'),
             password:     Setting.get('es_password'),
           }
@@ -181,7 +181,7 @@ create/update/delete index
       {
         json:         true,
         open_timeout: 8,
-        read_timeout: 30,
+        read_timeout: 60,
         user:         Setting.get('es_user'),
         password:     Setting.get('es_password'),
       }
@@ -219,7 +219,7 @@ add new object to search index
       {
         json:         true,
         open_timeout: 8,
-        read_timeout: 16,
+        read_timeout: 60,
         user:         Setting.get('es_user'),
         password:     Setting.get('es_password'),
       }
@@ -255,7 +255,7 @@ remove whole data from index
       url,
       {
         open_timeout: 8,
-        read_timeout: 16,
+        read_timeout: 60,
         user:         Setting.get('es_user'),
         password:     Setting.get('es_password'),
       }
@@ -285,9 +285,11 @@ remove whole data from index
 
   result = SearchIndexBackend.search('search query', ['User', 'Organization'], limit: limit)
 
-  result = SearchIndexBackend.search('search query', 'User', limit: limit)
+- result = SearchIndexBackend.search('search query', 'User', limit: limit)
 
   result = SearchIndexBackend.search('search query', 'User', limit: limit, sort_by: ['updated_at'], order_by: ['desc'])
+
+  result = SearchIndexBackend.search('search query', 'User', limit: limit, sort_by: ['active', updated_at'], order_by: ['desc', 'desc'])
 
   result = [
     {

--- a/lib/user_info.rb
+++ b/lib/user_info.rb
@@ -14,9 +14,7 @@ module UserInfo
     end
 
     yield
-
-    return if !reset_current_user_id
-
-    UserInfo.current_user_id = nil
+  ensure
+    UserInfo.current_user_id = nil if reset_current_user_id
   end
 end

--- a/lib/zammad/application/initializer/db_preflight_check.rb
+++ b/lib/zammad/application/initializer/db_preflight_check.rb
@@ -1,6 +1,7 @@
 require 'zammad/application/initializer/db_preflight_check/base'
 require 'zammad/application/initializer/db_preflight_check/mysql2'
 require 'zammad/application/initializer/db_preflight_check/postgresql'
+require 'zammad/application/initializer/db_preflight_check/nulldb'
 
 module Zammad
   class Application

--- a/lib/zammad/application/initializer/db_preflight_check/nulldb.rb
+++ b/lib/zammad/application/initializer/db_preflight_check/nulldb.rb
@@ -1,0 +1,12 @@
+module Zammad
+  class Application
+    class Initializer
+      module DBPreflightCheck
+        module Nulldb
+          # no-op
+          def self.perform; end
+        end
+      end
+    end
+  end
+end

--- a/spec/db/migrate/issue_2541_fix_notification_email_without_body_spec.rb
+++ b/spec/db/migrate/issue_2541_fix_notification_email_without_body_spec.rb
@@ -44,7 +44,23 @@ RSpec.describe Issue2541FixNotificationEmailWithoutBody, type: :db_migration do
       it "updates empty perform['notification.email']['body'] attribute" do
         expect { migrate }.to change { job.reload.perform['notification.email']['body'] }.from('').to('-')
       end
+
+      context 'when selector contains current_user.id' do
+        subject(:job) do
+          UserInfo.ensure_current_user_id do
+
+            create(:job, condition: { 'ticket.owner_id' => { 'operator' => 'is', 'pre_condition' => 'current_user.id', 'value' => '', 'value_completion' => '' } } )
+          end
+        end
+
+        let(:type) { 'notification.email' }
+
+        it "updates empty perform['notification.email']['body'] attribute" do
+          expect { migrate }.to change { job.reload.perform['notification.email']['body'] }.from('').to('-')
+        end
+      end
     end
+
   end
 
   describe 'scheduler management' do

--- a/spec/lib/core_ext/string_spec.rb
+++ b/spec/lib/core_ext/string_spec.rb
@@ -542,6 +542,18 @@ RSpec.describe String do
       TEXT
     end
 
+    context 'html encoding' do
+      it 'converts &Auml; in Ä' do
+        expect('<div>test something.&Auml;</div>'.html2text)
+          .to eq('test something.Ä')
+      end
+
+      it 'strips invalid html encoding chars' do
+        expect('<div>test something.&#55357;</div>'.html2text)
+          .to eq('test something.í ˝')
+      end
+    end
+
     context 'performance tests' do
       let(:filler) do
         %(<p>some word <a href="http://example.com?domain?example.com">some url</a> and the end.</p>\n) * 11 + "\n"
@@ -574,6 +586,7 @@ RSpec.describe String do
           </html>
         HTML
       end
+
     end
   end
 

--- a/spec/lib/user_info_spec.rb
+++ b/spec/lib/user_info_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe UserInfo do
 
   describe '#ensure_current_user_id' do
 
+    let(:return_value) { 'Hello World' }
+
     it 'uses and keeps set User IDs' do
       test_id = 99
       described_class.current_user_id = test_id
@@ -37,5 +39,26 @@ RSpec.describe UserInfo do
 
       expect(described_class.current_user_id).to be nil
     end
+
+    it 'resets current_user_id in case of an exception' do
+      begin
+        described_class.ensure_current_user_id do
+          raise 'error'
+        end
+      rescue # rubocop:disable Lint/HandleExceptions
+      end
+
+      expect(described_class.current_user_id).to be nil
+    end
+
+    it 'passes return value of given block' do
+
+      received = described_class.ensure_current_user_id do
+        return_value
+      end
+
+      expect(received).to eq(return_value)
+    end
+
   end
 end

--- a/spec/models/channel/email_parser_spec.rb
+++ b/spec/models/channel/email_parser_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Channel::EmailParser, type: :model do
           RAW
         end
 
-        shared_context 'ticket reference in attachment' do
+        shared_context 'ticket reference in text/plain attachment' do
           let(:raw_mail) { <<~RAW.chomp }
             From: me@example.com
             Content-Type: multipart/mixed; boundary="Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2"
@@ -216,6 +216,96 @@ RSpec.describe Channel::EmailParser, type: :model do
               filename=test1.txt
             Content-Type: text/plain;
               name="test.txt"
+            Content-Transfer-Encoding: 7bit
+
+            Some Text #{ticket_ref}
+
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2--
+          RAW
+        end
+
+        shared_context 'ticket reference in text/html (as content) attachment' do
+          let(:raw_mail) { <<~RAW.chomp }
+            From: me@example.com
+            Content-Type: multipart/mixed; boundary="Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2"
+            Subject: no reference
+            Date: Sun, 30 Aug 2015 23:20:54 +0200
+            To: Martin Edenhofer <me@znuny.com>
+            Mime-Version: 1.0 (Mac OS X Mail 8.2 \(2104\))
+            X-Mailer: Apple Mail (2.2104)
+
+
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2
+            Content-Transfer-Encoding: 7bit
+            Content-Type: text/plain;
+              charset=us-ascii
+
+            no reference
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2
+            Content-Disposition: attachment;
+              filename=test1.txt
+            Content-Type: text/html;
+              name="test.txt"
+            Content-Transfer-Encoding: 7bit
+
+            <div>Some Text #{ticket_ref}</div>
+
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2--
+          RAW
+        end
+
+        shared_context 'ticket reference in text/html (attribute) attachment' do
+          let(:raw_mail) { <<~RAW.chomp }
+            From: me@example.com
+            Content-Type: multipart/mixed; boundary="Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2"
+            Subject: no reference
+            Date: Sun, 30 Aug 2015 23:20:54 +0200
+            To: Martin Edenhofer <me@znuny.com>
+            Mime-Version: 1.0 (Mac OS X Mail 8.2 \(2104\))
+            X-Mailer: Apple Mail (2.2104)
+
+
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2
+            Content-Transfer-Encoding: 7bit
+            Content-Type: text/plain;
+              charset=us-ascii
+
+            no reference
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2
+            Content-Disposition: attachment;
+              filename=test1.txt
+            Content-Type: text/html;
+              name="test.txt"
+            Content-Transfer-Encoding: 7bit
+
+            <div>Some Text <b data-something="#{ticket_ref}">some text</b></div>
+
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2--
+          RAW
+        end
+
+        shared_context 'ticket reference in image/jpg attachment' do
+          let(:raw_mail) { <<~RAW.chomp }
+            From: me@example.com
+            Content-Type: multipart/mixed; boundary="Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2"
+            Subject: no reference
+            Date: Sun, 30 Aug 2015 23:20:54 +0200
+            To: Martin Edenhofer <me@znuny.com>
+            Mime-Version: 1.0 (Mac OS X Mail 8.2 \(2104\))
+            X-Mailer: Apple Mail (2.2104)
+
+
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2
+            Content-Transfer-Encoding: 7bit
+            Content-Type: text/plain;
+              charset=us-ascii
+
+            no reference
+            --Apple-Mail=_ED77AC8D-FB6F-40E5-8FBE-D41FF5E1BAF2
+            Content-Disposition: attachment;
+              filename=test1.jpg
+            Content-Type: image/jpg;
+              name="test.jpg"
             Content-Transfer-Encoding: 7bit
 
             Some Text #{ticket_ref}
@@ -328,8 +418,23 @@ RSpec.describe Channel::EmailParser, type: :model do
             include_examples 'creates a new ticket'
           end
 
-          context 'when attachment contains ticket reference' do
-            include_context 'ticket reference in attachment'
+          context 'when text/plain attachment contains ticket reference' do
+            include_context 'ticket reference in text/plain attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when text/html attachment (as content) contains ticket reference' do
+            include_context 'ticket reference in text/html (as content) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when text/html attachment (attribute) contains ticket reference' do
+            include_context 'ticket reference in text/html (attribute) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when image/jpg attachment contains ticket reference' do
+            include_context 'ticket reference in image/jpg attachment'
             include_examples 'creates a new ticket'
           end
 
@@ -448,8 +553,23 @@ RSpec.describe Channel::EmailParser, type: :model do
             end
           end
 
-          context 'when attachment contains ticket reference' do
-            include_context 'ticket reference in attachment'
+          context 'when text/plain attachment contains ticket reference' do
+            include_context 'ticket reference in text/plain attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when text/html attachment (as content) contains ticket reference' do
+            include_context 'ticket reference in text/html (as content) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when text/html attachment (attribute) contains ticket reference' do
+            include_context 'ticket reference in text/html (attribute) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when image/jpg attachment contains ticket reference' do
+            include_context 'ticket reference in image/jpg attachment'
             include_examples 'creates a new ticket'
           end
 
@@ -491,9 +611,24 @@ RSpec.describe Channel::EmailParser, type: :model do
             include_examples 'creates a new ticket'
           end
 
-          context 'when attachment contains ticket reference' do
-            include_context 'ticket reference in attachment'
+          context 'when text/plain attachment contains ticket reference' do
+            include_context 'ticket reference in text/plain attachment'
             include_examples 'adds message to ticket'
+          end
+
+          context 'when text/html attachment (as content) contains ticket reference' do
+            include_context 'ticket reference in text/html (as content) attachment'
+            include_examples 'adds message to ticket'
+          end
+
+          context 'when text/html attachment (attribute) contains ticket reference' do
+            include_context 'ticket reference in text/html (attribute) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when image/jpg attachment contains ticket reference' do
+            include_context 'ticket reference in image/jpg attachment'
+            include_examples 'creates a new ticket'
           end
 
           context 'when In-Reply-To header contains article message-id' do
@@ -534,8 +669,28 @@ RSpec.describe Channel::EmailParser, type: :model do
             include_examples 'creates a new ticket'
           end
 
-          context 'when attachment contains ticket reference' do
-            include_context 'ticket reference in attachment'
+          context 'when text/plain attachment contains ticket reference' do
+            include_context 'ticket reference in text/plain attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when text/html attachment (as content) contains ticket reference' do
+            include_context 'ticket reference in text/html (as content) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when text/html attachment (attribute) contains ticket reference' do
+            include_context 'ticket reference in text/html (attribute) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when image/jpg attachment contains ticket reference' do
+            include_context 'ticket reference in image/jpg attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when image/jpg attachment contains ticket reference' do
+            include_context 'ticket reference in image/jpg attachment'
             include_examples 'creates a new ticket'
           end
 
@@ -592,9 +747,24 @@ RSpec.describe Channel::EmailParser, type: :model do
             include_examples 'adds message to ticket'
           end
 
-          context 'when attachment contains ticket reference' do
-            include_context 'ticket reference in attachment'
+          context 'when text/plain attachment contains ticket reference' do
+            include_context 'ticket reference in text/plain attachment'
             include_examples 'adds message to ticket'
+          end
+
+          context 'when text/html attachment (as content) contains ticket reference' do
+            include_context 'ticket reference in text/html (as content) attachment'
+            include_examples 'adds message to ticket'
+          end
+
+          context 'when text/html attachment (attribute) contains ticket reference' do
+            include_context 'ticket reference in text/html (attribute) attachment'
+            include_examples 'creates a new ticket'
+          end
+
+          context 'when image/jpg attachment contains ticket reference' do
+            include_context 'ticket reference in image/jpg attachment'
+            include_examples 'creates a new ticket'
           end
 
           context 'when In-Reply-To header contains article message-id' do

--- a/spec/models/object_manager/attribute_spec.rb
+++ b/spec/models/object_manager/attribute_spec.rb
@@ -57,10 +57,20 @@ RSpec.describe ObjectManager::Attribute, type: :model do
       end.to raise_error 'attribute is a reserved word, please choose a different one'
     end
 
-    it 'rejects Zammad reserved word "table"' do
-      expect do
-        ObjectManager::Attribute.add attributes_for :object_manager_attribute_text, name: 'table'
-      end.to raise_error 'table is a reserved word, please choose a different one'
+    %w[destroy true false integer select drop create alter index table varchar blob date datetime timestamp url icon initials avatar permission validate subscribe unsubscribe translate search _type _doc _id id].each do |reserved_word|
+      it "rejects Zammad reserved word '#{reserved_word}'" do
+        expect do
+          ObjectManager::Attribute.add attributes_for :object_manager_attribute_text, name: reserved_word
+        end.to raise_error "#{reserved_word} is a reserved word, please choose a different one"
+      end
+    end
+
+    %w[someting_id something_ids].each do |reserved_word|
+      it "rejects word '#{reserved_word}' which is used for database references" do
+        expect do
+          ObjectManager::Attribute.add attributes_for :object_manager_attribute_text, name: reserved_word
+        end.to raise_error "Name can't get used, *_id and *_ids are not allowed"
+      end
     end
 
     it 'rejects duplicate attribute name of conflicting types' do

--- a/spec/requests/report_spec.rb
+++ b/spec/requests/report_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe 'Report', type: :request, searchindex: true do
       expect(@response['Content-Type']).to eq('application/vnd.ms-excel')
     end
 
+    it 'does convert UTC timestamp to local system based timestamp' do
+      expect(ReportsController.new.time_in_localtime_for_excel(Time.parse('2019-08-08T01:00:05Z').in_time_zone, 'Europe/Berlin')).to eq('2019-08-08 03:00:05')
+    end
+
     it 'does report example - deliver result' do
       skip('No ES configured') if !SearchIndexBackend.enabled?
 

--- a/test/unit/email_process_test.rb
+++ b/test/unit/email_process_test.rb
@@ -3180,6 +3180,31 @@ Content-Type: text/html; charset=us-ascii; format=flowed
   end
 
   test 'process trusted' do
+    groups = Group.all
+    roles  = Role.where(name: 'Agent')
+    agent1 = User.create!(
+      login:         'agent1',
+      firstname:     'Firstname',
+      lastname:      'agent1',
+      email:         'agent1@example.com',
+      active:        true,
+      roles:         roles,
+      groups:        groups,
+      updated_by_id: 1,
+      created_by_id: 1,
+    )
+    roles  = Role.where(name: 'Customer')
+    customer1 = User.create!(
+      login:         'customer1',
+      firstname:     'Firstname',
+      lastname:      'customer1',
+      email:         'customer1@example.com',
+      active:        true,
+      roles:         roles,
+      updated_by_id: 1,
+      created_by_id: 1,
+    )
+
     files = [
       {
         data: 'From: me@example.com
@@ -3199,6 +3224,7 @@ To: customer@example.com
 Subject: some subject
 X-Zammad-Ticket-Followup-State: closed
 X-Zammad-Ticket-priority: 3 high
+X-Zammad-Ticket-owner: agent1@example.com 
 X-Zammad-Article-sender: System
 x-Zammad-Article-type: phone
 x-Zammad-Article-Internal: true
@@ -3213,6 +3239,7 @@ Some Text',
             state: 'new',
             priority: '3 high',
             title: 'some subject',
+            owner: agent1,
           },
           1 => {
             sender: 'System',
@@ -3227,6 +3254,7 @@ To: customer@example.com
 Subject: some subject
 X-Zammad-Ticket-Followup-State: closed
 X-Zammad-Ticket-priority_id: 777777
+X-Zammad-Ticket-owner: not_existing@example.com 
 X-Zammad-Article-sender_id: 999999
 x-Zammad-Article-type: phone
 x-Zammad-Article-Internal: true
@@ -3241,11 +3269,87 @@ Some Text',
             state: 'new',
             priority: '2 normal',
             title: 'some subject',
+            owner: User.find(1),
           },
           1 => {
             sender: 'Customer',
             type: 'phone',
             internal: true,
+          },
+        },
+      },
+      {
+        data: 'From: me@example.com
+To: customer@example.com
+Subject: some subject / with customer as agent - customer can not be owner
+X-Zammad-Ticket-owner: customer1@example.com 
+
+Some Text',
+        channel: {
+          trusted: true,
+        },
+        success: true,
+        result: {
+          0 => {
+            state: 'new',
+            priority: '2 normal',
+            title: 'some subject / with customer as agent - customer can not be owner',
+            owner: User.find(1),
+          },
+          1 => {
+            sender: 'Customer',
+            type: 'email',
+            internal: false,
+          },
+        },
+      },
+      {
+        data: 'From: me@example.com
+To: customer@example.com
+Subject: some subject / with agent login
+X-Zammad-Ticket-owner: agent1
+
+Some Text',
+        channel: {
+          trusted: true,
+        },
+        success: true,
+        result: {
+          0 => {
+            state: 'new',
+            priority: '2 normal',
+            title: 'some subject / with agent login',
+            owner: agent1,
+          },
+          1 => {
+            sender: 'Customer',
+            type: 'email',
+            internal: false,
+          },
+        },
+      },
+      {
+        data: 'From: me@example.com
+To: customer@example.com
+Subject: some subject / with agent email
+X-Zammad-Ticket-owner: agent1@example.com
+
+Some Text',
+        channel: {
+          trusted: true,
+        },
+        success: true,
+        result: {
+          0 => {
+            state: 'new',
+            priority: '2 normal',
+            title: 'some subject / with agent email',
+            owner: agent1,
+          },
+          1 => {
+            sender: 'Customer',
+            type: 'email',
+            internal: false,
           },
         },
       },


### PR DESCRIPTION
Hello,

would it be possible, to make that integration more configurable?

Examples:
Treat Warning as OK and close the ticket.

Send notification when Status changs from:

OK -> WARNING (no need for a ticket, disabling possible via Check_MK)
WARNING -> CRITICAL (open a ticket, possible via Check_MK)
CRITICAL -> WARNING (currently not possible to close the ticket)
,....

The easiest would be to define the status in Zammad, which will open and which will close a ticket.

Thanks!