### PR TITLE
Fix deserialization of multiselect value

### DIFF
--- a/app/assets/javascripts/app/controllers/_ui_element/select.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/select.coffee
@@ -8,6 +8,15 @@ class App.UiElement.select extends App.UiElement.ApplicationUiElement
     else
       attribute.multiple = ''
 
+    if attribute.multiple && _.isString(attribute.value) && !_.isEmpty(attribute.value)
+      try
+        value = JSON.parse(attribute.value)
+        # only accept serialized arrays, nothing else
+        if _.isArray(value)
+          attribute.value = value
+      catch e
+        console.log("Invalid json passed as attribute value to selectmulti")
+
     if form.rejectNonExistentValues
       attribute.rejectNonExistentValues = true
 

--- a/public/assets/tests/form.js
+++ b/public/assets/tests/form.js
@@ -133,6 +133,9 @@ test("form params check", function() {
     select4: undefined,
     selectmulti1: false,
     selectmulti2: [ false, true ],
+    selectmulti3: '["a","b"]',
+    selectmulti4: '{"notan": "array"}',
+    selectmulti5: '{"invalid":, "json"',
     selectmultioption1: false,
     selectmultioption2: [ false, true ],
     autocompletion2: 'id2',
@@ -174,6 +177,9 @@ test("form params check", function() {
         { name: 'select4', display: 'Select4', tag: 'select', null: false, nulloption: true,  options: { aa: 'aa', bb: 'bb', select3: 'select4' } },
         { name: 'selectmulti1', display: 'SelectMulti1', tag: 'select', null: true, multiple: true, options: { true: 'internal', false: 'public' } },
         { name: 'selectmulti2', display: 'SelectMulti2', tag: 'select', null: false, multiple: true, options: { true: 'internal', false: 'public' } },
+        { name: 'selectmulti3', display: 'SelectMulti3', tag: 'select', null: false, multiple: true, options: { 'a': 'AA', 'b': 'BB' } },
+        { name: 'selectmulti4', display: 'SelectMulti4', tag: 'select', null: false, multiple: true, options: { 'a': 'AA', 'b': 'BB' } },
+        { name: 'selectmulti5', display: 'SelectMulti5', tag: 'select', null: false, multiple: true, options: { 'a': 'AA', 'b': 'BB' } },
         { name: 'selectmultioption1', display: 'SelectMultiOption1', tag: 'select', null: true, multiple: true, options: [{ value: true, name: 'internal' }, { value: false, name: 'public' }] },
         { name: 'selectmultioption2', display: 'SelectMultiOption2', tag: 'select', null: false, multiple: true, options: [{ value: true, name: 'A' }, { value: 1, name: 'B'}, { value: false, name: 'C' }] },
         { name: 'autocompletion1', display: 'AutoCompletion1', tag: 'autocompletion', null: false, options: { true: 'internal', false: 'public' }, source: [ { label: "Choice1", value: "value1", id: "id1" }, { label: "Choice2", value: "value2", id: "id2" }, ], minLength: 1 },
@@ -261,6 +267,16 @@ test("form params check", function() {
   equal(el.find('[name="selectmulti2"]').prop('required'), true, 'check selectmulti2 required')
   equal(el.find('[name="selectmulti2"]').is(":focus"), false, 'check selectmulti2 focus')
 
+  equal(el.find('[name="selectmulti3"]').val()[0], 'a', 'check selectmulti3 value')
+  equal(el.find('[name="selectmulti3"]').val()[1], 'b', 'check selectmulti3 value')
+  equal(el.find('[name="selectmulti3"]').prop('required'), true, 'check selectmulti3 required')
+  equal(el.find('[name="selectmulti3"]').is(":focus"), false, 'check selectmulti3 focus')
+
+  equal(el.find('[name="selectmulti4"]').find('option').length, 3, 'check selectmulti4 value')
+  equal(el.find('[name="selectmulti4"]').find('option')[0].value, '{"notan": "array"}', 'check selectmulti4 value')
+
+  equal(el.find('[name="selectmulti5"]').find('option').length, 3, 'check selectmulti5 value')
+
   params = App.ControllerForm.params(el)
   test_params = {
     input1: '',
@@ -277,6 +293,9 @@ test("form params check", function() {
     select4: '',
     selectmulti1: 'false',
     selectmulti2: [ 'true', 'false' ],
+    selectmulti3: ["a","b"],
+    selectmulti4: '{"notan": "array"}',
+    selectmulti5: '{"invalid":, "json"',
     selectmultioption1: 'false',
     selectmultioption2: [ 'true', 'false' ],
     autocompletion1: '',


### PR DESCRIPTION
When a multiselect Attribute is used with the Ticket object, the rails
backend persists the multiselect value as a serialized JSON array in the
database.

When this value is read back and passed down to the form widget to
render, it -- before this patch -- was simply rendering the serialized
JSON array string as an option.

This patch fixes the widget so that it will attempt to deserialize the
value as an array to render the multi selected options properly.

For the case where the passed value serializes to something other than
an array, it falls back on the default existing behavior of just
rendering the string as is.

In the event some bad data gets persisted to the database, we do not
want to break the UI. So we swallow JSON parse errors and fall back on
the existing default behavior of just rendering the string as is.


## screenshots

### before
![multi2](https://user-images.githubusercontent.com/1761767/74524437-5234e480-4f1f-11ea-88ed-939b6f19f41b.png)

### after
![multi1](https://user-images.githubusercontent.com/1761767/74524441-54973e80-4f1f-11ea-8ed2-cc5bbc81efb3.png)

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
