### PR TITLE
Fix issue with devices session remove button

### DIFF
--- a/app/assets/javascripts/app/controllers/_profile/devices.coffee
+++ b/app/assets/javascripts/app/controllers/_profile/devices.coffee
@@ -36,7 +36,7 @@ class Index extends App.ControllerSubContent
 
   delete: (e) =>
     e.preventDefault()
-    id = $(e.target).closest('a').data('device-id')
+    id = $(e.target).closest('div').data('device-id')
 
     @ajax(
       id:          'user_devices_delete'

--- a/app/assets/javascripts/app/views/profile/devices.jst.eco
+++ b/app/assets/javascripts/app/views/profile/devices.jst.eco
@@ -22,8 +22,10 @@
         <td><%= device.location %></td>
         <td><%- @humanTime(device.updated_at) %></td>
         <td class="settings-list-controls">
-          <div class="settings-list-control" href="#" data-device-id="<%- device.id %>" data-type="delete" title="<%- @Ti('Delete') %>"<% if device.current: %>disabled<% end %>><%- @Icon('trash') %></div>
+          <div class="settings-list-control" href="#" data-device-id="<%- device.id %>" data-type="delete" title="<%- @Ti('Delete') %>"<% if device.current: %>disabled<% end %>>
+            <%- @Icon('trash') %>
           </div>
+        </td>
       </tr>
     <% end %>
     </tbody>


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->


# Description of issue

In the `Device` page of user's `Profile`, Devices listed on this page can't be deleted when the remove button is clicked. See screenshot
![devices_bug](https://user-images.githubusercontent.com/36057474/74606743-3f631100-50d3-11ea-8874-f451d04d4b1d.gif)

Checking the log, I confirmed that the API call is malformed as reported in https://github.com/zammad/zammad/issues/2781

```log
I, [2020-02-16T16:06:59.341574 #14538-70174404499800]  INFO -- : Started DELETE "/api/v1/user_devices/undefined" for ::1 at 2020-02-16 16:06:59 +0100
I, [2020-02-16T16:06:59.373638 #14538-70174404499800]  INFO -- : Processing by UserDevicesController#destroy as JSON
I, [2020-02-16T16:06:59.373844 #14538-70174404499800]  INFO -- :   Parameters: {"id"=>"undefined"}
```
This issue has to do with the undefined `id` in the API call in `app/assets/javascripts/app/controllers/_profile/devices.coffee`.
The `id` is defined by targeting an anchor tag instead of a `div` tag.

```javascript
 id = $(e.target).closest('a').data('device-id')
```

This seems to be a bug after the `app/assets/javascripts/app/views/profile/devices.jst.eco` file was changed in this commit https://github.com/zammad/zammad/commit/97d14a93b3fee85769cedf4c1e7abd770798088f#diff-f150ec767074262095f89fef46309a31

The remove button was changed from the `a` element to `div` element.


### Reference to issue #2781

# Proposed solution 

### This issue was solved locally in two ways as follows:
1. Change the remove button to an anchor tag, this way the `closest()` method will be able to get the element


2. Alternatively, the `closest()` method selector could be changed to `div`, this way the method will be able to get the element


### This PR solves this issue using the second option (change `closest()` method selector to `div`)

# Testing

I couldn't replicate the issue initially on my local browser, so I had to create user devices manually from the rails console. The table below shows the comparison of deleting the devices before and after the changes

| Before changes | After Changes |
| :-----: | :-----: |
| ![devices_test_bug](https://user-images.githubusercontent.com/36057474/74609170-cd48f700-50e7-11ea-854e-861b13f9f800.gif)  | ![devices_test_fix](https://user-images.githubusercontent.com/36057474/74609167-cb7f3380-50e7-11ea-9b2a-7f92a3038c31.gif) |


### Logfile

The log file is now getting the right `id`

```

I, [2020-02-16T17:51:55.164162 #3500-69976394582120]  INFO -- : Started DELETE "/api/v1/user_devices/13" for ::1 at 2020-02-16 17:51:55 +0100
I, [2020-02-16T17:51:55.172672 #3500-69976394582120]  INFO -- : Processing by UserDevicesController#destroy as JSON
I, [2020-02-16T17:51:55.172783 #3500-69976394582120]  INFO -- :   Parameters: {"id"=>"13"}
```
