### PR TITLE
Fixes #3018: Times in ticket history are displayed in UTC.

### DIFF
--- a/app/assets/javascripts/app/controllers/_application_controller/generic_history.coffee
+++ b/app/assets/javascripts/app/controllers/_application_controller/generic_history.coffee
@@ -82,15 +82,17 @@ class App.GenericHistory extends App.ControllerModal
         content = "#{ @T( 'This ticket was merged into' ) } #{ @T( 'ticket' ) } #{ ticket_link }"
       else
         content = "#{ @T( item.type ) } #{ @T(item.object) } "
+
+        # convert time stamps
+        if item.value_from
+          dateObject = App.Utils.parseISO(item.value_from)
+          item.value_from = App.i18n.translateTimestamp(dateObject) if dateObject
+        if item.value_to
+          dateObject = App.Utils.parseISO(item.value_to)
+          item.value_to = App.i18n.translateTimestamp(dateObject) if dateObject
+
         if item.attribute
           content += "#{ @T(item.attribute) }"
-
-          # convert time stamps
-          if item.object is 'User' && item.attribute is 'last_login'
-            if item.value_from
-              item.value_from = App.i18n.translateTimestamp( item.value_from )
-            if item.value_to
-              item.value_to = App.i18n.translateTimestamp( item.value_to )
 
         if item.value_from
           if item.value_to

--- a/app/assets/javascripts/app/lib/app_post/utils.coffee
+++ b/app/assets/javascripts/app/lib/app_post/utils.coffee
@@ -1050,6 +1050,26 @@ class App.Utils
       num = '0' + num
     num
 
+  @parseISO: (timestamp) ->
+
+    # YYYY-MM-DD HH:mm:SS UTC
+    pattern = ///
+      ^
+        ([0-9]{4})-([0-9]{2})-([0-9]{2})
+        \s
+        ([0-9]{2}):([0-9]{2}):([0-9]{2})
+        \s
+        UTC
+      $
+    ///
+    return if !timestamp || !timestamp.match || !timestamp.match(pattern)
+
+    [YYYY, MM, DD, HH, mm, SS] = timestamp.match(pattern)[1..6]
+    dateObject = new Date( Date.parse( "#{YYYY}-#{MM}-#{DD}T#{HH}:#{mm}:#{SS}Z" ) )
+
+    return if dateObject is 'Invalid Date'
+    dateObject
+
   @icon: (name, className = '') ->
     return if !name
 

--- a/public/assets/tests/html_utils.js
+++ b/public/assets/tests/html_utils.js
@@ -2000,6 +2000,50 @@ test("check formatTime format", function() {
   equal(verify, result, string)
 });
 
+// check parseISO
+test("check parseISO", function() {
+
+  var string = '2021-01-01 00:00:00 UTC'
+  var result = new Date(2021, 0, 1, 0, 0, 0);
+  var verify = App.Utils.parseISO(string)
+  deepEqual(verify, result, string)
+
+  string = '2021-01-01 00:00:00 CET'
+  result = undefined;
+  verify = App.Utils.parseISO(string)
+  equal(verify, result, string)
+
+  string = '2021-01-01T00:00:00Z'
+  result = undefined;
+  verify = App.Utils.parseISO(string)
+  equal(verify, result, string)
+
+  string = new Date(2021, 0, 1, 0, 0, 0);
+  result = undefined;
+  verify = App.Utils.parseISO(string)
+  equal(verify, result, string)
+
+  string = '2021-02-30T00:00:00Z'
+  result = undefined;
+  verify = App.Utils.parseISO(string)
+  equal(verify, result, string)
+
+  string = ''
+  result = undefined;
+  verify = App.Utils.parseISO(string)
+  equal(verify, result, string)
+
+  string = undefined
+  result = undefined;
+  verify = App.Utils.parseISO(string)
+  equal(verify, result, string)
+
+  string = null
+  result = undefined;
+  verify = App.Utils.parseISO(string)
+  equal(verify, result, string)
+});
+
 // check diffPosition
 test("check diffPosition format", function() {
 


### PR DESCRIPTION
Fixes #3018.

Since the ticket history data does not contain type information for its values, we attempt to parse them in an oportune way and consider it a time stamp only in case it produces a valid date object. Later, these date objects can be localized in user's timezone.

Test cases have been added both for the new util method to parse ISO dates (QUnit), and ticket history modal integration (RSpec/Capybara).

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
