### PR TITLE
Fix issue with incomplete calendar view

### DIFF
--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -9450,6 +9450,7 @@ output {
     font-size: 12px;
     padding: 5px 5px 0;
     text-align: center;
+    font-weight: bold;
   }
 
   .day {
@@ -9457,6 +9458,9 @@ output {
     height: 26px;
     border-radius: 14px;
     padding: 1px 0 0 !important;
+    color: white;
+    background: none;
+    font-weight: bold;
   }
 
   .month,
@@ -9483,6 +9487,7 @@ output {
 
     &.today {
       background: hsl(240,10%,4%);
+      font-weight: bold;
     }
 
     &.focused {


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->


# Description of issue

In the `Admin/Manage` > `Calendar` page (http://localhost:3000/#manage/calendars), when adding an additional holiday to the Calendar panel, the calendar view is incomplete.

This issue has to do with the CSS style having the same font `color` as the `background`.

### Reference to issue #2776

# Proposed solution 

The CSS was adjusted accordingly to fit the screenshot of the Expected Behaviour in #2776

# Testing

The following screenshot shows the changes

| Before changes | After Changes |
| :-----: | :-----: |
| ![image](https://user-images.githubusercontent.com/36057474/76440156-bb443680-63bd-11ea-83d3-c805d5837722.png)  | ![image](https://user-images.githubusercontent.com/36057474/76439998-8506b700-63bd-11ea-8714-1a29329b9101.png)  |


I am not sure if this is the best approach, also I couldn't test with other parts that use the datepicker calendar view, in case the changes have affected them.

Kidly advice if there's a better approach to this solution and also parts that could be affected with these changes.
