### PR TITLE
Adding LDAP group retrieval for objectClass 'groupOfNames'

### DIFF
--- a/lib/ldap/group.rb
+++ b/lib/ldap/group.rb
@@ -113,7 +113,7 @@ class Ldap
     #
     # @return [String, nil] The active or found filter or nil if none could be found.
     def filter
-      @filter ||= lookup_filter(['(objectClass=groupOfUniqueNames)', '(objectClass=group)', '(objectClass=posixgroup)', '(objectClass=organization)'])
+      @filter ||= lookup_filter(['(objectClass=groupOfUniqueNames)', '(objectClass=groupOfNames)', '(objectClass=group)', '(objectClass=posixgroup)', '(objectClass=organization)'])
     end
 
     # The active uid attribute of the instance. If none give on initialization an automatic lookup is performed.


### PR DESCRIPTION
LDAP filter for groups currently doesn't recognize 'objectClass=groupOfNames', similar problem like in solved bug #1347.