### PR TITLE
Bugfix #3263: Don't pass apple-touch-icon.png to railsserver

### DIFF
--- a/contrib/apache2/zammad.conf
+++ b/contrib/apache2/zammad.conf
@@ -27,6 +27,7 @@
 
     ProxyPass /assets !
     ProxyPass /favicon.ico !
+    ProxyPass /apple-touch-icon.png !
     ProxyPass /robots.txt !
     ProxyPass /ws ws://127.0.0.1:6042/
     ProxyPass / http://127.0.0.1:3000/

--- a/contrib/apache2/zammad_ssl.conf
+++ b/contrib/apache2/zammad_ssl.conf
@@ -50,6 +50,7 @@
 
     ProxyPass /assets !
     ProxyPass /favicon.ico !
+    ProxyPass /apple-touch-icon.png !
     ProxyPass /robots.txt !
     ProxyPass /ws ws://127.0.0.1:6042/
     ProxyPass / http://127.0.0.1:3000/

--- a/contrib/nginx/zammad.conf
+++ b/contrib/nginx/zammad.conf
@@ -26,7 +26,7 @@ server {
 
     client_max_body_size 50M;
 
-    location ~ ^/(assets/|robots.txt|humans.txt|favicon.ico) {
+    location ~ ^/(assets/|robots.txt|humans.txt|favicon.ico|apple-touch-icon.png) {
         expires max;
     }
 

--- a/contrib/nginx/zammad_ssl.conf
+++ b/contrib/nginx/zammad_ssl.conf
@@ -82,7 +82,7 @@ server {
 
   client_max_body_size 50M;
 
-  location ~ ^/(assets/|robots.txt|humans.txt|favicon.ico) {
+  location ~ ^/(assets/|robots.txt|humans.txt|favicon.ico|apple-touch-icon.png) {
     expires max;
   }
 


### PR DESCRIPTION
Fixes #3263 