### PR TITLE
Make form style for `customer`-input consistent

### DIFF
--- a/app/assets/javascripts/app/views/generic/object_search/input.jst.eco
+++ b/app/assets/javascripts/app/views/generic/object_search/input.jst.eco
@@ -3,7 +3,7 @@
   <% if @attribute.multiple: %>
     <%- @tokens %>
   <% end %>
-  <input name="<%- @attribute.name %>_completion" class="user-select token-input js-objectSelect" autocapitalize="off" placeholder="<%- @Ti(@attribute.placeholder) %>" autocomplete="off" <%= @attribute.autofocus %> role="textbox" aria-autocomplete="list" value="<%= @name %>" aria-haspopup="true">
+  <input name="<%- @attribute.name %>_completion" class="user-select token-input js-objectSelect form-control" autocapitalize="off" placeholder="<%- @Ti(@attribute.placeholder) %>" autocomplete="off" <%= @attribute.autofocus %> role="textbox" aria-autocomplete="list" value="<%= @name %>" aria-haspopup="true">
   <% if @attribute.disableCreateObject isnt true: %><%- @Icon('arrow-down', 'dropdown-arrow') %><% end %>
 </div>
 


### PR DESCRIPTION
Set parameters like color and background with form-control class.

This template uses the `form-control` it as well without a problem.
https://github.com/zammad/zammad/blob/develop/app/assets/javascripts/app/views/layout_ref/chat_to_ticket.jst.eco

Before
![image](https://user-images.githubusercontent.com/1295633/145380057-92685e1f-b6dd-4225-b53b-1c2a8548d16c.png)


After
![image](https://user-images.githubusercontent.com/1295633/145380001-58952813-37c6-4a6c-a398-1ba9e9311552.png)

I entered the field, so you can see the position from complete is fine.

(The line end was done by GitHub editor)