### PR TITLE
Maintenance: Dont try to modify possibly frozen string in place

### DIFF
--- a/app/models/channel/email_parser.rb
+++ b/app/models/channel/email_parser.rb
@@ -740,7 +740,7 @@ process unprocessable_mails (tmp/unprocessable_mail/*.eml) again
     end
 
     # for some broken sm mail clients (X-MimeOLE: Produced By Microsoft Exchange V6.5)
-    filename ||= file.header[:content_location].to_s.force_encoding('utf-8')
+    filename ||= file.header[:content_location].to_s.dup.force_encoding('utf-8')
 
     # generate file name based on content-id
     if filename.blank? && headers_store['Content-ID'].present? && headers_store['Content-ID'] =~ /(.+?)@.+?/i

--- a/app/models/concerns/checks_client_notification.rb
+++ b/app/models/concerns/checks_client_notification.rb
@@ -11,8 +11,7 @@ module ChecksClientNotification
   end
 
   def notify_clients_data(event)
-    class_name = self.class.name
-    class_name.gsub!(/::/, '')
+    class_name = self.class.name.gsub(/::/, '')
 
     {
       message: {


### PR DESCRIPTION
When trying to use Zammad with ruby 2.7.2 I ran into a FrozenError. Class names are frozen, so they can't be modified in place by gsub!(). Even if Gemfile uses ruby 2.6.6 which does not have this issue, it might be a good idea to fix this.