### PR TITLE
Auto install '.szpm's as well as '.zpm's

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -52,7 +52,7 @@ returns:
 
 =begin
 
-install all packages located under auto_install/*.zpm
+install all packages located under auto_install/*.(s)zpm
 
   Package.auto_install
 
@@ -64,7 +64,7 @@ install all packages located under auto_install/*.zpm
 
     data = []
     Dir.foreach(path) do |entry|
-      if entry =~ /\.zpm/ && entry !~ /^\./
+      if entry =~ /\.s?zpm/ && entry !~ /^\./
         data.push entry
       end
     end


### PR DESCRIPTION
This patch makes '.szpm's auto install along with '.zpm's when placed in
`RAILSROOT/auto_install`


