### PR TITLE
Added options for external database server

### DIFF
--- a/config/database/database.yml
+++ b/config/database/database.yml
@@ -14,11 +14,19 @@ default: &default
   # username: zammad
   # password:
 
+  # If the database server is not on localhost, you can set hostname and port:
+  # host:
+  # port:
+
   #### mysql config #####
 
   # adapter: mysql2
   # username: zammad
   # password: <Password>
+
+  # If the database server is not on localhost, you can set hostname and port:
+  # host:
+  # port:
 
 production:
   <<: *default


### PR DESCRIPTION
Database config file has allowed only localhost database server. If you
want to use a database on a different host, you need the ability to set
hostname and port
- for MySQL see:
"https://stackoverflow.com/questions/5872264/correct-mysql-configuration-for-ruby-on-rails-database-yml-file"
- for PostgreSQL see:
"https://gist.github.com/jwo/4512764#file-postgres-database-yml"
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
