### PR TITLE
SAML missing from settings.rb

### DIFF
--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -1169,6 +1169,78 @@ Setting.create_if_not_exists(
   frontend:    false
 )
 Setting.create_if_not_exists(
+  title:   'Authentication via %s',
+  name:'auth_saml',
+  area:'Security::ThirdPartyAuthentication',
+  description: 'Enables user authentication via %s.',
+  options: {
+form: [
+  {
+display: '',
+null:true,
+name:'auth_saml',
+tag: 'boolean',
+options: {
+  true  => 'yes',
+  false => 'no',
+},
+  },
+],
+  },
+  preferences: {
+controller:   'SettingsAreaSwitch',
+sub:  ['auth_saml_credentials'],
+title_i18n:   ['SAML'],
+description_i18n: ['SAML'],
+permission:   ['admin.security'],
+  },
+  state:   false,
+  frontend:true
+)
+Setting.create_if_not_exists(
+  title:   'SAML App Credentials',
+  name:'auth_saml_credentials',
+  area:'Security::ThirdPartyAuthentication::SAML',
+  description: 'Enables user authentication via SAML.',
+  options: {
+form: [
+  {
+display: 'IDP SSO target URL',
+null:true,
+name:'idp_sso_target_url',
+tag: 'input',
+placeholder: 'https://capriza.github.io/samling/samling.html',
+  },
+  {
+display: 'IDP certificate',
+null:true,
+name:'idp_cert',
+tag: 'input',
+placeholder: '-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----',
+  },
+  {
+display: 'IDP certificate fingerprint',
+null:true,
+name:'idp_cert_fingerprint',
+tag: 'input',
+placeholder: 'E7:91:B2:E1:...',
+  },
+  {
+display: 'Name Identifier Format',
+null:true,
+name:'name_identifier_format',
+tag: 'input',
+placeholder: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+  },
+],
+  },
+  state:   {},
+  preferences: {
+permission: ['admin.security'],
+  },
+  frontend:false
+)
+Setting.create_if_not_exists(
   title:       'Authentication via %s',
   name:        'auth_facebook',
   area:        'Security::ThirdPartyAuthentication',


### PR DESCRIPTION
This pull request fixes the SAML issue I've been investigating since the SAML commit was added yesterday related to the SAML issue: https://github.com/zammad/zammad/issues/2741

I didn't write any of the code used in this pull request, it all came from the migration file: 20190715141227_saml_auth.rb

With this pull request applied I have successfully tested the SAML integration with the develop branch, and it works great. Without this patch the SAML gui elements are missing, and the database table: "settings" does not contain the needed rows for "auth_saml" and "auth_saml_credentials".


<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
