### PR TITLE
Fix issue with disapearing treeselect that has backslash

### DIFF
--- a/app/assets/javascripts/app/lib/app_post/searchable_select.coffee
+++ b/app/assets/javascripts/app/lib/app_post/searchable_select.coffee
@@ -249,6 +249,7 @@ class App.SearchableSelect extends Spine.Controller
     return if @animating
     if dir > 0
       target = @currentItem.attr('data-value')
+      target = App.Utils.escapeRegExp(target)
       target_menu = @optionsSubmenu.filter("[data-parent-value=\"#{target}\"]")
     else
       target_menu = @findMenuContainingValue(@currentMenu.attr('data-parent-value'))

--- a/public/assets/tests/form_searchable_select.js
+++ b/public/assets/tests/form_searchable_select.js
@@ -183,5 +183,59 @@ test( "searchable_select check", function() {
   equal(el.find('[name="searchable_select1"].js-shadow + .js-input').val(), 'aaa display L2', 'verify shown input')
   equal(el.find('[name="searchable_select2"].js-shadow + .js-input').val(), 'ccc display L2', 'verify shown input')
 
+});
+
+asyncTest("searchable_select submenu and option list check", function() {
+  expect(3);
+
+  $('#forms').append('<hr><h1>searchable_select check for special charaters values</h1><form id="form3"></form>')
+  var el = $('#form3')
+  var defaults = {
+    searchable_select1: 'aaa',
+  }
+  var options = [
+    { value: 'aaa', name: 'aaa display' },
+    { value: 'bbb', name: 'bbb display' },
+    { value: 'c\\cc', name: 'ccc display', children: [
+      { value: 'c\\cc::aaa', name: 'aaa display L2' },
+      { value: 'c\\cc::bbb', name: 'bbb display L2' },
+      { value: 'c\\cc::ccc', name: 'ccc display L2' },
+    ] },
+  ]
+  new App.ControllerForm({
+    el:        el,
+    model:     {
+      configure_attributes: [
+        {
+          name:    'searchable_select1',
+          display: 'SearchableSelect1',
+          tag:     'searchable_select',
+          options: options,
+          default: defaults['searchable_select1'],
+          null:    true,
+        },
+      ]
+    },
+  })
+
+  el.find("[name=\"searchable_select1\"].js-shadow + .js-input").click()
+  el.find(".searchableSelect .js-optionsList [data-value=\"c\\\\cc\"]").mouseenter().click()
+  el.find(".searchableSelect .js-optionsSubmenu [data-value=\"c\\\\cc::bbb\"]").mouseenter().click()
+  el.find("[name=\"searchable_select1\"].js-shadow + .js-input").click()
+
+  var params = App.ControllerForm.params(el)
+  var test_params = {
+    searchable_select1: 'c\\cc::bbb'
+  }
+
+  var optionsSubmenu = el.find(".searchableSelect .js-optionsSubmenu")
+  var optionsList = el.find(".searchableSelect .js-optionsList")
+
+  setTimeout( () => {
+    deepEqual(params, test_params, 'form param check')
+    equal(optionsSubmenu.is('[hidden]'), false, 'options submenu menu not hidden')
+    equal(optionsList.is('[hidden]'), true, 'options list is hidden')
+    start();
+  }, 300)
 
 });

--- a/public/assets/tests/form_searchable_select.js
+++ b/public/assets/tests/form_searchable_select.js
@@ -184,4 +184,53 @@ test( "searchable_select check", function() {
   equal(el.find('[name="searchable_select2"].js-shadow + .js-input').val(), 'ccc display L2', 'verify shown input')
 
 
+  $('#forms').append('<hr><h1>searchable_select check for special charaters values</h1><form id="form3"></form>')
+  var el = $('#form3')
+  var defaults = {
+    searchable_select1: 'c\\cc::aaa',
+    searchable_select2: 'c\\cc::ccc',
+  }
+  var options = [
+    { value: 'aaa', name: 'aaa display' },
+    { value: 'bbb', name: 'bbb display' },
+    { value: 'c\\cc', name: 'ccc display', children: [
+      { value: 'c\\cc::aaa', name: 'aaa display L2' },
+      { value: 'c\\cc::bbb', name: 'bbb display L2' },
+      { value: 'c\\cc::ccc', name: 'ccc display L2' },
+    ] },
+  ]
+  new App.ControllerForm({
+    el:        el,
+    model:     {
+      configure_attributes: [
+        {
+          name:    'searchable_select1',
+          display: 'SearchableSelect1',
+          tag:     'searchable_select',
+          options: options,
+          default: defaults['searchable_select1'],
+          null:    true,
+        },
+        {
+          name:    'searchable_select2',
+          display: 'SearchableSelect2',
+          tag:     'searchable_select',
+          options: options,
+          default: defaults['searchable_select2'],
+          null:    true,
+        },
+      ]
+    },
+  })
+
+  var params = App.ControllerForm.params(el)
+  var test_params = {
+    searchable_select1: 'c\\cc::aaa',
+    searchable_select2: 'c\\cc::ccc',
+  }
+  deepEqual(params, test_params, 'form param check')
+  equal(el.find('[name="searchable_select1"].js-shadow + .js-input').val(), 'aaa display L2', 'verify shown input')
+  equal(el.find('[name="searchable_select2"].js-shadow + .js-input').val(), 'ccc display L2', 'verify shown input')
+
+
 });

--- a/public/assets/tests/form_tree_select.js
+++ b/public/assets/tests/form_tree_select.js
@@ -268,3 +268,86 @@ test("form elements check", function() {
   deepEqual(params, test_params, 'form param check')
 
 });
+
+asyncTest("searchable_select submenu and option list check", function() {
+  expect(3);
+
+
+  $('#forms').append('<hr><h1>form elements check</h1><form id="form5"></form>')
+  var el = $('#form5')
+  new App.ControllerForm({
+    el:        el,
+    model:     {
+      "configure_attributes": [
+        {
+          "name": "tree_select",
+          "display": "tree_select",
+          "tag": "tree_select",
+          "null": true,
+          "translate": true,
+          "value": "bb",
+          "options": [
+            {
+              "value": "a\\a",
+              "name": "a\\a",
+              "children": [
+                  {
+                    "value": "a\\a::aaa",
+                    "name": "aaa",
+                  },
+                  {
+                    "value": "a\\a::aab",
+                    "name": "aab",
+                  },
+                  {
+                    "value": "a\\a::aac",
+                    "name": "aac",
+                  },
+              ]
+            },
+            {
+              "value": "bb",
+              "name": "bb",
+              "children": [
+                  {
+                    "value": "bb::bba",
+                    "name": "bba",
+                  },
+                  {
+                    "value": "bb::bbb",
+                    "name": "bbb",
+                  },
+                  {
+                    "value": "bb::bbc",
+                    "name": "bbc",
+                  },
+              ]
+            },
+          ],
+        }
+      ]
+    },
+    autofocus: true
+  });
+
+  el.find("[name=\"tree_select\"].js-shadow + .js-input").click()
+  el.find(".searchableSelect .js-optionsList [data-value=\"a\\\\a\"]").mouseenter().click()
+  el.find(".searchableSelect .js-optionsSubmenu [data-value=\"a\\\\a::aab\"]").mouseenter().click()
+  el.find("[name=\"tree_select\"].js-shadow + .js-input").click()
+
+  var params = App.ControllerForm.params(el)
+  var test_params = {
+    tree_select: 'a\\a::aab'
+  }
+
+  var optionsSubmenu = el.find(".searchableSelect [data-parent-value=\"a\\\\a\"].js-optionsSubmenu")
+  var optionsList = el.find(".searchableSelect .js-optionsList")
+
+  setTimeout( () => {
+    deepEqual(params, test_params, 'form param check')
+    equal(optionsSubmenu.is('[hidden]'), false, 'options submenu menu not hidden')
+    equal(optionsList.is('[hidden]'), true, 'options list is hidden')
+    start();
+  }, 300)
+
+});

--- a/public/assets/tests/form_tree_select.js
+++ b/public/assets/tests/form_tree_select.js
@@ -62,6 +62,70 @@ test("form elements check", function() {
   }
   deepEqual(params, test_params, 'form param check')
 
+  $('#forms').append('<hr><h1>form elements check</h1><form id="form5"></form>')
+  var el = $('#form5')
+  new App.ControllerForm({
+    el:        el,
+    model:     {
+      "configure_attributes": [
+        {
+          "name": "tree_select",
+          "display": "tree_select",
+          "tag": "tree_select",
+          "null": true,
+          "translate": true,
+          "value": "a\\a::aac",
+          "options": [
+            {
+              "value": "a\\a",
+              "name": "a\\a",
+              "children": [
+                  {
+                    "value": "a\\a::aaa",
+                    "name": "aaa",
+                  },
+                  {
+                    "value": "a\\a::aab",
+                    "name": "aab",
+                  },
+                  {
+                    "value": "a\\a::aac",
+                    "name": "aac",
+                  },
+              ]
+            },
+            {
+              "value": "bb",
+              "name": "bb",
+              "children": [
+                  {
+                    "value": "bb::bba",
+                    "name": "bba",
+                  },
+                  {
+                    "value": "bb::bbb",
+                    "name": "bbb",
+                  },
+                  {
+                    "value": "bb::bbc",
+                    "name": "bbc",
+                  },
+              ]
+            },
+          ],
+        }
+      ]
+    },
+    autofocus: true
+  });
+  equal(el.find('[name="tree_select"]').val(), 'a\\a::aac', 'check tree_select value');
+  equal(el.find('[name="tree_select"]').closest('.searchableSelect').find('.js-input').val(), 'aac', 'check tree_select .js-input value');
+  var params = App.ControllerForm.params(el)
+  var test_params = {
+    tree_select: 'a\\a::aac'
+  }
+  deepEqual(params, test_params, 'form param check')
+
   $('#forms').append('<hr><h1>form elements check</h1><form id="form2"></form>')
   var el = $('#form2')
   new App.ControllerForm({


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

# Description of issue

When a tree select has values with backtick `\`,  it gets impossible to navigate to such element children. This is because the query used to select the element to escape the backtick, so for example, when `le \ test` is the parent it selects `le  test` which would not be found.

### Reference to issue #3162

Fixes #3162

## Proposed solution 

The backtick is escaped using the existing escape utility `App.Utils.escapeRegExp` method. So when backtick or other special characters are used, the method escape this character so the query that selects the element use the character, the character keeps all it's value. Now, when `le \ test` is the value used the method escape the bactick by returning `le \\ test` and then the query uses `le \ test`.

## Screenshots

The following screenshot shows the changes

### Before changes

https://user-images.githubusercontent.com/36057474/107861871-ff02b400-6e48-11eb-8a87-7a580242ee5a.mov

### After Changes

https://user-images.githubusercontent.com/36057474/107860297-e2fa1500-6e3e-11eb-92c7-96002fc9379b.mov
