### PR TITLE
Filter articles by sender/visibility

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1221,6 +1221,31 @@ result
     Ticket::Article.where(ticket_id: id).order(:created_at, :id)
   end
 
+  # get only public articles
+  def articles_public
+    Ticket::Article.where(ticket_id: id, internal: false).order(:created_at, :id)
+  end
+
+  # get only articles by agent
+  def articles_agent
+    Ticket::Article.where(ticket_id: id, sender_id: Ticket::Article::Sender.find_by(name: 'Agent')).order(:created_at, :id)
+  end
+
+  # get only public articles by agent
+  def articles_agent_public
+    Ticket::Article.where(ticket_id: id, internal: false, sender_id: Ticket::Article::Sender.find_by(name: 'Agent')).order(:created_at, :id)
+  end
+
+  # get only articles by customer
+  def articles_customer
+    Ticket::Article.where(ticket_id: id, sender_id: Ticket::Article::Sender.find_by(name: 'Customer')).order(:created_at, :id)
+  end
+
+  # get only articles by system
+  def articles_system
+    Ticket::Article.where(ticket_id: id, sender_id: Ticket::Article::Sender.find_by(name: 'System')).order(:created_at, :id)
+  end
+
   private
 
   def check_generate

--- a/lib/notification_factory/renderer.rb
+++ b/lib/notification_factory/renderer.rb
@@ -58,7 +58,7 @@ examples how to use
         'article.body_as_html'                      => true,
         'article.body_as_text_with_quote.text2html' => true,
       }
-      if no_escape[key]
+      if no_escape[key] || key =~ /articles_.*.body_as_html/i
         escape = false
       end
     end


### PR DESCRIPTION
While Zammad is able to remind customers of an open ticket (i.e. "waiting for response"), it lacks variables to include the last message from the agent to the customer
(e.g. Zendesk does it with a variable named ticket.public_comments_formatted.)

Here's my take on this—as a workaround for the time being:

```
#{ticket.articles_agent.last.body}
#{ticket.articles_agent_public.last.body}
#{ticket.articles_customer.last.body}
#{ticket.articles_system.last.body}
```

(originally suggested by @martini on 31 Mar 2016: https://github.com/zammad/zammad/issues/905#issuecomment-290696185)

Some more context: https://community.zammad.org/t/article-body-as-html-uses-the-last-article-even-private-ones/4162/4?u=herzkerl

I'd love to enhance this contribution (i.e. add more variables), so please let me know what you think :)