### PR TITLE
replacing find -mtime with find -mmin

### DIFF
--- a/contrib/backup/functions
+++ b/contrib/backup/functions
@@ -16,7 +16,7 @@ function get_backup_date () {
 }
 
 function delete_old_backups () {
-  test -d ${BACKUP_DIR} && find ${BACKUP_DIR}/*_zammad_*.gz -type f -mtime +${HOLD_DAYS} -delete
+  test -d ${BACKUP_DIR} && find ${BACKUP_DIR}/*_zammad_*.gz -type f -mmin +$(((60*24)*${HOLD_DAYS})) -delete
 }
 
 function get_db_credentials () {


### PR DESCRIPTION
Changing the find parameter for deleting old backups would make things more intuitive.

mtime +1 returns files accessed two days ago.
mmin +$(((60*24)*1)) returns files accessed 1 day (1440mins) ago.

Therefore you're configuring your HOLD_DAYS let's say to "3" expecting to keep backups for three days but it's keeping backups for four days right now.
mmin behaves more accurate to what the user would expect.

see find man (https://linux.die.net/man/1/find) for details

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
