### PR TITLE
Fixes Issue #2842 : Show linked public KB Answers to Customers in Ticket view

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_ticket.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_ticket.coffee
@@ -141,18 +141,20 @@ class SidebarTicket extends App.Controller
         links:       @links
       )
 
-      if @permissionCheck('knowledge_base.*') and App.Config.get('kb_active')
-        @linkKbAnswerWidget = new App.WidgetLinkKbAnswer(
-          el:          localEl.filter('.link_kb_answers')
-          object_type: 'Ticket'
-          object:      @ticket
-          links:       @links
-        )
-
       @timeUnitWidget = new App.TicketZoomTimeUnit(
         el:        localEl.filter('.js-timeUnit')
         object_id: @ticket.id
       )
+
+    if (@ticket.currentView() is 'agent' or @ticket.currentView() is 'customer') and @permissionCheck('knowledge_base.*') and App.Config.get('kb_active')
+      @linkKbAnswerWidget = new App.WidgetLinkKbAnswer(
+        el:          localEl.filter('.link_kb_answers')
+        object_type: 'Ticket'
+        object:      @ticket
+        links:       @links
+        isAgent: @ticket.currentView() is 'agent'
+      )
+
     @html localEl
 
   showTicketHistory: =>

--- a/app/assets/javascripts/app/controllers/widget/link/kb_answer.coffee
+++ b/app/assets/javascripts/app/controllers/widget/link/kb_answer.coffee
@@ -39,7 +39,8 @@ class App.WidgetLinkKbAnswer extends App.WidgetLink
 
   render: ->
     @html App.view('link/kb_answer')(
-      list: @linksForRendering()
+      list: @linksForRendering(),
+      isAgent: @isAgent
     )
 
     @renderPopovers()

--- a/app/assets/javascripts/app/views/link/kb_answer.jst.eco
+++ b/app/assets/javascripts/app/views/link/kb_answer.jst.eco
@@ -8,9 +8,13 @@
       <div class="task-text">
         <a class="name kb-answer-popover" data-id="<%- item.id %>" href="<%- item.url %>"><%= item.title %></a>
       </div>
-      <a class="list-item-delete js-delete" data-object="KnowledgeBase::Answer::Translation" data-object-id="<%= item.id %>" data-link-type="normal">
-        <%- @Icon('diagonal-cross') %>
-      </a>
+      <% if @isAgent: %>
+        <a class="list-item-delete js-delete" data-object="KnowledgeBase::Answer::Translation" data-object-id="<%= item.id %>" data-link-type="normal">
+          <%- @Icon('diagonal-cross') %>
+        </a>
+      <% end %>
   <% end %>
 </ol>
-<div class="text-muted js-add u-clickable">+ <%- @T('Link Related Answer') %></div>
+<% if @isAgent: %>
+  <div class="text-muted js-add u-clickable">+ <%- @T('Link Related Answer') %></div>
+<% end %>


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
Fixes issue https://github.com/zammad/zammad/issues/2842

The fix includes following changes:

1) Adding knowledge base reader permission to **customer** in _db/seeds/permissions.rb_ 
`customer.permission_grant('knowledge_base.reader')`

2) Changing the agent role check for rendering **Related Answers Block** to both agent & customer role

3) Adding conditional rendering for edit actions such as link and unlink KBAnswers

Please let me know if this solution works well :)