### PR TITLE
backup: stop using su for pg_dump

### DIFF
--- a/contrib/backup/functions
+++ b/contrib/backup/functions
@@ -51,9 +51,11 @@ function backup_db () {
     ln -sfn ${BACKUP_DIR}/${TIMESTAMP}_zammad_db.mysql.gz ${BACKUP_DIR}/latest_zammad_db.mysql.gz
   elif [ "${DB_ADAPTER}" == "postgresql" ]; then
     echo "creating postgresql backup..."
-    su -c "pg_dump --no-privileges --no-owner -c ${DB_NAME} | \
-      gzip > /tmp/${TIMESTAMP}_zammad_db.psql.gz" postgres
-    mv /tmp/${TIMESTAMP}_zammad_db.psql.gz ${BACKUP_DIR}
+    PGPASSWORD="${DB_PASS}" pg_dump \
+        --dbname "${DB_NAME}" \
+        --username "${DB_USER}" \
+        --no-privileges --no-owner --clean \
+        --compress 6 --file "${BACKUP_DIR}/${TIMESTAMP}_zammad_db.psql.gz"
     ln -sfn ${BACKUP_DIR}/${TIMESTAMP}_zammad_db.psql.gz ${BACKUP_DIR}/latest_zammad_db.psql.gz
   else
     echo "DB ADAPTER not found. if its sqlite backup is already saved in the filebackup"


### PR DESCRIPTION
* It creates files owned by postgres user which cannot be later moved to correct location
* It requires password in most cases what is not suitable for execution from cron

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
