### PR TITLE
Don't add a blank line to the signature on reply

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
@@ -303,7 +303,6 @@ class EmailReply extends App.Controller
         App.Utils.htmlStrip(signature)
         if signaturePosition is 'top'
           body.prepend(signature)
-          body.prepend('<br>')
         else
           body.append(signature)
         ui.$('[data-name=body]').replaceWith(body)


### PR DESCRIPTION
Unfortunately it's not possible to create reply-templates, so we (and maybe other users too) include the whole template in the signature, starting with the greeting - and this should start in the very first line of the reply.

If someone needs a blank line above his signature, he can add it to the signature manually, so this change doesn't break the former behaviour.

See also: https://community.zammad.org/t/empty-line-above-signature/2870