### PR TITLE
Fix html-tag typos in polish ticket_escalation and ticket_creation view

### DIFF
--- a/app/views/mailer/ticket_create/pl.html.erb
+++ b/app/views/mailer/ticket_create/pl.html.erb
@@ -2,7 +2,7 @@ Nowe zgłoszenie (#{ticket.title})
 
 <div>Witaj #{recipient.firstname},</div>
 <br>
-<divOtrzymałeś nowe zgłoszenie (#{ticket.title}) od "<b>#{current_user.longname}</b>".</div>
+<div>Otrzymałeś nowe zgłoszenie (#{ticket.title}) od "<b>#{current_user.longname}</b>".</div>
 <br>
 <div>
 #{t('Group')}: #{ticket.group.name}<br>

--- a/app/views/mailer/ticket_escalation/pl.html.erb
+++ b/app/views/mailer/ticket_escalation/pl.html.erb
@@ -15,4 +15,4 @@ Zgłoszenie (#{ticket.title}) zostało eskalowane
 <br>
 <div>
   <a href="#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}" target="zammad_app">#{t('Zobacz w Zammad')}</a>
-</div
+</div>


### PR DESCRIPTION
These two commits will solve issue https://github.com/zammad/zammad/issues/2747 by abeluck.
Basically it just changes two lines of code fixing incorrect div-closing