### PR TITLE
Macro handles setting relative pending_time

### DIFF
--- a/app/assets/javascripts/app/models/ticket.coffee
+++ b/app/assets/javascripts/app/models/ticket.coffee
@@ -133,6 +133,20 @@ class App.Ticket extends App.Model
               else
                 @tagAdd(params.ticket.id, tag)
 
+        else if attributes[1] is 'pending_time' && content.operator is 'relative'
+          pendtil = new Date
+          if content.range is 'day'
+            pendtil.setDate(pendtil.getDate() + parseInt(content.value, 10))
+          if content.range is 'minute'
+            pendtil.setMinutes(pendtil.getMinutes() + parseInt(content.value, 10))
+          if content.range is 'hour'
+            pendtil.setHours(pendtil.getHours() + parseInt(content.value, 10))
+          if content.range is 'month'
+            pendtil.setMonth(pendtil.getMonth() + parseInt(content.value, 10))
+          if content.range is 'year'
+            pendtil.setYear(pendtil.getYear() + parseInt(content.value, 10))
+          params.ticket[attributes[1]] = pendtil.toISOString()
+
         # apply user changes
         else if attributes[1] is 'owner_id'
           if content.pre_condition is 'current_user.id'


### PR DESCRIPTION
This is a step toward implementing [this feature request](https://community.zammad.org/t/relative-time-and-date-for-pending-till-in-macros/1748).

This adds functionality for Macros to handle relative pending_time operations.

Consider the following macro:
```
Macro.create_if_not_exists(
name:            'Rails rel pend',
perform:         {
    'ticket.pending_time' => {
        operator: 'relative',
        value:    7,
        range:    'day',
    }
},
updated_by_id: 1,
created_by_id: 1,
ux_flow_next_up: 'none',
note:            'MACRO FROM RAILS CONSOLE',
active:          true,
)
```

With this change, after the above macro is activated, the pending date is set to exactly 7 days from now.
