### PR TITLE
Add RocketChat integration

### DIFF
--- a/app/assets/javascripts/app/controllers/_integration/rocketchat.coffee
+++ b/app/assets/javascripts/app/controllers/_integration/rocketchat.coffee
@@ -1,0 +1,91 @@
+class Index extends App.ControllerIntegrationBase
+  featureIntegration: 'rocketchat_integration'
+  featureName: 'Rocketchat'
+  featureConfig: 'rocketchat_config'
+  description: [
+    ['This service sends direct messages to user mentioned in articles with @username.', 'Rocketchat']
+    ['To set up this service you need to create a user acting as bot to send direct messages', 'Rocketchat']
+  ]
+  events:
+    'click .js-submit': 'update'
+    'submit .js-form': 'update'
+    'change .js-switch input': 'switch'
+
+  render: =>
+    super
+
+    params = App.Setting.get(@featureConfig)
+    if params && params.items
+      params = params.items[0] || {}
+
+    options =
+      create: '1. Ticket Create'
+      update: '2. Ticket Update'
+      reminder_reached: '3. Ticket Reminder Reached'
+      escalation: '4. Ticket Escalation'
+      escalation_warning: '5. Ticket Escalation Warning'
+
+    configureAttributes = [
+      { name: 'webhook',   display: 'Webhook',  tag: 'input', type: 'url',  limit: 200, 'null': false, placeholder: 'https://support.mycompany.org' },
+      { name: 'types',     display: 'Trigger',  tag: 'checkbox', options: options, 'null': false, class: 'vertical', note: 'When notification is being sent.' },
+      { name: 'username',  display: 'Username', tag: 'input', type: 'text', limit: 100, 'null': false, placeholder: 'username' },
+      { name: 'password',  display: 'Password', tag: 'input', type: 'password', limit: 100, 'null': false, placeholder: 'password' },
+      { name: 'channel',  display: 'Channel', tag: 'input', type: 'text', limit: 100, 'null': false, placeholder: '#general' },
+      { name: 'icon_url',  display: 'Icon Url', tag: 'input', type: 'url',  limit: 200, 'null': true, placeholder: 'https://example.com/logo.png' },
+   ]
+
+    settings = []
+    for item in configureAttributes
+      setting =
+        options:
+          form: [item]
+        name: item.name
+        description: item.note || ''
+        title: item.display
+      settings.push setting
+
+    formEl = $( App.view('settings/form')(
+      settings: settings
+    ))
+
+    for setting in settings
+      configure_attribute = setting.options['form']
+      configure_attribute[0].display = ''
+      value = params[setting.name]
+      localParams = {}
+      localParams[setting.name] = value
+      new App.ControllerForm(
+        el: formEl.find("[data-name=#{setting.name}]")
+        model: { configure_attributes: configure_attribute, className: '' }
+        params: localParams
+      )
+
+    @$('.js-form').html(formEl)
+
+    new App.HttpLog(
+      el: @$('.js-log')
+      facility: 'rocketchat_webhook'
+    )
+
+  update: (e) =>
+    e.preventDefault()
+    params = @formParam(e.target)
+    value =
+      items: [params]
+    App.Setting.set(@featureConfig, value, {notify: true})
+
+class State
+  @current: ->
+    App.Setting.get('rocketchat_integration')
+
+App.Config.set(
+  'IntegrationRocketchat'
+  {
+    name: 'Rocketchat'
+    target: '#system/integration/rocketchat'
+    description: 'An opensource chat.'
+    controller: Index
+    state: State
+  }
+  'NavBarIntegrations'
+)

--- a/app/models/transaction/rocketchat.rb
+++ b/app/models/transaction/rocketchat.rb
@@ -1,0 +1,371 @@
+# Copyright (C) 2019 Olivier Sallou <olivier.sallou@irisa.fr>
+require 'net/http'
+require 'json'
+require 'uri'
+
+class Transaction::Rocketchat
+
+=begin
+    
+      backend = Transaction::Rocketchat.new(
+        object: 'Ticket',
+        type: 'update',
+        object_id: 123,
+        interface_handle: 'application_server', # application_server|websocket|scheduler
+        changes: {
+          'attribute1' => [before, now],
+          'attribute2' => [before, now],
+        },
+        created_at: Time.zone.now,
+        user_id: 123,
+      )
+      backend.perform
+    
+=end
+    
+      def initialize(item, params = {})
+        @item = item
+        @params = params
+      end
+    
+      def perform
+        # return if we run import mode
+        return if Setting.get('import_mode')
+    
+        return if @item[:object] != 'Ticket'
+        return if !Setting.get('rocketchat_integration')
+    
+        config = Setting.get('rocketchat_config')
+        return if !config
+        return if !config['items']
+    
+        ticket = Ticket.find_by(id: @item[:object_id])
+        return if !ticket
+    
+        if @item[:article_id]
+          article = Ticket::Article.find(@item[:article_id])    
+          # ignore notifications
+          sender = Ticket::Article::Sender.lookup(id: article.sender_id)
+          if sender&.name == 'System'
+            return if @item[:changes].blank?
+    
+            article = nil
+          end
+        end
+    
+        # ignore if no changes has been done
+        changes = human_changes(ticket)
+        return if @item[:type] == 'update' && !article && changes.blank?
+        
+    
+        # get user based notification template
+        # if create, send create message / block update messages
+        template = nil
+        sent_value = nil
+        if @item[:type] == 'create'
+          template = 'ticket_create'
+        elsif @item[:type] == 'update'
+          template = 'ticket_update'
+        elsif @item[:type] == 'reminder_reached'
+          template = 'ticket_reminder_reached'
+          sent_value = ticket.pending_time
+        elsif @item[:type] == 'escalation'
+          template = 'ticket_escalation'
+          sent_value = ticket.escalation_at
+        elsif @item[:type] == 'escalation_warning'
+          template = 'ticket_escalation_warning'
+          sent_value = ticket.escalation_at
+        else
+          raise "unknown type for notification #{@item[:type]}"
+        end
+    
+        user = User.find(1)
+    
+        current_user = User.lookup(id: @item[:user_id])
+        if !current_user
+          current_user = User.lookup(id: 1)
+        end
+    
+        result = NotificationFactory::Rocketchat.template(
+          template: template,
+          locale:   user[:preferences][:locale] || Setting.get('locale_default'),
+          timezone: user[:preferences][:timezone] || Setting.get('timezone_default'),
+          objects:  {
+            ticket:       ticket,
+            article:      article,
+            current_user: current_user,
+            changes:      changes,
+          },
+        )
+    
+        # good, warning, danger
+        color = '#000000'
+        ticket_state_type = ticket.state.state_type.name
+        if ticket.escalation_at && ticket.escalation_at < Time.zone.now
+          color = '#f35912'
+        elsif ticket_state_type == 'pending reminder'
+          if ticket.pending_time && ticket.pending_time < Time.zone.now
+            color = '#faab00'
+          end
+        elsif ticket_state_type.match?(/^(new|open)$/)
+          color = '#faab00'
+        elsif ticket_state_type == 'closed'
+          color = '#38ad69'
+        end
+    
+        config['items'].each do |local_config|
+          next if local_config['webhook'].blank?
+    
+          # check if reminder_reached/escalation/escalation_warning is already sent today
+          md5_webhook = Digest::MD5.hexdigest(local_config['webhook'])
+          cache_key = "rocketchat::backend::#{@item[:type]}::#{ticket.id}::#{md5_webhook}"
+          if sent_value
+            value = Cache.get(cache_key)
+            if value == sent_value
+              Rails.logger.debug { "did not send webhook, already sent (#{@item[:type]}/#{ticket.id}/#{local_config['webhook']})" }
+              next
+            end
+            Cache.write(
+              cache_key,
+              sent_value,
+              {
+                expires_in: 24.hours
+              },
+            )
+          end
+    
+          logo_url = 'https://zammad.com/assets/images/logo-200x200.png'
+          if local_config['logo_url'].present?
+            logo_url = local_config['logo_url']
+          end
+        
+          notifier = Transaction::Rocketchat::Notifier.new(
+            local_config['webhook'],
+            channel:     local_config['channel'],
+            username:    local_config['username'],
+            password:    local_config['password'],
+            icon_url:    logo_url,
+            mrkdwn:      true,
+            http_client: Transaction::Rocketchat::Client,
+          )
+
+          token, uid = notifier.login
+          if token == nil
+            Rails.logger.debug { "failed to login to Rocketchat" }
+            next
+          end
+
+          matches = article.body.scan(/@(\w+)/)
+          if matches != nil &&  matches.length > 0
+            result_mentioned = NotificationFactory::Rocketchat.template(
+              template: 'ticket_mentioned',
+              locale:   user[:preferences][:locale] || Setting.get('locale_default'),
+              timezone: user[:preferences][:timezone] || Setting.get('timezone_default'),
+              objects:  {
+                ticket:       ticket,
+                article:      article,
+                current_user: current_user,
+                changes:      changes,
+              },
+            )
+            message = "#{result_mentioned[:subject]}\n#{result_mentioned[:body]}"
+            # message = "You've been mentioned in a ticket: #{result[:subject]}\n#{result[:body]}"
+            matches.each do |notif|
+              notif_res = notifier.notify notif[0].to_s, message
+              if !notif_res
+                Rails.logger.error "Unable to notify webhook: #{local_config['webhook']}"
+              end
+            end
+          end
+
+          # check action
+          if local_config['types'].class == Array
+            hit = false
+            local_config['types'].each do |type|
+              next if type.to_s != @item[:type].to_s
+    
+              hit = true
+              break
+            end
+            next if !hit
+          elsif local_config['types']
+            next if local_config['types'].to_s != @item[:type].to_s
+          end
+
+          Rails.logger.debug { "sent webhook (#{@item[:type]}/#{ticket.id}/#{local_config['webhook']})" }
+
+          body = "#{result[:subject]}\n#{result[:body]}"
+          ping_res = notifier.ping body
+          if !ping_res
+            if sent_value
+              Cache.delete(cache_key)
+            end
+            Rails.logger.error "Unable to post ping webhook: #{local_config['webhook']}"
+            next
+          end
+          Rails.logger.debug { "sent webhook (#{@item[:type]}/#{ticket.id}/#{local_config['webhook']})" }
+        end
+    
+      end
+    
+      def human_changes(record)
+    
+        return {} if !@item[:changes]
+    
+        user = User.find(1)
+        locale = user.preferences[:locale] || Setting.get('locale_default') || 'en-us'
+    
+        # only show allowed attributes
+        attribute_list = ObjectManager::Attribute.by_object_as_hash('Ticket', user)
+        #puts "AL #{attribute_list.inspect}"
+        user_related_changes = {}
+        @item[:changes].each do |key, value|
+    
+          # if no config exists, use all attributes
+          if attribute_list.blank?
+            user_related_changes[key] = value
+    
+          # if config exists, just use existing attributes for user
+          elsif attribute_list[key.to_s]
+            user_related_changes[key] = value
+          end
+        end
+    
+        changes = {}
+        user_related_changes.each do |key, value|
+    
+          # get attribute name
+          attribute_name           = key.to_s
+          object_manager_attribute = attribute_list[attribute_name]
+          if attribute_name[-3, 3] == '_id'
+            attribute_name = attribute_name[ 0, attribute_name.length - 3 ].to_s
+          end
+    
+          # add item to changes hash
+          if key.to_s == attribute_name
+            changes[attribute_name] = value
+          end
+    
+          # if changed item is an _id field/reference, do an lookup for the realy values
+          value_id  = []
+          value_str = [ value[0], value[1] ]
+          if key.to_s[-3, 3] == '_id'
+            value_id[0] = value[0]
+            value_id[1] = value[1]
+    
+            if record.respond_to?(attribute_name) && record.send(attribute_name)
+              relation_class = record.send(attribute_name).class
+              if relation_class && value_id[0]
+                relation_model = relation_class.lookup(id: value_id[0])
+                if relation_model
+                  if relation_model['name']
+                    value_str[0] = relation_model['name']
+                  elsif relation_model.respond_to?('fullname')
+                    value_str[0] = relation_model.send('fullname')
+                  end
+                end
+              end
+              if relation_class && value_id[1]
+                relation_model = relation_class.lookup(id: value_id[1])
+                if relation_model
+                  if relation_model['name']
+                    value_str[1] = relation_model['name']
+                  elsif relation_model.respond_to?('fullname')
+                    value_str[1] = relation_model.send('fullname')
+                  end
+                end
+              end
+            end
+          end
+    
+          # check if we have an dedcated display name for it
+          display = attribute_name
+          if object_manager_attribute && object_manager_attribute[:display]
+    
+            # delete old key
+            changes.delete(display)
+    
+            # set new key
+            display = object_manager_attribute[:display].to_s
+          end
+          changes[display] = if object_manager_attribute && object_manager_attribute[:translate]
+                               from = Translation.translate(locale, value_str[0])
+                               to = Translation.translate(locale, value_str[1])
+                               [from, to]
+                             else
+                               [value_str[0].to_s, value_str[1].to_s]
+                             end
+        end
+        changes
+      end
+    
+      class Transaction::Rocketchat::Client
+        def self.post(uri, params = {})
+          UserAgent.post(
+            uri.to_s,
+            params,
+            {
+              open_timeout:  4,
+              read_timeout:  10,
+              total_timeout: 20,
+              log:           {
+                facility: 'rocketchat_webhook',
+              }
+            },
+          )
+        end
+      end
+
+      class Transaction::Rocketchat::Notifier
+        def initialize url, options={}
+
+          @url = url
+          @options = options
+        end
+
+        def login
+            uri = URI.parse(@url + '/api/v1/login')
+            header = {'Accept': 'application/json'}
+            req = Net::HTTP::Post.new(uri.request_uri, header)
+            req.set_form_data({"user" => @options[:username], "password" => @options[:password]})
+            res = Net::HTTP.start(uri.host, uri.port, 
+                :use_ssl => uri.scheme == 'https') {|http| http.request req}
+            if res.code != '200'
+                return nil, nil
+            end
+            data = JSON.parse(res.body)
+            @token = data['data']['authToken']
+            @uid = data['data']['userId']
+            return @token, @uid
+        end
+
+        def ping message
+            uri = URI(@url + '/api/v1/chat.postMessage')
+            message = {'channel': @options[:channel], 'text': message}
+            loggedheader = {'X-Auth-Token': @token, 'X-User-Id': @uid}
+            req = Net::HTTP::Post.new(uri.request_uri, loggedheader)
+            req.set_form_data(message)
+            res = Net::HTTP.start(uri.host, uri.port, 
+                :use_ssl => uri.scheme == 'https') {|http| http.request req}
+            if res.code != '200'
+              return false
+            end
+            return true
+        end
+
+        def notify user, message
+            uri = URI(@url + '/api/v1/chat.postMessage')
+            message = {'channel': '@' + user, 'text': message}
+            loggedheader = {'X-Auth-Token': @token, 'X-User-Id': @uid}
+            req = Net::HTTP::Post.new(uri.request_uri, loggedheader)
+            req.set_form_data(message)
+            res = Net::HTTP.start(uri.host, uri.port, 
+                  :use_ssl => uri.scheme == 'https') {|http| http.request req}
+            if res.code != '200'
+              return false
+            end
+            return true
+        end
+    
+    end
+end

--- a/app/views/rocketchat/application.md.erb
+++ b/app/views/rocketchat/application.md.erb
@@ -1,0 +1,1 @@
+<%= d 'message', false %>

--- a/app/views/rocketchat/ticket_create/en.md.erb
+++ b/app/views/rocketchat/ticket_create/en.md.erb
@@ -1,0 +1,9 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Created by #{current_user.longname} at #{ticket.updated_at}_
+* #{t('Group')}: #{ticket.group.name}
+* #{t('Owner')}: #{ticket.owner.fullname}
+* #{t('State')}: #{t(ticket.state.name)}
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_create/pt-br.md.erb
+++ b/app/views/rocketchat/ticket_create/pt-br.md.erb
@@ -1,0 +1,9 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Criado por #{current_user.longname} em #{ticket.updated_at}_
+* #{t('Group')}: #{ticket.group.name}
+* #{t('Owner')}: #{ticket.owner.fullname}
+* #{t('State')}: #{t(ticket.state.name)}
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_create/zh-cn.md.erb
+++ b/app/views/rocketchat/ticket_create/zh-cn.md.erb
@@ -1,0 +1,9 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 由 #{current_user.longname} 在 #{ticket.updated_at} 创建_
+* #{t('Group')}: #{ticket.group.name}
+* #{t('Owner')}: #{ticket.owner.fullname}
+* #{t('State')}: #{t(ticket.state.name)}
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_create/zh-tw.md.erb
+++ b/app/views/rocketchat/ticket_create/zh-tw.md.erb
@@ -1,0 +1,9 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 由 #{current_user.longname} 在 #{ticket.updated_at} 創建_
+* #{t('Group')}: #{ticket.group.name}
+* #{t('Owner')}: #{ticket.owner.fullname}
+* #{t('State')}: #{t(ticket.state.name)}
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation/en.md.erb
+++ b/app/views/rocketchat/ticket_escalation/en.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Escalated at #{ticket.escalation_at}_
+A ticket (#{ticket.title}) from "#{ticket.customer.longname}" is escalated since "#{ticket.escalation_at}"!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation/pt-br.md.erb
+++ b/app/views/rocketchat/ticket_escalation/pt-br.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Escalado em #{ticket.escalation_at}_
+Um chamado (#{ticket.title}) de "#{ticket.customer.longname}" foi escalado desde "#{ticket.escalation_at}"!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation/zh-cn.md.erb
+++ b/app/views/rocketchat/ticket_escalation/zh-cn.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 在 #{ticket.escalation_at} 开始升级_
+"#{ticket.customer.longname}" 的工单 (#{ticket.title}) 已经在 "#{ticket.escalation_at}" 开始升级!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation/zh-tw.md.erb
+++ b/app/views/rocketchat/ticket_escalation/zh-tw.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 在 #{ticket.escalation_at} 開始升級_
+"#{ticket.customer.longname}" 的工單 (#{ticket.title}) 已經在 "#{ticket.escalation_at}" 開始升級!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation_warning/en.md.erb
+++ b/app/views/rocketchat/ticket_escalation_warning/en.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Will escalate at #{ticket.escalation_at}_
+A ticket (#{ticket.title}) from "#{ticket.customer.longname}" will escalate at "#{ticket.escalation_at}"!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation_warning/pt-br.md.erb
+++ b/app/views/rocketchat/ticket_escalation_warning/pt-br.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Vai ser escalado em #{ticket.escalation_at}_
+Um chamado (#{ticket.title}) de "#{ticket.customer.longname}" vai ser escalado em "#{ticket.escalation_at}"!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation_warning/zh-cn.md.erb
+++ b/app/views/rocketchat/ticket_escalation_warning/zh-cn.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 即将在 #{ticket.escalation_at} 开始升级_
+"#{ticket.customer.longname}" 的工单 (#{ticket.title}) 即将在 "#{ticket.escalation_at}" 开始升级!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_escalation_warning/zh-tw.md.erb
+++ b/app/views/rocketchat/ticket_escalation_warning/zh-tw.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 即將在 #{ticket.escalation_at} 開始升級_
+"#{ticket.customer.longname}" 的工單 (#{ticket.title}) 即將在 "#{ticket.escalation_at}" 開始升級!
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_mentioned/en.md.erb
+++ b/app/views/rocketchat/ticket_mentioned/en.md.erb
@@ -1,0 +1,6 @@
+# #{ticket.title}
+_ You were mentioned in <#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>_
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_reminder_reached/en.md.erb
+++ b/app/views/rocketchat/ticket_reminder_reached/en.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Reminder reached!_
+A ticket needs attention, reminder reached for (#{ticket.title}) with customer "*#{ticket.customer.longname}*".
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_reminder_reached/pt-br.md.erb
+++ b/app/views/rocketchat/ticket_reminder_reached/pt-br.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Lembrete!_
+um chamado precisa de atenção, lembrete criado para (#{ticket.title}) com usuário "*#{ticket.customer.longname}*".
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_reminder_reached/zh-cn.md.erb
+++ b/app/views/rocketchat/ticket_reminder_reached/zh-cn.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 到达提醒时间!_
+请留意, "*#{ticket.customer.longname}*" 的工单 (#{ticket.title}) 到达提醒时间.
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_reminder_reached/zh-tw.md.erb
+++ b/app/views/rocketchat/ticket_reminder_reached/zh-tw.md.erb
@@ -1,0 +1,7 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 到達提醒時間!_
+請留意, "*#{ticket.customer.longname}*" 的工單 (#{ticket.title}) 到達提醒時間.
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_update/en.md.erb
+++ b/app/views/rocketchat/ticket_update/en.md.erb
@@ -1,0 +1,11 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Updated by #{current_user.longname} at #{ticket.updated_at}_
+<% if @objects[:changes].present? %>
+  <% @objects[:changes].each do |key, value| %>
+  * <%= t key %>: <%= h value[0] %> -> <%= h value[1] %>
+  <% end %>
+<% end %>
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_update/pt-br.md.erb
+++ b/app/views/rocketchat/ticket_update/pt-br.md.erb
@@ -1,0 +1,11 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: Atualizado por #{current_user.longname} em #{ticket.updated_at}_
+<% if @objects[:changes].present? %>
+  <% @objects[:changes].each do |key, value| %>
+  * <%= t key %>: <%= h value[0] %> -> <%= h value[1] %>
+  <% end %>
+<% end %>
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_update/zh-cn.md.erb
+++ b/app/views/rocketchat/ticket_update/zh-cn.md.erb
@@ -1,0 +1,11 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 由 #{current_user.longname} 在 #{ticket.updated_at} 更新了_
+<% if @objects[:changes].present? %>
+  <% @objects[:changes].each do |key, value| %>
+  * <%= t key %>: <%= h value[0] %> -> <%= h value[1] %>
+  <% end %>
+<% end %>
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/app/views/rocketchat/ticket_update/zh-tw.md.erb
+++ b/app/views/rocketchat/ticket_update/zh-tw.md.erb
@@ -1,0 +1,11 @@
+# #{ticket.title}
+_<#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}|Ticket##{ticket.number}>: 由 #{current_user.longname} 在 #{ticket.updated_at} 更新了_
+<% if @objects[:changes].present? %>
+  <% @objects[:changes].each do |key, value| %>
+  * <%= t key %>: <%= h value[0] %> -> <%= h value[1] %>
+  <% end %>
+<% end %>
+
+<% if @objects[:article] %>
+#{article.body_as_text}
+<% end %>

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -4510,3 +4510,54 @@ Setting.create_if_not_exists(
   },
   frontend:    true
 )
+
+Setting.create_if_not_exists(
+  title:       'Defines transaction backend.',
+  name:        '7000_rocketchat_webhook',
+  area:        'Transaction::Backend::Async',
+  description: 'Defines the transaction backend which posts messages to Rocketchat.',
+  options:     {},
+  state:       'Transaction::Rocketchat',
+  frontend:    false
+)
+Setting.create_if_not_exists(
+  title:       'Rocketchat integration',
+  name:        'rocketchat_integration',
+  area:        'Integration::Switch',
+  description: 'Defines if Rocketchat is enabled or not.',
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    true,
+        name:    'rocketchat_integration',
+        tag:     'boolean',
+        options: {
+          true  => 'yes',
+          false => 'no',
+        },
+      },
+    ],
+  },
+  state:       false,
+  preferences: {
+    prio:       1,
+    permission: ['admin.integration'],
+  },
+  frontend:    false
+)
+Setting.create_if_not_exists(
+  title:       'Rocketchat config',
+  name:        'rocketchat_config',
+  area:        'Integration::Rocketchat',
+  description: 'Defines the rocketchat config.',
+  options:     {},
+  state:       {
+    items: []
+  },
+  preferences: {
+    prio:       2,
+    permission: ['admin.integration'],
+  },
+  frontend:    false,
+)

--- a/lib/notification_factory/rocketchat.rb
+++ b/lib/notification_factory/rocketchat.rb
@@ -1,0 +1,79 @@
+class NotificationFactory::Rocketchat
+
+=begin
+    
+  result = NotificationFactory::Rocketchat.template(
+        template: 'ticket_update',
+        locale: 'en-us',
+        timezone: 'Europe/Berlin',
+        objects:  {
+          recipient: User.find(2),
+          ticket: Ticket.find(1)
+        },
+      )
+    
+    returns
+    
+      {
+        subject: 'some subject',
+        body: 'some body',
+      }
+    
+=end
+    
+      def self.template(data)
+    
+        if data[:templateInline]
+          return NotificationFactory::Renderer.new(
+            objects:  data[:objects],
+            locale:   data[:locale],
+            timezone: data[:timezone],
+            template: data[:templateInline]
+          ).render
+        end
+    
+        template = NotificationFactory.template_read(
+          locale:   data[:locale] || Setting.get('locale_default') || 'en-us',
+          template: data[:template],
+          format:   'md',
+          type:     'rocketchat',
+        )
+    
+        message_subject = NotificationFactory::Renderer.new(
+          objects:  data[:objects],
+          locale:   data[:locale],
+          timezone: data[:timezone],
+          template: template[:subject],
+          escape:   false
+        ).render
+        message_body = NotificationFactory::Renderer.new(
+          objects:  data[:objects],
+          locale:   data[:locale],
+          timezone: data[:timezone],
+          template: template[:body],
+          escape:   false
+        ).render
+    
+        if !data[:raw]
+          application_template = NotificationFactory.application_template_read(
+            format: 'md',
+            type:   'rocketchat',
+          )
+          data[:objects][:message] = message_body
+          data[:objects][:standalone] = data[:standalone]
+          message_body = NotificationFactory::Renderer.new(
+            objects:  data[:objects],
+            locale:   data[:locale],
+            timezone: data[:timezone],
+            template: application_template,
+            escape:   false
+          ).render
+        end
+        {
+          subject: message_subject.strip!,
+          body:    message_body.strip!,
+        }
+      end
+    
+    end
+    

--- a/spec/lib/notification_factory/rocketchat_spec.rb
+++ b/spec/lib/notification_factory/rocketchat_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+RSpec.describe NotificationFactory::Rocketchat do
+  describe '.template' do
+    subject(:template) do
+      described_class.template(
+        template: action,
+        locale:   'en-us',
+        timezone: 'Europe/Berlin',
+        objects:  {
+          ticket:       ticket,
+          article:      article,
+          recipient:    agent,
+          current_user: current_user,
+          changes:      changes,
+        }
+      )
+    end
+
+    let(:ticket) { article.ticket }
+    let(:article) { create(:ticket_article) }
+    let(:agent) { create(:agent_user) }
+    let(:current_user) { create(:agent_user) }
+
+    context 'for "ticket_create", with an empty "changes" hash' do
+      let(:action) { 'ticket_create' }
+
+      let(:changes) { {} }
+
+      it 'returns a hash with subject: <ticket title> (as Markdown heading)' do
+        expect(template).to include(subject: "# #{ticket.title}")
+      end
+
+      it 'returns a hash with body: <article author & body>' do
+        expect(template[:body])
+          .to match(/Created by #{current_user.fullname}/)
+          .and match(/#{article.body}\z/)
+      end
+    end
+
+    context 'for "ticket_update", with a populated "changes" hash' do
+      let(:action) { 'ticket_update' }
+
+      let(:changes) do
+        {
+          state:        %w[aaa bbb],
+          group:        %w[xxx yyy],
+          pending_time: [Time.zone.parse('2019-04-01T10:00:00Z0'), Time.zone.parse('2019-04-01T23:00:00Z0')],
+        }
+      end
+
+      it 'returns a hash with subject: <ticket title> (as Markdown heading)' do
+        expect(template).to include(subject: "# #{ticket.title}")
+      end
+
+      it 'returns a hash with body: <article editor, changes, & body>' do
+        expect(template[:body])
+          .to match(/Updated by #{current_user.fullname}/)
+          .and match(/state: aaa -> bbb/)
+          .and match(/group: xxx -> yyy/)
+          .and match(%r{pending_time: 04/01/2019 12:00 \(Europe/Berlin\) -> 04/02/2019 01:00 \(Europe/Berlin\)})
+          .and match(/#{article.body}\z/)
+      end
+    end
+
+    context 'for "ticket_escalate"' do
+      subject(:template) do
+        described_class.template(
+          template: 'ticket_escalation',
+          locale:   'en-us',
+          timezone: 'Europe/Berlin',
+          objects:  {
+            ticket:    ticket,
+            article:   article,
+            recipient: agent,
+          }
+        )
+      end
+
+      before { ticket.escalation_at = escalation_time }
+
+      let(:escalation_time) { Time.zone.parse('2019-04-01T10:00:00Z') }
+
+      it 'returns a hash with subject: <ticket title> (as Markdown heading)' do
+        expect(template).to include(subject: "# #{ticket.title}")
+      end
+
+      it 'returns a hash with body: <ticket customer, escalation time, & body>' do
+        expect(template[:body])
+          .to match(/A ticket \(#{ticket.title}\) from "#{ticket.customer.fullname}"/)
+          .and match(%r{is escalated since "04/01/2019 12:00 \(Europe/Berlin\)"!})
+          .and match(/#{article.body}\z/)
+      end
+    end
+  end
+end

--- a/test/browser/integration_test.rb
+++ b/test/browser/integration_test.rb
@@ -335,4 +335,106 @@ class IntegrationTest < TestCase
       value: 'yes',
     )
   end
+
+  def test_rocketchat
+    @browser = browser_instance
+    login(
+      username: 'master@example.com',
+      password: 'test',
+      url:      browser_url,
+    )
+    tasks_close_all()
+
+    # change settings
+    click(css: 'a[href="#manage"]')
+    click(css: 'a[href="#system/integration"]')
+    click(css: 'a[href="#system/integration/rocketchat"]')
+    sleep 2
+    switch(
+      css:  '.content.active .main .js-switch',
+      type: 'on',
+    )
+    click(css: '.content.active .main .checkbox-replacement')
+    set(
+      css:   '.content.active .main input[name="webhook"]',
+      value: 'http://some_url/webhook/123',
+    )
+    set(
+      css:   '.content.active .main input[name="username"]',
+      value: 'someuser',
+    )
+    set(
+      css:   '.content.active .main input[name="password"]',
+      value: 'somepassword',
+    )
+    set(
+      css:   '.content.active .main input[name="channel"]',
+      value: '#general',
+    )
+
+    click(css: '.content.active .main .js-submit')
+
+    match(
+      css:   '.content.active .main input[name="webhook"]',
+      value: 'http://some_url/webhook/123',
+    )
+    match(
+      css:   '.content.active .main input[name="username"]',
+      value: 'someuser',
+    )
+    match(
+      css:   '.content.active .main input[name="password"]',
+      value: 'somepassword',
+    )
+    match(
+      css:   '.content.active .main input[name="channel"]',
+      value: '#general',
+    )
+
+    click(css: 'a[href="#dashboard"]')
+    click(css: 'a[href="#manage"]')
+    click(css: 'a[href="#system/integration"]')
+    click(css: 'a[href="#system/integration/rocketchat"]')
+
+    match(
+      css:   '.content.active .main input[name="webhook"]',
+      value: 'http://some_url/webhook/123',
+    )
+    match(
+      css:   '.content.active .main input[name="username"]',
+      value: 'someuser',
+    )
+    match(
+      css:   '.content.active .main input[name="password"]',
+      value: 'somepassword',
+    )
+    match(
+      css:   '.content.active .main input[name="channel"]',
+      value: '#general',
+    )
+
+    reload()
+
+    match(
+      css:   '.content.active .main input[name="webhook"]',
+      value: 'http://some_url/webhook/123',
+    )
+    match(
+      css:   '.content.active .main input[name="username"]',
+      value: 'someuser',
+    )
+    match(
+      css:   '.content.active .main input[name="password"]',
+      value: 'somepassword',
+    )
+    match(
+      css:   '.content.active .main input[name="channel"]',
+      value: '#general',
+    )
+
+    switch(
+      css:  '.content.active .main .js-switch',
+      type: 'off',
+    )
+  end
 end


### PR DESCRIPTION
This PR adds RocketChat integration, it mimics Slack.
    
It provides browser configuration to request notifications on ticket create/update/etc. Notifications are sent on defined channel. Configured user must have access to this channel.

Additionally, if article contains a user mention with @userid (one or many), a direct message is sent to specified users help with message templates.
By defaults it sends information that user is mentioned in ticket XXX with text of note.
