### PR TITLE
Debian 10 support for packager.io

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -38,6 +38,17 @@ targets:
     build_dependencies:
       - libimlib2
       - libimlib2-dev
+  debian-10:
+    dependencies:
+      - curl
+      - elasticsearch
+      - nginx|apache2
+      - postgresql|mariadb-server|sqlite
+      - libimlib2
+      - libimlib2-dev
+    build_dependencies:
+      - libimlib2
+      - libimlib2-dev
   ubuntu-16.04:
     dependencies:
       - curl


### PR DESCRIPTION
Not sure whether the dependencies are all available under this name, but that should get you going. Debian 10 support has been added in July on packager.io