### PR TITLE
Fix issue with modal dialogues when last action or condition is removed

### DIFF
--- a/app/assets/javascripts/app/controllers/_ui_element/postmaster_match.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/postmaster_match.coffee
@@ -151,6 +151,7 @@ class App.UiElement.postmaster_match
 
     # remove filter
     item.find('.js-remove').bind('click', (e) =>
+      return if $(e.currentTarget).hasClass('is-disabled')
       $(e.target).closest('.js-filterElement').remove()
       @rebuildAttributeSelectors(item)
     )

--- a/app/assets/javascripts/app/controllers/_ui_element/ticket_perform_action.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/ticket_perform_action.coffee
@@ -109,14 +109,16 @@ class App.UiElement.ticket_perform_action
         item.append(element)
         @rebuildAttributeSelectors(item, element, groupAndAttribute, elements, {}, attribute)
 
-      return item
+    else
 
-    for groupAndAttribute, meta of params[attribute.name]
+      for groupAndAttribute, meta of params[attribute.name]
 
-      # build and append
-      element = @placeholder(item, attribute, params, groups, elements)
-      @rebuildAttributeSelectors(item, element, groupAndAttribute, elements, meta, attribute)
-      item.append(element)
+        # build and append
+        element = @placeholder(item, attribute, params, groups, elements)
+        @rebuildAttributeSelectors(item, element, groupAndAttribute, elements, meta, attribute)
+        item.append(element)
+    
+    @disableRemoveForOneAttribute(item)
     item
 
   @buildAttributeSelector: (elementFull, groups, elements) ->
@@ -145,6 +147,13 @@ class App.UiElement.ticket_perform_action
           optgroup.append("<option value=\"#{elementKey}\" #{selected}>#{displayName}</option>")
     selection
 
+  # disable - if we only have one attribute
+  @disableRemoveForOneAttribute: (elementFull) ->
+    if elementFull.find('.js-attributeSelector select').length > 1
+      elementFull.find('.js-remove').removeClass('is-disabled')
+    else
+      elementFull.find('.js-remove').addClass('is-disabled')
+
   @updateAttributeSelectors: (elementFull) ->
 
     # enable all
@@ -157,10 +166,7 @@ class App.UiElement.ticket_perform_action
     )
 
     # disable - if we only have one attribute
-    if elementFull.find('.js-attributeSelector select').length > 1
-      elementFull.find('.js-remove').removeClass('is-disabled')
-    else
-      elementFull.find('.js-remove').addClass('is-disabled')
+    @disableRemoveForOneAttribute(elementFull)
 
   @rebuildAttributeSelectors: (elementFull, elementRow, groupAndAttribute, elements, meta, attribute) ->
 

--- a/app/assets/javascripts/app/controllers/_ui_element/ticket_selector.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/ticket_selector.coffee
@@ -200,6 +200,7 @@ class App.UiElement.ticket_selector
         triggerSearch()
       )
 
+    @disableRemoveForOneAttribute(item)
     item
 
   @preview: (item) ->
@@ -240,6 +241,13 @@ class App.UiElement.ticket_selector
             optgroup.append("<option value=\"#{elementKey}\">#{displayName}</option>")
     selection
 
+  # disable - if we only have one attribute
+  @disableRemoveForOneAttribute: (elementFull) ->
+    if elementFull.find('.js-attributeSelector select').length > 1
+      elementFull.find('.js-remove').removeClass('is-disabled')
+    else
+      elementFull.find('.js-remove').addClass('is-disabled')
+
   @updateAttributeSelectors: (elementFull) ->
 
     # enable all
@@ -252,10 +260,7 @@ class App.UiElement.ticket_selector
     )
 
     # disable - if we only have one attribute
-    if elementFull.find('.js-attributeSelector select').length > 1
-      elementFull.find('.js-remove').removeClass('is-disabled')
-    else
-      elementFull.find('.js-remove').addClass('is-disabled')
+    @disableRemoveForOneAttribute(elementFull)
 
 
   @rebuildAttributeSelectors: (elementFull, elementRow, groupAndAttribute, elements, meta, attribute) ->


### PR DESCRIPTION
# Description of issue

A user can remove all action and condition in most modal dialogues. This renders the UI useless if the last action or condition is removed because the user will not be able to re-add such actions or conditions.

After interaction with the UI, I discovered that the remove button is only disabled when there's a triggered event after the modal is active **and** when only one action/condition is left.

   <details>
   <summary>
 <b>CLICK HERE</b> to see the screenshot of when there's only one element in the modal dialogue with the remove button enable but gets disabled on a triggered event (change in options) 
   </summary>

   ![Screenshot example of ](https://user-images.githubusercontent.com/36057474/74541084-e1022b00-4f38-11ea-90f7-5b6449dd355e.gif)
   </details>

After looking into the `ticket_selector.coffee` and `ticket_perform_action.coffee` file I discovered that the static method `@updateAttributeSelectors` is responsible for adding the `is-disabled` class which disables the remove button from removing conditions/actions when clicked.
This method is called only called when there's a `change` event in the attribute selector (as shown in the screenshot above) and `click` event in the remove button (this means when there's exactly two actions/conditions and one is removed the `updateAttributeSelectors` is called and adds the `is-disabled` class to the one left, this makes the bug, less obvious for actions/conditions with more than one attribute)

However, the **Postmaster FIlters** interface issue is different as it is using the `postmaster_set.coffee.coffee` and `postmaster_match.coffee.coffee` files instead, which does not have the `@updateAttributeSelectors` method, instead the condition to add `is-disabled` class is in the `@rebuildAttributeSelectors` method which already gets called in the `@render` method.
The issue with the **Postmaster FIlters** interface as shown below is that the remove button still works even when the `is-disabled` class is added. The `click` event handler on the remove button does not have the condition to not remove the element if the button has `is-disabled` class.

   <details>
   <summary>
 <b>CLICK HERE</b> to see the screenshot of the **Postmaster FIlters** interface issue
   </summary>

   ![Screenshot example](https://user-images.githubusercontent.com/36057474/74604194-c0161300-50bb-11ea-9941-83f696ecc9c0.gif)

   </details>

### List of affected interfaces 

- [x] Trigger
- [x] Scheduler
- [x] SLA
- [x] Reporting-Profiles
- [x] Time Accounting
- [x] Overviews
- [x] Postmaster FIlters
- [x] Macros
- [x] Ticket (Auto Assignment)

### Reference to issue https://github.com/zammad/zammad/issues/2764

# Proposed solution

- The actions/conditions attribute of the modal dialogue should be checked when the modal is rendered. If there is only one attribute in the action or condition, the remove button should be disabled.

- For the **Postmaster FIlters** interface, the click event handler on the remove button should have the condition to not remove the element if the button is disabled.

### Implementation details

1. The `updateAttributeSelectors` method has this condition (shown below), which disables the remove button by adding the `is-disabled` class when the attribute selector is more than one. This condition is moved to a reusable static method called `disableRemoveForOneAttribute` which is called at the end of the `render` method. Doing this will make sure that when there is only one action/condition, the attribute selector `remove` button is disabled when the modal is rendered.

   ```coffee
       if elementFull.find('.js-attributeSelector select').length > 1
         elementFull.find('.js-remove').removeClass('is-disabled')
       else
         elementFull.find('.js-remove').addClass('is-disabled')
   ```
2. For **Postmaster FIlters** interface, the condition to check if the remove button has the class `is-disabled` is added to the click event handler of the remove button, if it is not disabled, the element gets removed otherwise, nothing is done.


# Testing

Tested the following attributes locally in the browser, screenshots are also linked:

- [Trigger](https://user-images.githubusercontent.com/36057474/74557347-db680d80-4f57-11ea-8168-267a93cc8f91.gif)
- [Scheduler](https://user-images.githubusercontent.com/36057474/74557343-d905b380-4f57-11ea-8eee-749e51a76e75.gif)
- [SLA](https://user-images.githubusercontent.com/36057474/74558386-23882f80-4f5a-11ea-8a4a-7616c6c4e310.gi)
- [Reporting-Profiles](https://user-images.githubusercontent.com/36057474/74558383-22ef9900-4f5a-11ea-9e9a-950dcfcb9ea3.gif)
- [Time Accounting](https://user-images.githubusercontent.com/36057474/74558381-22570280-4f5a-11ea-8327-800f8f3e00dc.gif)
- [Overviews](https://user-images.githubusercontent.com/36057474/74558372-1ec37b80-4f5a-11ea-8596-3e4003e37ad3.gif)
- [Postmaster FIlters](https://user-images.githubusercontent.com/36057474/74604195-c1dfd680-50bb-11ea-802f-140473db9756.gif)
- [Macros](https://user-images.githubusercontent.com/36057474/74602214-af0ed700-50a6-11ea-846f-1f382566a7d8.gif)
- [Ticket (Auto Assignment)](https://user-images.githubusercontent.com/36057474/74602399-550f1100-50a8-11ea-921e-bf3c299d2e27.gif)


# Update
- Add fix for the Postmaster filter in this commit https://github.com/zammad/zammad/pull/2934/commits/fdd17a713bfc40ace259067f91df76b43fc4d020

