### PR TITLE
Issue 2714: fixed Ticket::Overview.all query

### DIFF
--- a/app/models/ticket/overviews.rb
+++ b/app/models/ticket/overviews.rb
@@ -31,7 +31,7 @@ returns
       if links.present?
         overview_filter[:link] = links
       end
-      overviews = Overview.joins(:roles).left_joins(:users).where(overviews_roles: { role_id: role_ids }, overviews_users: { user_id: nil }, overviews: overview_filter).or(Overview.joins(:roles).left_joins(:users).where(overviews_roles: { role_id: role_ids }, overviews_users: { user_id: current_user.id }, overviews: overview_filter)).distinct('overview.id').order(:prio, :name)
+      overviews = Overview.joins(:roles).left_joins(:users).where(overviews_roles: { role_id: role_ids }, overviews: overview_filter).or(Overview.joins(:roles).left_joins(:users).where(overviews_users: { user_id: current_user.id }, overviews: overview_filter)).distinct('overview.id').order(:prio, :name)
       return overviews
     end
 


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
#2714 

The query restricted the `current_user` to only see the union of the following overview lists:
List 1: Overviews* where `current_user` is a member of one `overviews_roles` AND is a member of `overviews_users`.
List 2: Overviews* where `current_user` is a member of one of `overviews_roles` AND `overviews_users` is `nil`.

*(After overview filters are placed)

I can't imagine why this was the original query, but this should fix the issue so as to comply with the documentation and what the UI suggests.