### PR TITLE
Change Opps to Oops to be more gramatically correct

### DIFF
--- a/app/assets/javascripts/app/views/generic/error/not_found.jst.eco
+++ b/app/assets/javascripts/app/views/generic/error/not_found.jst.eco
@@ -1,4 +1,4 @@
 <div class="flex fullscreenMessage">
   <%- @Icon('diagonal-cross', 'icon-error') %>
-  <h2><%- @T('Opps.. I\'m sorry, but I can\'t find this %s.', @objectName ) %></h2>
+  <h2><%- @T('Oops.. I\'m sorry, but I can\'t find this %s.', @objectName ) %></h2>
 </div>

--- a/app/assets/javascripts/app/views/generic/error/unauthorized.jst.eco
+++ b/app/assets/javascripts/app/views/generic/error/unauthorized.jst.eco
@@ -1,4 +1,4 @@
 <div class="flex fullscreenMessage">
   <%- @Icon('diagonal-cross', 'icon-error') %>
-  <h2><%- @T('Opps.. I\'m sorry, but you have insufficient rights to open this %s.', @objectName ) %></h2>
+  <h2><%- @T('Oops.. I\'m sorry, but you have insufficient rights to open this %s.', @objectName ) %></h2>
 </div>

--- a/app/assets/javascripts/app/views/layout_ref/insufficient_rights.jst.eco
+++ b/app/assets/javascripts/app/views/layout_ref/insufficient_rights.jst.eco
@@ -1,4 +1,4 @@
 <div class="flex fullscreenMessage">
   <%- @Icon('diagonal-cross', 'icon-error') %>
-  <h2>Opps.. I'm sorry, but you have insufficient rights to open this ticket.</h2>
+  <h2>Oops.. I'm sorry, but you have insufficient rights to open this ticket.</h2>
 </div>


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
While setting up Zammad I noticed that some of the error pages say Opps instead of Oops, which is probably what was meant. So I changed it. Dictionary link for reference: https://www.merriam-webster.com/dictionary/oops?show=0 :)

![image](https://user-images.githubusercontent.com/11754504/88216522-34d11880-cc2b-11ea-80b4-276652728ea9.png)

