### PR TITLE
Add apple-touch-icon to HTML head

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=1024">
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <title><%= Setting.get('product_name') %></title>
+  <link rel="apple-touch-icon" href="apple-touch-icon.png" />
   <%= stylesheet_link_tag "application", :media => 'all' %>
   <%= stylesheet_link_tag "application-print", :media => 'print' %>
   <% if Rails.configuration.assets.debug %>


### PR DESCRIPTION
This helps browser to load the existing icon.

Example screenshot Firefox [Top sites](https://support.mozilla.org/en-US/kb/customize-new-tab-page):

**Current** tile in "Top sites":
![image](https://user-images.githubusercontent.com/1295633/71553313-003b0c80-2a0e-11ea-855e-8627dcb6ce7f.png)

**Afterwards**
![image](https://user-images.githubusercontent.com/1295633/71553306-b2be9f80-2a0d-11ea-8e8d-9966d07c14ab.png)

