### PR TITLE
Fix issue with table column resize in RTL (right to left) languages

### DIFF
--- a/app/assets/javascripts/app/controllers/_application_controller_table.coffee
+++ b/app/assets/javascripts/app/controllers/_application_controller_table.coffee
@@ -934,7 +934,7 @@ class App.ControllerTable extends App.Controller
 
   onColResizeMousemove: (event) =>
     # use pixels while moving for max precision
-    if $('html[dir="rtl"]').length
+    if App.i18n.dir() is 'rtl'
       difference = @resizeStartX - event.pageX
     else
       difference = event.pageX - @resizeStartX

--- a/app/assets/javascripts/app/controllers/_application_controller_table.coffee
+++ b/app/assets/javascripts/app/controllers/_application_controller_table.coffee
@@ -934,7 +934,10 @@ class App.ControllerTable extends App.Controller
 
   onColResizeMousemove: (event) =>
     # use pixels while moving for max precision
-    difference = event.pageX - @resizeStartX
+    if $('html[dir="rtl"]').length
+      difference = @resizeStartX - event.pageX
+    else
+      difference = event.pageX - @resizeStartX
 
     if @resizeLeftStartWidth + difference < @minColWidth
       difference = - (@resizeLeftStartWidth - @minColWidth)


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->


# Description of issue

When language is set to an RTL language (for example, Hebrew), adjusting the column size of any table goes to the wrong direction, that is, when intending to reduce the size it increases and when intending to increase it reduces.

### Reference to issue #2977

# Proposed solution 

The `difference` variable in the `onColResizeMousemove` method is inverted (additive) for RTL languages, that is when the `html` have the `dir` attribute to be `rtl`, the `difference` variable is calculated by multiplying `-1` to it's calculated value.

# Testing

The following screenshot shows the changes

| Before changes | After Changes |
| :-----: | :-----: |
| ![rtl-zammad-bug](https://user-images.githubusercontent.com/36057474/77233104-8dbd7100-6ba5-11ea-9905-d563bdc70125.gif)  |![rtl-zammad-fixed](https://user-images.githubusercontent.com/36057474/77233107-90b86180-6ba5-11ea-94be-16c01502a50c.gif)  |






