### PR TITLE
Added elasticsearch-oss as an dependency

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -6,7 +6,7 @@ targets:
   centos-7:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx
       - postgresql-server
       - which
@@ -18,7 +18,7 @@ targets:
   centos-8:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx
       - postgresql-server
       - which
@@ -30,7 +30,7 @@ targets:
   debian-9:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx|apache2
       - postgresql|mariadb-server|sqlite
       - libimlib2
@@ -40,7 +40,7 @@ targets:
   debian-10:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx|apache2
       - postgresql|mariadb-server|sqlite
       - libimlib2
@@ -50,7 +50,7 @@ targets:
   ubuntu-16.04:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx|apache2
       - postgresql|mysql-server|mariadb-server|sqlite
       - libimlib2
@@ -60,7 +60,7 @@ targets:
   ubuntu-18.04:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx|apache2
       - postgresql|mysql-server|mariadb-server|sqlite
       - libimlib2
@@ -70,7 +70,7 @@ targets:
   ubuntu-20.04:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx|apache2
       - postgresql|mysql-server|mariadb-server|sqlite
       - libimlib2
@@ -80,7 +80,7 @@ targets:
   sles-12:
     dependencies:
       - curl
-      - elasticsearch
+      - elasticsearch|elasticsearch-oss
       - nginx
       - postgresql-server
       - libImlib2-1


### PR DESCRIPTION
As per your documentation it's possbile to run Zammad without elasticsearch. Therefore it is not a proper way to define it as a dependency. At least for Debian-like systems elasticsearch should be a [recommends](https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends).

Because packager.io doesn't [support](https://doc.packager.io/documentation/customizing-the-build/) definining recommends I suggest to add `elasticsearch-oss` as an alternative dependency. At least it's now possbible to choose betweem the oss version and the bundled oss/non-free verion of elasticsearch.