### PR TITLE
Stop the execution of the backup script if a command or pipeline has an error

### DIFF
--- a/contrib/backup/zammad_backup.sh
+++ b/contrib/backup/zammad_backup.sh
@@ -3,6 +3,9 @@
 # zammad backup script
 #
 
+# Stop the execution of the script if a command or pipeline has an error
+set -e
+
 # shellcheck disable=SC2046
 BACKUP_SCRIPT_PATH="$(dirname $(realpath $0))"
 


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->


Hi,


I was surprised by the log output below:
```
# Zammad backup started - Sat Sep 18 03:35:01 CEST 2021!

creating file backup...
creating postgresql backup...

gzip: stdout: No space left on device

# Zammad backuped successfully - Sat Sep 18 04:00:59 CEST 2021!
```

The 'No space left on device' is obviously mine to fix, but the 'Zammad backuped successfully' line below it annoyed me ;)

Adding `set -e` should prevent that from happening.
