### PR TITLE
fix: IMAP support for unicode on verification

### DIFF
--- a/app/models/channel/driver/imap.rb
+++ b/app/models/channel/driver/imap.rb
@@ -1,5 +1,6 @@
 # Copyright (C) 2012-2016 Zammad Foundation, http://zammad-foundation.org/
 require 'net/imap'
+require 'mail'
 
 class Channel::Driver::Imap < Channel::EmailParser
 
@@ -126,12 +127,12 @@ example
     end
 
     message_ids = nil
-    timeout(6.minutes) do
-
-      message_ids = @imap.sort(['DATE'], filter, 'US-ASCII')
-    rescue
+    begin
+      timeout(6.minutes) do
+        message_ids = @imap.sort(['DATE'], filter, 'US-ASCII')
+      end
+    rescue Timeout::Error
       message_ids = @imap.search(filter)
-
     end
 
     # check mode only
@@ -180,7 +181,7 @@ example
         end
 
         # check if verify message exists
-        subject = message_meta['ENVELOPE'].subject
+        subject = Mail::Encodings.value_decode(message_meta['ENVELOPE'].subject)
         next if !subject
         next if !subject.match?(/#{verify_string}/)
 


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
This is a bugfix to issue #3037.
- Rescue doesn't catch timeout error, should use "rescue Timeout::Error" instead of rescue. In my case, `message_ids = @imap.sort(['DATE'], filter, 'US-ASCII')` never returns, and rescue not called after 6 mins. Using rescue Timeout::Error ensure it would fallback to `imap.search`.
- should decode message subject when verifying email with imap. In my case, message_meta['ENVELOPE'].subject returns something like this: 
`=?gbk?B?WmFtbWFkIEdldHRpbmcgc3RhcnRlZCBUZXN0IEVtYWlsICM2MDkyMjY1ODIzNQ==?=`
 
Reply me if you want an email configuration for reproduce this issue.
