### PR TITLE
Fullquote Header for forwarded mails

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
@@ -201,7 +201,14 @@ class EmailReply extends App.Controller
       body = App.Utils.textCleanup(article.body)
       body = App.Utils.text2html(body)
 
-    body = "<br/><div>---Begin forwarded message:---<br/><br/></div><div><blockquote type=\"cite\">#{body}</blockquote></div><div><br></div>"
+    quote_header = ''
+    if App.Config.get('ui_ticket_zoom_article_email_full_quote_header')
+      date = @date_format(article.created_at)
+      name = article.updated_by.displayName()
+      email = article.updated_by.email
+      quote_header = App.i18n.translateInline('On %s, %s <%s> wrote:', date, name, email) + '<br><br>'
+
+    body = "<br/><div>---Begin forwarded message:---<br/><br/></div><div><blockquote type=\"cite\">#{quote_header}#{body}</blockquote></div><div><br></div>"
 
     articleNew = {}
     articleNew.body = body


### PR DESCRIPTION
- Add a header line containung the timestamp, sender name and From address upon forwarding an email (cloned from Reply action)

=====

Considering this requirement:

- Add tests for your changes. Feel free to ask for support. We are happy to help you.

I have no idea how to do that. I found this old commit:

https://github.com/zammad/zammad/commit/2a09863df5c15ea61d3aa173e4c3da464fa5e7b7

Is that a good starting point? The action should be very similar.