### PR TITLE
Allow single tenant only application in microsoft 365 

### DIFF
--- a/app/assets/javascripts/app/views/microsoft365/app_config.jst.eco
+++ b/app/assets/javascripts/app/views/microsoft365/app_config.jst.eco
@@ -20,6 +20,14 @@
       <input id="client_secret" type="text" name="client_secret" value="<% if @external_credential && @external_credential.credentials: %><%= @external_credential.credentials.client_secret %><% end %>" class="form-control" required autocomplete="off" >
     </div>
   </div>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="client_tenant">Tenant UUID/Name<span>*</span></label>
+    </div>
+    <div class="controls">
+      <input id="client_tenant" type="text" name="client_tenant" value="<% if @external_credential && @external_credential.credentials: %><%= @external_credential.credentials.client_tenant %><% end %>" class="form-control" required autocomplete="off" >
+    </div>
+  </div>
   <h2><%- @T('Your callback URL') %></h2>
   <div class="input form-group">
     <div class="controls">

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -1518,10 +1518,10 @@ Setting.create_if_not_exists(
         tag:     'input',
       },
       {
-        display: 'App Tenant ID',
-        null:    true,
-        name:    'app_tenant',
-        tag:     'input',
+        display:     'App Tenant ID',
+        null:        true,
+        name:        'app_tenant',
+        tag:         'input',
         placeholder: 'common',
       },
 

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -1522,6 +1522,7 @@ Setting.create_if_not_exists(
         null:    true,
         name:    'app_tenant',
         tag:     'input',
+        placeholder: 'common',
       },
 
     ],

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -1517,6 +1517,13 @@ Setting.create_if_not_exists(
         name:    'app_secret',
         tag:     'input',
       },
+      {
+        display: 'App Tenant ID',
+        null:    true,
+        name:    'app_tenant',
+        tag:     'input',
+      },
+
     ],
   },
   state:       {},

--- a/lib/external_credential/microsoft365.rb
+++ b/lib/external_credential/microsoft365.rb
@@ -173,7 +173,7 @@ class ExternalCredential::Microsoft365
 
     uri = URI::HTTPS.build(
       host:  'login.microsoftonline.com',
-      path:  "/#{client_tenant]}/oauth2/v2.0/authorize",
+      path:  "/#{client_tenant}/oauth2/v2.0/authorize",
       query: params.to_query
     )
 

--- a/lib/external_credential/microsoft365.rb
+++ b/lib/external_credential/microsoft365.rb
@@ -222,7 +222,7 @@ class ExternalCredential::Microsoft365
     }
     uri = URI::HTTPS.build(
       host: 'login.microsoftonline.com',
-      path: '/common/oauth2/v2.0/token',
+      path: "/#{client_tenant}/oauth2/v2.0/token",
     )
 
     response = Net::HTTP.post_form(uri, params)

--- a/lib/external_credential/microsoft365.rb
+++ b/lib/external_credential/microsoft365.rb
@@ -25,7 +25,7 @@ class ExternalCredential::Microsoft365
     raise Exceptions::UnprocessableEntity, 'No client_secret param!' if credentials[:client_secret].blank?
     raise Exceptions::UnprocessableEntity, 'No client_tenant param!' if credentials[:client_tenant].blank?
 
-    authorize_url = generate_authorize_url(credentials[:client_id],credentials[:client_tenant])
+    authorize_url = generate_authorize_url(credentials[:client_id], credentials[:client_tenant])
 
     {
       authorize_url: authorize_url,

--- a/lib/omniauth/microsoft_office365_database.rb
+++ b/lib/omniauth/microsoft_office365_database.rb
@@ -8,7 +8,7 @@ class MicrosoftOffice365Database < OmniAuth::Strategies::MicrosoftOffice365
     args[0] = config['app_id']
     args[1] = config['app_secret']
     self.class.option :client_options, {
-      site:          "https://login.microsoftonline.com",
+      site:          'https://login.microsoftonline.com',
       authorize_url: "/#{config['app_tenant']}/oauth2/v2.0/authorize",
       token_url:     "/#{config['app_tenant']}/oauth2/v2.0/token",
     }

--- a/lib/omniauth/microsoft_office365_database.rb
+++ b/lib/omniauth/microsoft_office365_database.rb
@@ -7,6 +7,7 @@ class MicrosoftOffice365Database < OmniAuth::Strategies::MicrosoftOffice365
     config  = Setting.get('auth_microsoft_office365_credentials') || {}
     args[0] = config['app_id']
     args[1] = config['app_secret']
+    args[2] = config['app_tenant']
     super
   end
 

--- a/lib/omniauth/microsoft_office365_database.rb
+++ b/lib/omniauth/microsoft_office365_database.rb
@@ -7,7 +7,12 @@ class MicrosoftOffice365Database < OmniAuth::Strategies::MicrosoftOffice365
     config  = Setting.get('auth_microsoft_office365_credentials') || {}
     args[0] = config['app_id']
     args[1] = config['app_secret']
-#    args[2] = config['app_tenant']
+
+    option :client_options, {
+      site:          "https://login.microsoftonline.com",
+      authorize_url: "/#{config['app_tenant']}/oauth2/v2.0/authorize",
+      token_url:     "/#{config['app_tenant']}/oauth2/v2.0/token",
+    }
     super
   end
 

--- a/lib/omniauth/microsoft_office365_database.rb
+++ b/lib/omniauth/microsoft_office365_database.rb
@@ -7,7 +7,7 @@ class MicrosoftOffice365Database < OmniAuth::Strategies::MicrosoftOffice365
     config  = Setting.get('auth_microsoft_office365_credentials') || {}
     args[0] = config['app_id']
     args[1] = config['app_secret']
-    args[2] = config['app_tenant']
+#    args[2] = config['app_tenant']
     super
   end
 

--- a/lib/omniauth/microsoft_office365_database.rb
+++ b/lib/omniauth/microsoft_office365_database.rb
@@ -1,18 +1,17 @@
 class MicrosoftOffice365Database < OmniAuth::Strategies::MicrosoftOffice365
   option :name, 'microsoft_office365'
-
+  config  = Setting.get('auth_microsoft_office365_credentials') || {}
+  option :client_options, {
+    site:          "https://login.microsoftonline.com",
+    authorize_url: "/#{config['app_tenant']}/oauth2/v2.0/authorize",
+    token_url:     "/#{config['app_tenant']}/oauth2/v2.0/token",
+  }
   def initialize(app, *args, &block)
 
     # database lookup
     config  = Setting.get('auth_microsoft_office365_credentials') || {}
     args[0] = config['app_id']
     args[1] = config['app_secret']
-
-    option :client_options, {
-      site:          "https://login.microsoftonline.com",
-      authorize_url: "/#{config['app_tenant']}/oauth2/v2.0/authorize",
-      token_url:     "/#{config['app_tenant']}/oauth2/v2.0/token",
-    }
     super
   end
 

--- a/lib/omniauth/microsoft_office365_database.rb
+++ b/lib/omniauth/microsoft_office365_database.rb
@@ -1,17 +1,17 @@
 class MicrosoftOffice365Database < OmniAuth::Strategies::MicrosoftOffice365
   option :name, 'microsoft_office365'
-  config  = Setting.get('auth_microsoft_office365_credentials') || {}
-  option :client_options, {
-    site:          "https://login.microsoftonline.com",
-    authorize_url: "/#{config['app_tenant']}/oauth2/v2.0/authorize",
-    token_url:     "/#{config['app_tenant']}/oauth2/v2.0/token",
-  }
+
   def initialize(app, *args, &block)
 
     # database lookup
     config  = Setting.get('auth_microsoft_office365_credentials') || {}
     args[0] = config['app_id']
     args[1] = config['app_secret']
+    self.class.option :client_options, {
+      site:          "https://login.microsoftonline.com",
+      authorize_url: "/#{config['app_tenant']}/oauth2/v2.0/authorize",
+      token_url:     "/#{config['app_tenant']}/oauth2/v2.0/token",
+    }
     super
   end
 


### PR DESCRIPTION
In given PR you can find code that enables per tenant authorization and email integration and not just by
/common/ code path (multi-tenant azure applications) , I hope it can be used as is or what is expected to be added (not a ruby programmer so sorry for code quality)