### PR TITLE
Add redis as an (optional) session store backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'delayed_job_active_record'
 # core - websocket
 gem 'em-websocket'
 gem 'eventmachine'
+gem 'redis'
 
 # core - password security
 gem 'argon2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,6 +434,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rchardet (1.8.0)
+    redis (4.2.5)
     regexp_parser (1.8.2)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
@@ -660,6 +661,7 @@ DEPENDENCIES
   rails-observers
   rb-fsevent
   rchardet (>= 1.8.0)
+  redis
   rspec-rails
   rszr (= 0.5.2)
   rubocop

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,9 @@ module Zammad
     # define cache store
     config.cache_store = :file_store, Rails.root.join('tmp', "cache_file_store_#{Rails.env}")
 
+    # define websocket session store
+    config.websocket_session_store = ENV['REDIS_URL'] ? :redis : :file
+
     # default preferences by permission
     config.preferences_default_by_permission = {
       'ticket.agent' => {

--- a/lib/sessions.rb
+++ b/lib/sessions.rb
@@ -1,13 +1,9 @@
 module Sessions
 
-  # get application root directory
-  @root = Dir.pwd.to_s
-  if @root.blank? || @root == '/'
-    @root = Rails.root
+  @store = case Rails.application.config.websocket_session_store
+    when :redis then Sessions::Store::Redis.new
+    else Sessions::Store::File.new 
   end
-
-  # get working directories
-  @path = "#{@root}/tmp/websocket_#{Rails.env}"
 
   # create global vars for threads
   @@client_threads = {} # rubocop:disable Style/ClassVars
@@ -25,10 +21,6 @@ returns
 =end
 
   def self.create(client_id, session, meta)
-    path         = "#{@path}/#{client_id}"
-    path_tmp     = "#{@path}/tmp/#{client_id}"
-    session_file = "#{path_tmp}/session"
-
     # collect session data
     meta[:last_ping] = Time.now.utc.to_i
     data = {
@@ -37,19 +29,7 @@ returns
     }
     content = data.to_json
 
-    # store session data in session file
-    FileUtils.mkpath path_tmp
-    File.open(session_file, 'wb') do |file|
-      file.write content
-    end
-
-    # destroy old session if needed
-    if File.exist?(path)
-      Sessions.destroy(client_id)
-    end
-
-    # move to destination directory
-    FileUtils.mv(path_tmp, path)
+    @store.create(client_id, content)
 
     # send update to browser
     return if !session || session['id'].blank?
@@ -76,23 +56,7 @@ returns
 =end
 
   def self.sessions
-    path = "#{@path}/"
-
-    # just make sure that spool path exists
-    if !File.exist?(path)
-      FileUtils.mkpath path
-    end
-
-    data = []
-    Dir.foreach(path) do |entry|
-      next if entry == '.'
-      next if entry == '..'
-      next if entry == 'tmp'
-      next if entry == 'spool'
-
-      data.push entry.to_s
-    end
-    data
+    @store.sessions
   end
 
 =begin
@@ -108,13 +72,7 @@ returns
 =end
 
   def self.session_exists?(client_id)
-    session_dir = "#{@path}/#{client_id}"
-    return false if !File.exist?(session_dir)
-
-    session_file = "#{session_dir}/session"
-    return false if !File.exist?(session_file)
-
-    true
+    @store.session_exists?(client_id)
   end
 
 =begin
@@ -173,8 +131,7 @@ returns
 =end
 
   def self.destroy(client_id)
-    path = "#{@path}/#{client_id}"
-    FileUtils.rm_rf path
+    @store.destroy(client_id)
   end
 
 =begin
@@ -217,13 +174,8 @@ returns
     data = get(client_id)
     return false if !data
 
-    path = "#{@path}/#{client_id}"
     data[:meta][:last_ping] = Time.now.utc.to_i
-    File.open("#{path}/session", 'wb' ) do |file|
-      file.flock(File::LOCK_EX)
-      file.write data.to_json
-      file.flock(File::LOCK_UN)
-    end
+    @store.set(client_id, data)
     true
   end
 
@@ -248,41 +200,7 @@ returns
 =end
 
   def self.get(client_id)
-    session_dir  = "#{@path}/#{client_id}"
-    session_file = "#{session_dir}/session"
-    data         = nil
-
-    # if no session dir exists, session got destoried
-    if !File.exist?(session_dir)
-      destroy(client_id)
-      log('debug', "missing session directory #{session_dir} for '#{client_id}', remove session.")
-      return
-    end
-
-    # if only session file is missing, then it's an error behavior
-    if !File.exist?(session_file)
-      destroy(client_id)
-      log('error', "missing session file for '#{client_id}', remove session.")
-      return
-    end
-    begin
-      File.open(session_file, 'rb') do |file|
-        file.flock(File::LOCK_SH)
-        all = file.read
-        file.flock(File::LOCK_UN)
-        data_json = JSON.parse(all)
-        if data_json
-          data        = symbolize_keys(data_json)
-          data[:user] = data_json['user'] # for compat. reasons
-        end
-      end
-    rescue => e
-      log('error', e.inspect)
-      destroy(client_id)
-      log('error', "error in reading/parsing session file '#{session_file}', remove session.")
-      return
-    end
-    data
+    @store.get client_id
   end
 
 =begin
@@ -298,34 +216,7 @@ returns
 =end
 
   def self.send(client_id, data)
-    path     = "#{@path}/#{client_id}/"
-    filename = "send-#{Time.now.utc.to_f}"
-    location = "#{path}#{filename}"
-    check    = true
-    count    = 0
-    while check
-      if File.exist?(location)
-        count += 1
-        location = "#{path}#{filename}-#{count}"
-      else
-        check = false
-      end
-    end
-    return false if !File.directory? path
-
-    begin
-      File.open(location, 'wb') do |file|
-        file.flock(File::LOCK_EX)
-        file.write data.to_json
-        file.flock(File::LOCK_UN)
-        file.close
-      end
-    rescue => e
-      log('error', e.inspect)
-      log('error', "error in writing message file '#{location}'")
-      return false
-    end
-    true
+    @store.send_data(client_id, data)
   end
 
 =begin
@@ -429,43 +320,7 @@ returns
 =end
 
   def self.queue(client_id)
-    path  = "#{@path}/#{client_id}/"
-    data  = []
-    files = []
-    Dir.foreach(path) do |entry|
-      next if entry == '.'
-      next if entry == '..'
-
-      files.push entry
-    end
-    files.sort.each do |entry|
-      next if !entry.start_with?('send')
-
-      message = Sessions.queue_file_read(path, entry)
-      next if !message
-
-      data.push message
-    end
-    data
-  end
-
-  def self.queue_file_read(path, filename)
-    location = "#{path}#{filename}"
-    message = ''
-    File.open(location, 'rb') do |file|
-      file.flock(File::LOCK_EX)
-      message = file.read
-      file.flock(File::LOCK_UN)
-    end
-    File.delete(location)
-    return if message.blank?
-
-    begin
-      JSON.parse(message)
-    rescue => e
-      log('error', "can't parse queue message: #{message}, #{e.inspect}")
-      nil
-    end
+    @store.queue(client_id)
   end
 
 =begin
@@ -477,10 +332,7 @@ remove all session and spool messages
 =end
 
   def self.cleanup
-    return true if !File.exist?(@path)
-
-    FileUtils.rm_rf @path
-    true
+    @store.cleanup
   end
 
 =begin
@@ -493,18 +345,11 @@ create spool messages
 
   def self.spool_create(data)
     msg = JSON.generate(data)
-    path = "#{@path}/spool/"
-    FileUtils.mkpath path
     data = {
       msg:       msg,
       timestamp: Time.now.utc.to_i,
     }
-    file_path = "#{path}/#{Time.now.utc.to_f}-#{rand(99_999)}"
-    File.open(file_path, 'wb') do |file|
-      file.flock(File::LOCK_EX)
-      file.write data.to_json
-      file.flock(File::LOCK_UN)
-    end
+    @store.add_to_spool(data)
   end
 
 =begin
@@ -516,84 +361,66 @@ get spool messages
 =end
 
   def self.spool_list(timestamp, current_user_id)
-    path = "#{@path}/spool/"
-    FileUtils.mkpath path
-
     data      = []
     to_delete = []
-    files     = []
-    Dir.foreach(path) do |entry|
-      next if entry == '.'
-      next if entry == '..'
+    @store.each_spool do |message|
+      message_parsed = {}
+      begin
+        spool = JSON.parse(message)
+        message_parsed = JSON.parse(spool['msg'])
+      rescue => e
+        log('error', "can't parse spool message: #{message}, #{e.inspect}")
+        to_delete.push message
+        next
+      end
 
-      files.push entry
-    end
-    files.sort.each do |entry|
-      filename = "#{path}/#{entry}"
-      next if !File.exist?(filename)
+      # ignore message older then 48h
+      if spool['timestamp'] + (2 * 86_400) < Time.now.utc.to_i
+        to_delete.push message
+        next
+      end
 
-      File.open(filename, 'rb') do |file|
-        file.flock(File::LOCK_SH)
-        message = file.read
-        file.flock(File::LOCK_UN)
-        message_parsed = {}
-        begin
-          spool = JSON.parse(message)
-          message_parsed = JSON.parse(spool['msg'])
-        rescue => e
-          log('error', "can't parse spool message: #{message}, #{e.inspect}")
-          to_delete.push "#{path}/#{entry}"
-          next
-        end
+      # add spool attribute to push spool info to clients
+      message_parsed['spool'] = true
 
-        # ignore message older then 48h
-        if spool['timestamp'] + (2 * 86_400) < Time.now.utc.to_i
-          to_delete.push "#{path}/#{entry}"
-          next
-        end
+      # only send not already older messages
+      if !timestamp || timestamp < spool['timestamp']
 
-        # add spool attribute to push spool info to clients
-        message_parsed['spool'] = true
+        # spool to recipient list
+        if message_parsed['recipient'] && message_parsed['recipient']['user_id']
 
-        # only send not already older messages
-        if !timestamp || timestamp < spool['timestamp']
+          message_parsed['recipient']['user_id'].each do |user_id|
 
-          # spool to recipient list
-          if message_parsed['recipient'] && message_parsed['recipient']['user_id']
+            next if current_user_id != user_id
 
-            message_parsed['recipient']['user_id'].each do |user_id|
-
-              next if current_user_id != user_id
-
-              message = message_parsed
-              if message_parsed['event'] == 'broadcast'
-                message = message_parsed['data']
-              end
-
-              item = {
-                type:    'direct',
-                message: message,
-              }
-              data.push item
-            end
-
-          # spool to every client
-          else
             message = message_parsed
             if message_parsed['event'] == 'broadcast'
               message = message_parsed['data']
             end
+
             item = {
-              type:    'broadcast',
+              type:    'direct',
               message: message,
             }
             data.push item
           end
+
+        # spool to every client
+        else
+          message = message_parsed
+          if message_parsed['event'] == 'broadcast'
+            message = message_parsed['data']
+          end
+          item = {
+            type:    'broadcast',
+            message: message,
+          }
+          data.push item
         end
       end
     end
     to_delete.each do |file|
-      File.delete(file)
+      @store.remove_from_spool(file)
     end
     data
   end
@@ -607,16 +434,10 @@ delete spool messages
 =end
 
   def self.spool_delete
-    path = "#{@path}/spool/"
-    FileUtils.rm_rf path
+    @store.clear_spool
   end
 
   def self.jobs(node_id = nil)
-
-    # just make sure that spool path exists
-    if !File.exist?(@path)
-      FileUtils.mkpath(@path)
-    end
 
     # dispatch sessions
     if node_id.blank? && ENV['ZAMMAD_SESSION_JOBS_CONCURRENT'].to_i.positive?

--- a/lib/sessions.rb
+++ b/lib/sessions.rb
@@ -1,9 +1,9 @@
 module Sessions
 
   @store = case Rails.application.config.websocket_session_store
-    when :redis then Sessions::Store::Redis.new
-    else Sessions::Store::File.new 
-  end
+           when :redis then Sessions::Store::Redis.new
+           else Sessions::Store::File.new
+           end
 
   # create global vars for threads
   @@client_threads = {} # rubocop:disable Style/ClassVars

--- a/lib/sessions/node.rb
+++ b/lib/sessions/node.rb
@@ -1,13 +1,9 @@
 module Sessions::Node
 
-  # get application root directory
-  @root = Dir.pwd.to_s
-  if @root.blank? || @root == '/'
-    @root = Rails.root
+  @store = case Rails.application.config.websocket_session_store
+    when :redis then Sessions::Store::Redis.new
+    else Sessions::Store::File.new 
   end
-
-  # get working directories
-  @path = "#{@root}/tmp/session_node_#{Rails.env}"
 
   def self.session_assigne(client_id, force = false)
 
@@ -39,90 +35,33 @@ module Sessions::Node
   end
 
   def self.cleanup
-    FileUtils.rm_rf @path
+    @store.clear_nodes
   end
 
   def self.registered
-    path = "#{@path}/*.status"
-    nodes = []
-    files = Dir.glob(path)
-    files.each do |filename|
-      File.open(filename, 'rb') do |file|
-        file.flock(File::LOCK_SH)
-        content = file.read
-        file.flock(File::LOCK_UN)
-        begin
-          data = JSON.parse(content)
-          nodes.push data
-        rescue => e
-          Rails.logger.error "can't parse status file #{filename}, #{e.inspect}"
-          #to_delete.push "#{path}/#{entry}"
-          #next
-        end
-      end
-    end
-    nodes
+    @store.get_nodes
   end
 
   def self.register(node_id)
-    if !File.exist?(@path)
-      FileUtils.mkpath @path
-    end
-
-    status_file = "#{@path}/#{node_id}.status"
-
-    # write node status file
     data = {
       updated_at_human: Time.now.utc,
       updated_at:       Time.now.utc.to_i,
       node_id:          node_id.to_s,
       pid:              $PROCESS_ID,
     }
-    content = data.to_json
-
-    # store session data in session file
-    File.open(status_file, 'wb') do |file|
-      file.write content
-    end
-
+    @store.add_node node_id, data
   end
 
   def self.stats
-    # read node sessions
-    path = "#{@path}/*.session"
-
     sessions = {}
-    files = Dir.glob(path)
-    files.each do |filename|
-      File.open(filename, 'rb') do |file|
-        file.flock(File::LOCK_SH)
-        content = file.read
-        file.flock(File::LOCK_UN)
-        begin
-          next if content.blank?
-
-          data = JSON.parse(content)
-          next if data.blank?
-          next if data['client_id'].blank?
-
-          sessions[data['client_id']] = data['node_id']
-        rescue => e
-          Rails.logger.error "can't parse session file #{filename}, #{e.inspect}"
-          #to_delete.push "#{path}/#{entry}"
-          #next
-        end
-      end
+    @store.each_node_session do |data|
+      next if data['client_id'].blank?
+      sessions[data['client_id']] = data['node_id']
     end
     sessions
   end
 
   def self.sessions_for(node_id, client_id)
-    if !File.exist?(@path)
-      FileUtils.mkpath @path
-    end
-
-    status_file = "#{@path}/#{node_id}.#{client_id}.session"
-
     # write node status file
     data = {
       updated_at_human: Time.now.utc,
@@ -131,42 +70,15 @@ module Sessions::Node
       client_id:        client_id.to_s,
       pid:              $PROCESS_ID,
     }
-    content = data.to_json
-
-    # store session data in session file
-    File.open(status_file, 'wb') do |file|
-      file.write content
-    end
-
+    @store.create_node_session node_id, client_id, data
   end
 
   def self.sessions_by(node_id, force = false)
-
-    # read node sessions
-    path = "#{@path}/#{node_id}.*.session"
-
     sessions = []
-    files = Dir.glob(path)
-    files.each do |filename|
-      File.open(filename, 'rb') do |file|
-        file.flock(File::LOCK_SH)
-        content = file.read
-        file.flock(File::LOCK_UN)
-        begin
-          next if content.blank?
-
-          data = JSON.parse(content)
-          next if data.blank?
-          next if data['client_id'].blank?
-          next if !Sessions.session_exists?(data['client_id']) && force == false
-
-          sessions.push data['client_id']
-        rescue => e
-          Rails.logger.error "can't parse session file #{filename}, #{e.inspect}"
-          #to_delete.push "#{path}/#{entry}"
-          #next
-        end
-      end
+    @store.each_session_by_node(node_id) do |data|
+      next if data['client_id'].blank?
+      next if !Sessions.session_exists?(data['client_id']) && force == false
+      sessions.push data['client_id']
     end
     sessions
   end

--- a/lib/sessions/node.rb
+++ b/lib/sessions/node.rb
@@ -1,9 +1,9 @@
 module Sessions::Node
 
   @store = case Rails.application.config.websocket_session_store
-    when :redis then Sessions::Store::Redis.new
-    else Sessions::Store::File.new 
-  end
+           when :redis then Sessions::Store::Redis.new
+           else Sessions::Store::File.new
+           end
 
   def self.session_assigne(client_id, force = false)
 
@@ -39,7 +39,7 @@ module Sessions::Node
   end
 
   def self.registered
-    @store.get_nodes
+    @store.nodes
   end
 
   def self.register(node_id)
@@ -56,6 +56,7 @@ module Sessions::Node
     sessions = {}
     @store.each_node_session do |data|
       next if data['client_id'].blank?
+
       sessions[data['client_id']] = data['node_id']
     end
     sessions
@@ -78,6 +79,7 @@ module Sessions::Node
     @store.each_session_by_node(node_id) do |data|
       next if data['client_id'].blank?
       next if !Sessions.session_exists?(data['client_id']) && force == false
+
       sessions.push data['client_id']
     end
     sessions

--- a/lib/sessions/store/file.rb
+++ b/lib/sessions/store/file.rb
@@ -1,0 +1,240 @@
+class Sessions::Store::File
+  def initialize
+    # get application root directory
+    @root = Dir.pwd.to_s
+    if @root.blank? || @root == '/'
+      @root = Rails.root
+    end
+
+    # get working directories
+    @path = "#{@root}/tmp/websocket_#{Rails.env}"
+  end
+
+  def create(client_id, content)
+    path         = "#{@path}/#{client_id}"
+    path_tmp     = "#{@path}/tmp/#{client_id}"
+    session_file = "#{path_tmp}/session"
+
+    # store session data in session file
+    FileUtils.mkpath path_tmp
+    File.open(session_file, 'wb') do |file|
+      file.write content
+    end
+
+    # destroy old session if needed
+    if File.exist?(path)
+      destroy(client_id)
+    end
+
+    # move to destination directory
+    FileUtils.mv(path_tmp, path)
+  end
+
+  def sessions
+    path = "#{@path}/"
+
+    # just make sure that spool path exists
+    if !File.exist?(path)
+      FileUtils.mkpath path
+    end
+
+    data = []
+    Dir.foreach(path) do |entry|
+      next if entry == '.'
+      next if entry == '..'
+      next if entry == 'tmp'
+      next if entry == 'spool'
+
+      data.push entry.to_s
+    end
+    data
+  end
+
+  def session_exists?(client_id)
+    session_dir = "#{@path}/#{client_id}"
+    return false if !File.exist?(session_dir)
+
+    session_file = "#{session_dir}/session"
+    return false if !File.exist?(session_file)
+
+    true
+  end
+
+  def destroy(client_id)
+    path = "#{@path}/#{client_id}"
+    FileUtils.rm_rf path
+  end
+  
+  def set(client_id, data)
+    path = "#{@path}/#{client_id}"
+    File.open("#{path}/session", 'wb' ) do |file|
+      file.flock(File::LOCK_EX)
+      file.write data.to_json
+      file.flock(File::LOCK_UN)
+    end
+  end
+
+  def get(client_id)
+    session_dir  = "#{@path}/#{client_id}"
+    session_file = "#{session_dir}/session"
+    data         = nil
+
+    # if no session dir exists, session got destoried
+    if !File.exist?(session_dir)
+      destroy(client_id)
+      Sessions.log('debug', "missing session directory #{session_dir} for '#{client_id}', remove session.")
+      return
+    end
+
+    # if only session file is missing, then it's an error behavior
+    if !File.exist?(session_file)
+      destroy(client_id)
+      Sessions.log('error', "missing session file for '#{client_id}', remove session.")
+      return
+    end
+    begin
+      File.open(session_file, 'rb') do |file|
+        file.flock(File::LOCK_SH)
+        all = file.read
+        file.flock(File::LOCK_UN)
+        data_json = JSON.parse(all)
+        if data_json
+          data        = Sessions.symbolize_keys(data_json)
+          data[:user] = data_json['user'] # for compat. reasons
+        end
+      end
+    rescue => e
+      Sessions.log('error', e.inspect)
+      destroy(client_id)
+      Sessions.log('error', "error in reading/parsing session file '#{session_file}', remove session.")
+      return
+    end
+    data
+  end
+
+  def send_data(client_id, data)
+    path     = "#{@path}/#{client_id}/"
+    filename = "send-#{Time.now.utc.to_f}"
+    location = "#{path}#{filename}"
+    check    = true
+    count    = 0
+    while check
+      if File.exist?(location)
+        count += 1
+        location = "#{path}#{filename}-#{count}"
+      else
+        check = false
+      end
+    end
+    return false if !File.directory? path
+
+    begin
+      File.open(location, 'wb') do |file|
+        file.flock(File::LOCK_EX)
+        file.write data.to_json
+        file.flock(File::LOCK_UN)
+        file.close
+      end
+    rescue => e
+      Sessions.log('error', e.inspect)
+      Sessions.log('error', "error in writing message file '#{location}'")
+      return false
+    end
+    true
+  end
+
+  def queue(client_id)
+    path  = "#{@path}/#{client_id}/"
+    data  = []
+    files = []
+    Dir.foreach(path) do |entry|
+      next if entry == '.'
+      next if entry == '..'
+
+      files.push entry
+    end
+    files.sort.each do |entry|
+      next if !entry.start_with?('send')
+
+      message = queue_file_read(path, entry)
+      next if !message
+
+      data.push message
+    end
+    data
+  end
+
+  def cleanup
+    return true if !File.exist?(@path)
+
+    FileUtils.rm_rf @path
+    true
+  end
+
+  def add_to_spool(data)
+    path = "#{@path}/spool/"
+    FileUtils.mkpath path
+
+    file_path = "#{path}/#{Time.now.utc.to_f}-#{rand(99_999)}"
+    File.open(file_path, 'wb') do |file|
+      file.flock(File::LOCK_EX)
+      file.write data.to_json
+      file.flock(File::LOCK_UN)
+    end
+  end
+
+  def each_spool(&block)
+    path = "#{@path}/spool/"
+    FileUtils.mkpath path
+
+    files     = []
+    Dir.foreach(path) do |entry|
+      next if entry == '.'
+      next if entry == '..'
+
+      files.push entry
+    end
+    files.sort.each do |entry|
+      filename = "#{path}/#{entry}"
+      next if !File.exist?(filename)
+
+      File.open(filename, 'rb') do |file|
+        file.flock(File::LOCK_SH)
+        message = file.read
+        file.flock(File::LOCK_UN)
+
+        block.call message
+      end
+    end
+  end
+
+  def remove_from_spool(entry)
+    File.remove "#{path}/#{entry}"
+  end
+
+  def clear_spool
+    path = "#{@path}/spool/"
+    FileUtils.rm_rf path
+  end
+
+  private
+
+  def queue_file_read(path, filename)
+    location = "#{path}#{filename}"
+    message = ''
+    File.open(location, 'rb') do |file|
+      file.flock(File::LOCK_EX)
+      message = file.read
+      file.flock(File::LOCK_UN)
+    end
+    File.delete(location)
+    return if message.blank?
+
+    begin
+      JSON.parse(message)
+    rescue => e
+      Sessions.log('error', "can't parse queue message: #{message}, #{e.inspect}")
+      nil
+    end
+  end
+end

--- a/lib/sessions/store/redis.rb
+++ b/lib/sessions/store/redis.rb
@@ -1,0 +1,97 @@
+class Sessions::Store::Redis
+  SESSIONS_KEY = "sessions"
+  MESSAGES_KEY = "messages"
+  SPOOL_KEY = "spool"
+
+  def initialize
+    @redis = Redis.new
+  end
+
+  def create(client_id, data)
+    @redis.set client_session_key(client_id), data
+    @redis.sadd SESSIONS_KEY, client_id
+  end
+
+  def sessions
+    @redis.smembers SESSIONS_KEY
+  end
+
+  def session_exists?(client_id)
+    @redis.sismember SESSIONS_KEY, client_id
+  end
+
+  def destroy(client_id)
+    @redis.srem SESSIONS_KEY, client_id
+    @redis.del client_session_key(client_id)
+    @redis.del client_messages_key(client_id)
+  end
+
+  def set(client_id, data)
+    @redis.set client_session_key(client_id), data.to_json
+  end
+
+  def get(client_id)
+    data         = nil
+
+    # if only session is missing, then it's an error behavior
+    session = @redis.get client_session_key(client_id)
+    if !session
+      destroy(client_id)
+      Sessions.log('error', "missing session value for '#{client_id}', removing session.")
+      return
+    end
+
+    data_json = JSON.parse(session)
+    if data_json
+      data        = Sessions.symbolize_keys(data_json)
+      data[:user] = data_json['user'] # for compat. reasons
+    end
+
+    data
+  end
+
+  def send_data(client_id, data)
+    @redis.rpush(client_messages_key(client_id), data.to_json) > 0
+  end
+
+  def queue(client_id)
+    data  = []
+    while item = @redis.lpop(client_messages_key(client_id))
+      data.push JSON.parse(item)
+    end
+    data
+  end
+
+  def cleanup
+    @redis.flushall
+    true
+  end
+
+  def add_to_spool(data)
+    @redis.rpush SPOOL_KEY, data.to_json
+  end
+
+  def each_spool(&block)
+    @redis.lrange(SPOOL_KEY, 0, -1).each do |message|
+      block.call message
+    end
+  end
+
+  def remove_from_spool(message)
+    @redis.lrem SPOOL_KEY, 1, message
+  end
+
+  def clear_spool
+    @redis.del SPOOL_KEY
+  end
+
+  protected
+
+  def client_session_key(client_id)
+    "#{SESSIONS_KEY}/#{client_id}"
+  end
+
+  def client_messages_key(client_id)
+    "#{MESSAGES_KEY}/#{client_id}"
+  end
+end


### PR DESCRIPTION
As [discussed on the community forum](https://community.zammad.org/t/overviews-and-notifications-not-pushed-updated-via-websocket/5854), it is currently a bit of a struggle to make a Zammad work on a multi-machine cluster. The main problem is the use of a shared directory as a kind of message queue for the sessions. Sharing that directory via a distributed filesystem turns out to be really problematic.

A much more suitable tool for this kind of work is Redis. I thus refactored the sessions module to allow for different store backends and implemented a Redis backend in addition to the file backend. 

In my local tests, this seems to work well. I still have to try this out in production though.

I am a bit unsure with the naming (is `store` the right term to use for the backends?). Also, I did not yet have a look at the tests in order to see if or how the new backend can be tested.

In order to use this, you need to set the env variable `REDIS_URL` to a running Redis server for the Zammad services.

Let me know what you think of this.