### PR TITLE
Settings: Add Option for `mark and quote` feature

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
@@ -147,7 +147,7 @@ class EmailReply extends App.Controller
         selected = App.Utils.textCleanup(article.body)
         selected = App.Utils.text2html(selected)
 
-    if selected
+    if selected && App.Config.get('ui_ticket_zoom_article_email_mark_and_quote')
       quote_header = @replyQuoteHeader(article)
 
       selected = "<div><br><br/></div><div><blockquote type=\'cite\'>#{quote_header}#{selected}<br></blockquote></div><div><br></div>"

--- a/db/migrate/20210128000000_setting_add_email_mark_and_quote.rb
+++ b/db/migrate/20210128000000_setting_add_email_mark_and_quote.rb
@@ -1,0 +1,34 @@
+class SettingAddEmailMarkAndQuote < ActiveRecord::Migration[5.2]
+  def up
+    # return if it's a new setup
+    return if !Setting.exists?(name: 'system_init_done')
+
+    Setting.create_if_not_exists(
+      title:       'Email - Mark and Quote',
+      name:        'ui_ticket_zoom_article_email_mark_and_quote',
+      area:        'UI::TicketZoom',
+      description: 'Enable if you want to automatically quote selected text.',
+      options:     {
+        form: [
+          {
+            display:   '',
+            null:      true,
+            name:      'ui_ticket_zoom_article_email_mark_and_quote',
+            tag:       'boolean',
+            translate: true,
+            options:   {
+              true  => 'yes',
+              false => 'no',
+            },
+          },
+        ],
+      },
+      state:       true,
+      preferences: {
+        prio:       240,
+        permission: ['admin.ui'],
+      },
+      frontend:    true
+    )
+  end
+end

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -755,6 +755,33 @@ Setting.create_if_not_exists(
   frontend:    true
 )
 Setting.create_if_not_exists(
+  title:       'Email - Mark and Quote',
+  name:        'ui_ticket_zoom_article_email_mark_and_quote',
+  area:        'UI::TicketZoom',
+  description: 'Enable if you want to automatically quote selected text.',
+  options:     {
+    form: [
+      {
+        display:   '',
+        null:      true,
+        name:      'ui_ticket_zoom_article_email_mark_and_quote',
+        tag:       'boolean',
+        translate: true,
+        options:   {
+          true  => 'yes',
+          false => 'no',
+        },
+      },
+    ],
+  },
+  state:       true,
+  preferences: {
+    prio:       240,
+    permission: ['admin.ui'],
+  },
+  frontend:    true
+)
+Setting.create_if_not_exists(
   title:       'Twitter - tweet initials',
   name:        'ui_ticket_zoom_article_twitter_initials',
   area:        'UI::TicketZoom',


### PR DESCRIPTION
- Add option to settings to enable/disable `mark and quote` feature
- Default: enabled (current behaviour)

This options allows to turn off the `mark and quote` feature. This is
desirable in some cases, because while convenient it may lead to agents
accidentally leaking data to customers, when not intended.

This feature was requested here:
https://community.zammad.org/t/zammad-shouldnt-automatically-quote-selected-text/4651/3

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
