### PR TITLE
#3080 changes scopes to API versions > 6

### DIFF
--- a/lib/external_credential/facebook.rb
+++ b/lib/external_credential/facebook.rb
@@ -31,7 +31,7 @@ class ExternalCredential::Facebook
     {
       request_token: state,
       #authorize_url: oauth.url_for_oauth_code(permissions: 'publish_pages, manage_pages, user_posts', state: state),
-      authorize_url: oauth.url_for_oauth_code(permissions: 'publish_pages, manage_pages', state: state),
+      authorize_url: oauth.url_for_oauth_code(permissions: 'pages_manage_posts, pages_manage_engagement, pages_manage_metadata, pages_read_engagement, pages_read_user_content', state: state),
     }
   end
 


### PR DESCRIPTION
#3080 
Change OAuth scopes for FB API version 7 and above according to the changelog: [https://developers.facebook.com/docs/graph-api/changelog/version7.0](https://developers.facebook.com/docs/graph-api/changelog/version7.0)

I skipped the "pages_manage_ads" scope, as I do not think it should be needed.
