### PR TITLE
Wrong translation on Turkish

### DIFF
--- a/i18n/zammad.tr.po
+++ b/i18n/zammad.tr.po
@@ -11302,9 +11302,7 @@ msgstr ""
 msgid ""
 "You're already registered with your email address if you've been in touch "
 "with our support team."
-msgstr ""
-"IKCU Atatürk Eğitim Ve Araştırma Hastanesi Bilgi İşlem Arıza Bildirim "
-"Uygulaması"
+msgstr "Eğer destek ekibimiz ile görüştüyseniz mail adresiniz sistemde kayıtlıdır."
 
 #: app/controllers/first_steps_controller.rb
 msgid "Your Email Configuration"


### PR DESCRIPTION
This translation was false. Someone added a hospital name to the footer. The part was "IKCU Atatürk Eğitim Ve Araştırma Hastanesi". This is the correct translation.

<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
