### PR TITLE
Fix #2793: CSV-Export contains Tags twice (once empty)

### DIFF
--- a/lib/excel_sheet/ticket.rb
+++ b/lib/excel_sheet/ticket.rb
@@ -56,7 +56,7 @@ class ExcelSheet::Ticket < ExcelSheet
     objects.each do |object|
       already_exists = false
       header.each do |local_header|
-        next if local_header[:name] != object[:name]
+        next if local_header[:display] != object[:display]
 
         already_exists = true
         break


### PR DESCRIPTION
Closes #2793 

### Description

When exporting tickets from the reports page, the field Tags appears in the report twice.

### Proposed solution

When choosing header fields of the report, filter them by display name.

### Testing

Attached please find report generated after fix.


[tickets--all--Created.pdf](https://github.com/zammad/zammad/files/5147567/tickets--all--Created.pdf)

