### PR TITLE
Accept 2xx as response for requests in UserAgent

### DIFF
--- a/lib/user_agent.rb
+++ b/lib/user_agent.rb
@@ -472,7 +472,7 @@ returns
 
       url = response['location']
       return get(url, params, options, count - 1)
-    when Net::HTTPOK, Net::HTTPCreated
+    when Net::HTTPSuccess
       data = nil
       if options[:json] && !options[:jsonParseDisable] && response.body
         data = JSON.parse(response.body)


### PR DESCRIPTION
Stumbled upon a case, where the backend responded with 202 (Accepted), as this request was triggering an asynchronous process.
Since Zammad didn't accept 202, the Webhook was triggered multiple times and the health check endpoint complained about failing Webhooks.

Zammad should accept all 2xx success messages.