### PR TITLE
Fix postinstall.sh getting es_url

### DIFF
--- a/contrib/packager.io/functions
+++ b/contrib/packager.io/functions
@@ -228,7 +228,7 @@ function create_webserver_config () {
 function setup_elasticsearch () {
   echo "# Configuring Elasticsearch..."
 
-  ES_CONNECTION="$(zammad run rails r "puts Setting.get('es_url')"| tail -n 1 2>> /dev/null)"
+  ES_CONNECTION="$(zammad run rails r "puts '',Setting.get('es_url')"| tail -n 1 2>> /dev/null)"
 
   if [ -z "${ES_CONNECTION}" ]; then
     echo "-- Nevermind, no es_url is set, leaving Elasticsearch untouched ...!"


### PR DESCRIPTION
Hi,

This fixes #2674.

During `postinstall.sh`, the following command is executed :
`zammad run rails r "puts Setting.get('es_url')"`

Which can lead to the following output :
```
Warning: Database config value 'max_allowed_packet' less than Zammad setting 'Maximum Email Size'
Zammad will fail to process emails (both incoming and outgoing)
larger than the value of 'max_allowed_packet' (16MB).
Please increase this value in your MariaDB configuration accordingly.
http://127.0.0.1:9200
```
However, as a warning, the first 4 lines are yellow-coloured, which leads to some invisible characters at the beginning of the last line :
`^[[0mhttp://127.0.0.1:9200`

This PR simply gets ride of them adding a newline before `es_url` output.

Post install script will now run flawlessly.

Thx 👍