### PR TITLE
Fixes #3012: Don't display "article type" selection for customers within UI.

### DIFF
--- a/app/assets/javascripts/app/views/ticket_zoom/article_new.jst.eco
+++ b/app/assets/javascripts/app/views/ticket_zoom/article_new.jst.eco
@@ -7,6 +7,7 @@
   <div class="editControls">
     <div class="js-avatar"></div>
     <div class="editControls-item is-hidden pop-select">
+      <% if @articleTypes.length > 1: %>
       <div class="editControls-iconHolder centered js-selectedArticleType">
         <% for articleType in @articleTypes: %>
         <div class="editControls-icon js-selectableTypes<%- ' hide' if articleType.icon != @article.icon %>" data-type="<%- articleType.name %>">
@@ -21,6 +22,7 @@
         </div>
         <% end %>
       </div>
+      <% end %>
     </div>
     <% if @internalSelector: %>
     <div class="editControls-item is-hidden js-toggleVisibility js-selectInternalPublic">

--- a/spec/system/ticket/zoom_spec.rb
+++ b/spec/system/ticket/zoom_spec.rb
@@ -1094,6 +1094,32 @@ RSpec.describe 'Ticket zoom', type: :system do
     end
   end
 
+  # regression test for issue #3012 - hide article type selection button for single choice
+  describe 'article type selection' do
+    context 'when logged in as a customer', authenticated_as: :customer do
+      let(:customer)        { create(:customer) }
+      let(:ticket)          { create(:ticket, customer: customer) }
+
+      it 'hides button for single choice' do
+        visit "ticket/zoom/#{ticket.id}"
+
+        find('.articleNewEdit-body').send_keys('Some reply')
+        expect(page).to have_no_selector('.js-selectedArticleType')
+      end
+    end
+
+    context 'when logged in as an agent' do
+      let(:ticket)          { create(:ticket, group: Group.find_by(name: 'Users')) }
+
+      it 'shows button for multiple choices' do
+        visit "ticket/zoom/#{ticket.id}"
+
+        find('.articleNewEdit-body').send_keys('Some reply')
+        expect(page).to have_selector('.js-selectedArticleType')
+      end
+    end
+  end
+
   # https://github.com/zammad/zammad/issues/3260
   describe 'next in overview macro changes URL', authenticated_as: :authenticate do
     let(:next_ticket) { create(:ticket, title: 'next Ticket', group: Group.first) }

--- a/test/browser/agent_ticket_update1_test.rb
+++ b/test/browser/agent_ticket_update1_test.rb
@@ -44,11 +44,6 @@ class AgentTicketUpdate1Test < TestCase
       do_not_submit: true,
     )
 
-    # regression test for issue #3012 - check that article type selection button is shown
-    exists(
-      css: '.js-selectedArticleType'
-    )
-
     close_task(
       data:            {
         title: 'some changes',

--- a/test/browser/agent_ticket_update1_test.rb
+++ b/test/browser/agent_ticket_update1_test.rb
@@ -43,6 +43,12 @@ class AgentTicketUpdate1Test < TestCase
       },
       do_not_submit: true,
     )
+
+    # regression test for issue #3012 - check that article type selection button is shown
+    exists(
+      css: '.js-selectedArticleType'
+    )
+
     close_task(
       data:            {
         title: 'some changes',

--- a/test/browser/customer_ticket_create_test.rb
+++ b/test/browser/customer_ticket_create_test.rb
@@ -59,6 +59,11 @@ class CustomerTicketCreateTest < TestCase
       no_click: true,
     )
 
+    # regression test for issue #3012 - check that article type selection button is not shown
+    exists_not(
+      css: '.js-selectedArticleType'
+    )
+
     task_type(
       type: 'stayOnTab',
     )

--- a/test/browser/customer_ticket_create_test.rb
+++ b/test/browser/customer_ticket_create_test.rb
@@ -59,11 +59,6 @@ class CustomerTicketCreateTest < TestCase
       no_click: true,
     )
 
-    # regression test for issue #3012 - check that article type selection button is not shown
-    exists_not(
-      css: '.js-selectedArticleType'
-    )
-
     task_type(
       type: 'stayOnTab',
     )


### PR DESCRIPTION
Fixes #3012.

Article type selection button next to the article text input will be hidden in case there are no alternative choices.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
