### PR TITLE
Remove dots next to icons in tables

### DIFF
--- a/app/assets/javascripts/app/controllers/report.coffee
+++ b/app/assets/javascripts/app/controllers/report.coffee
@@ -310,6 +310,7 @@ class Download extends App.Controller
       attribute =
         name:         'icon'
         display:      ''
+        parentClass:  'noTruncate'
         translation:  false
         width:        '28px'
         displayWidth: 28

--- a/app/assets/javascripts/app/controllers/ticket_overview.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_overview.coffee
@@ -1184,6 +1184,7 @@ class Table extends App.Controller
         attribute =
           name:         'icon'
           display:      ''
+          parentClass:  'noTruncate'
           translation:  false
           width:        '28px'
           displayWidth: 28

--- a/app/assets/javascripts/app/controllers/widget/answer_list.coffee
+++ b/app/assets/javascripts/app/controllers/widget/answer_list.coffee
@@ -44,6 +44,7 @@ class App.AnswerList extends App.Controller
       attribute =
         name:        'icon'
         display:     ''
+        parentClass:  'noTruncate'
         translation: false
         width:       '28px'
         displayWidth:28

--- a/app/assets/javascripts/app/controllers/widget/ticket_list.coffee
+++ b/app/assets/javascripts/app/controllers/widget/ticket_list.coffee
@@ -53,6 +53,7 @@ class App.TicketList extends App.Controller
       attribute =
         name:         'icon'
         display:      ''
+        parentClass:  'noTruncate'
         translation:  false
         width:        '28px'
         displayWidth: 28

--- a/app/assets/javascripts/app/views/integration/idoit_object_result.jst.eco
+++ b/app/assets/javascripts/app/views/integration/idoit_object_result.jst.eco
@@ -12,7 +12,7 @@
   <tbody>
   <% for item in @items: %>
     <tr>
-      <td><input type="checkbox" name="object_id" value="<%= item.id %>"/></td>
+      <td class="noTruncate"><input type="checkbox" name="object_id" value="<%= item.id %>"/></td>
       <td title="<%= item.id %>"><%= item.id %></td>
       <td title="<%= item.title %>"><a href="<%- item.link %>" target="_blank"><%= item.title %></a></td>
       <td><%= item.cmdb_status_title %></td>

--- a/app/assets/javascripts/app/views/integration/index.jst.eco
+++ b/app/assets/javascripts/app/views/integration/index.jst.eco
@@ -13,7 +13,7 @@
     <tbody>
     <% for integration in @integrations: %>
       <tr data-key="<%= integration.key %>">
-        <td>
+        <td class="noTruncate">
           <% if !integration.state.current(): %>
             <%- @Icon('status', 'inactive inline') %>
           <% else: %>


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

# Description of issue

The functionality to truncate long text and replace with an ellipsis (dots) using the `text-overflow` overflow property affects icon columns in a table to appear with dots on certain viewports or/and browsers.

### Reference to issue #3262 #3172

Fixes #3262, fixes #3172

# Proposed solution 

The existing CSS class `noTruncate` already serve the purpose of not been included to have this CSS property. Adding the class either directly to the template files or through the `parentClass` attribute to be added dynamically.

# Screenshots

The following screenshot shows the changes

<details>
<summary>Click to see screenshots ...</summary>

| Before changes | After changes  |
|:----:|:----:|
| ![image](https://user-images.githubusercontent.com/36057474/107671592-4a279600-6c94-11eb-8fa2-1a98401e3133.png) | ![image](https://user-images.githubusercontent.com/36057474/107671955-ab4f6980-6c94-11eb-9e96-43fe81b92e34.png)|
| ![image](https://user-images.githubusercontent.com/36057474/107671702-6cb9af00-6c94-11eb-9725-7eb5f54f3908.png) | ![image](https://user-images.githubusercontent.com/36057474/107671788-822ed900-6c94-11eb-952b-27a550e26001.png) |
| ![image](https://user-images.githubusercontent.com/36057474/107673125-fae26500-6c95-11eb-967e-d08962131c3c.png) | ![image](https://user-images.githubusercontent.com/36057474/107673206-10f02580-6c96-11eb-9fa9-4f590b80083a.png) |
| ![image](https://user-images.githubusercontent.com/36057474/107673748-9247b800-6c96-11eb-9846-bc8cc5b31787.png) | ![image](https://user-images.githubusercontent.com/36057474/107673785-9bd12000-6c96-11eb-8584-c560792dc6da.png) |

</details>
