### PR TITLE
LDAP: apply user filter during auth on bind

### DIFF
--- a/lib/ldap/user.rb
+++ b/lib/ldap/user.rb
@@ -95,7 +95,7 @@ class Ldap
     def valid?(username, password)
       bind_success = @ldap.connection.bind_as(
         base:     @ldap.base_dn,
-        filter:   "(#{login_attribute}=#{username})",
+        filter:   @user_filter ? "(&(#{login_attribute}=#{username})#{@user_filter})" : "(#{login_attribute}=#{username})",
         password: password
       )
 
@@ -179,6 +179,7 @@ class Ldap
 
       @uid_attribute = config[:uid_attribute]
       @filter        = config[:filter]
+      @user_filter   = config[:user_filter]
     end
   end
 end


### PR DESCRIPTION
Previously the user filter was not used for the login attempt.
Thus in case of multiple LDAP entries matching the login name (e.g. `cn=foo`), the wrong entry could be used (by default the first result is attempted).

In our case we have an LDAP tree with an "identity" and an "account" for each user (both residing in different branches of the LDAP tree).

The `user_filter` needs to be applied during login attempts in order to avoid this ambiguity.

Please note, that I am can barely parse ruby. Thus you may feel tempted to use a more conventional style for this change. You are very welcome to do so.