### PR TITLE
Fixes #3137 - New email account expert view cannot be opened without …

### DIFF
--- a/app/assets/javascripts/app/controllers/_channel/email.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/email.coffee
@@ -410,6 +410,15 @@ class ChannelEmailAccountWizard extends App.ControllerWizardModal
       { name: 'options::keep_on_server',  display: 'Keep messages on server', tag: 'boolean', null: true, options: { true: 'yes', false: 'no' }, translate: true, default: false, item_class: 'formGroup--halfSize' },
     ]
 
+    if !@channel
+      #Email Inbound form opened from new email wizard, show full settings
+      configureAttributesInbound = [
+        { name: 'options::realname', display: 'Organization & Department Name', tag: 'input',  type: 'text', limit: 160, null: false, placeholder: 'Organization Support', autocomplete: 'off' },
+        { name: 'options::email',    display: 'Email',    tag: 'input',  type: 'email', limit: 120, null: false, placeholder: 'support@example.com', autocapitalize: false, autocomplete: 'off' },
+        { name: 'options::group_id', display: 'Destination Group', tag: 'select', null: false, relation: 'Group', nulloption: true },
+      ].concat(configureAttributesInbound)
+
+
     showHideFolder = (params, attribute, attributes, classname, form, ui) ->
       return if !params
       if params.adapter is 'imap'
@@ -484,18 +493,12 @@ class ChannelEmailAccountWizard extends App.ControllerWizardModal
       params.channel_id = @channel.id
 
     if $(e.currentTarget).hasClass('js-expert')
-
-      # validate form
-      errors = @formMeta.validate(params)
-      if errors
-        delete errors.password
-      if !_.isEmpty(errors)
-        @formValidate(form: e.target, errors: errors)
-        return
-
       @showSlide('js-inbound')
       @$('.js-inbound [name="options::user"]').val(params.email)
       @$('.js-inbound [name="options::password"]').val(params.password)
+      @$('.js-inbound [name="options::email"]').val(params.email)
+      @$('.js-inbound [name="options::realname"]').val(params.realname)
+      @$('.js-inbound [name="options::group_id"]').val(params.group_id)
       return
 
     @disable(e)
@@ -528,6 +531,9 @@ class ChannelEmailAccountWizard extends App.ControllerWizardModal
           @showAlert('js-inbound', 'Unable to detect your server settings. Manual configuration needed.')
           @$('.js-inbound [name="options::user"]').val(@account['meta']['email'])
           @$('.js-inbound [name="options::password"]').val(@account['meta']['password'])
+          @$('.js-inbound [name="options::email"]').val(@account['meta']['email'])
+          @$('.js-inbound [name="options::realname"]').val(@account['meta']['realname'])
+          @$('.js-inbound [name="options::group_id"]').val(@account['meta']['group_id'])
 
         @enable(e)
       error: =>
@@ -543,6 +549,11 @@ class ChannelEmailAccountWizard extends App.ControllerWizardModal
 
     if params.options && params.options.password is @passwordPlaceholder
       params.options.password = @inboundPassword
+
+    # Update meta as the one from AttributesBase could be outdated
+    @account.meta.realname = params.options.realname
+    @account.meta.email = params.options.email
+    @account.meta.group_id = params.options.group_id
 
     # let backend know about the channel
     if @channel


### PR DESCRIPTION
…filling in all fields

This fix tries to balance:

1. Improving the user experience when a user wants to input
   expert/advanced settings directly.
2. Do as little code changes as possible.
3. Leave the internal state as is.

A such, the fix assumes that the 'Experts' form is an extension of the
base one instead of being additional settings and shows all the relevant
settings from the base form in the expert view too. This allows the user
to directly open the experts view when adding a new email. Already entered
values are not lost and related fields are filled in.

Pros of this approach:

- In the basic and expert case, the user has only one form to fill in
  with all the relevant settings.
- The validation of the form does not need special handling.
- The user gets immediate feedback about validation errors.
- Housekeeping on the code side is minimal.

Cons:

- An additional array, which is semantically but not syntactically linked
  to the `configureAttributesBase` array is created (email.coffee:416-418)
- `@account.meta` needs manual update to be in sync (email.coffee:553-556)

The last con could be not needed but because of (3) and my unfamiliarity
with the implications of having `@account.meta` out-of-sync, I opt-in
to update it.

Another approach considered was moving the validation of both forms to
occur when the 'submit' button of the expert form was pressed. This would
get rid of the mentioned cons but introduce jarring behaviour for the user
when a base form validation failed on the expert view and the modal would
change back.

Potential issues:

- Going back from the expert view does not carry over related settings
  as it does going from the base view to the expert view. This is in-line
  with the behaviour before this fix.
- Going to the expert view does not use its own callback but reuses
  `probeBasedOnIntro` (email.coffee:484)
- Changing the 'SSL/STARTTLS' setting to 'yes' in the expert view does
  not set the port if the port is 143 (the default for no SSL).
  Changing the setting to 'no' does set the port.

The last point is technically not in scope of the issue and the other
points would need more code changes than strictly necessary for
functionality, violating (2). However, those small further
improvements could result in a net win and could be added with further
commits.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
