### PR TITLE
Fix knowledge base layout and spacing

### DIFF
--- a/app/assets/stylesheets/knowledge_base.scss
+++ b/app/assets/stylesheets/knowledge_base.scss
@@ -457,7 +457,7 @@ b {
 
     ul,
     ol {
-      @include bidi-style(padding-left, 1.5em, padding-right, 0);
+      @include bidi-style(padding-left, 0, padding-right, 0);
     }
   }
 }


### PR DESCRIPTION
## Issue Description
Knowledge Base should have the same layout and spacing from LTR and RTL.
The knowledge base UI has an unwanted gap.

[Issue Link]()https://github.com/zammad/zammad/issues/3925

## Proposed Solution
The CSS property `padding-left` for the `ul` and `ol` elements in the knowledge_base.scss is moving the component of the page causing the gap, setting it to `0` should fix the issue.

## Screenshots  <!-- Optional, very helpful for the reviewer colleagues from other teams -->

### Before

![zammad1](https://user-images.githubusercontent.com/44624138/155170709-b3d23860-f85c-4f42-85d5-061aa3a7beb7.png)
![zammad2](https://user-images.githubusercontent.com/44624138/155173096-cbef3379-f06e-4beb-93cd-c3be73047820.png)

### After
- RTL
![screenshot (3)](https://user-images.githubusercontent.com/44624138/155172383-0721b8a2-d424-4320-ab5f-8fd62294ba98.png)
![screenshot (1)](https://user-images.githubusercontent.com/44624138/155173513-18bf8973-72b7-4e20-b871-9de11c40fff4.png)

- LTR
![screenshot (4)](https://user-images.githubusercontent.com/44624138/155172393-9994b683-896f-4640-8758-a26b1e890c6d.png)
![screenshot (2)](https://user-images.githubusercontent.com/44624138/155173519-c50f07c4-af72-4880-bb79-add51611a498.png)

## Code Changes
- Modify knowledge_base.scss file

Note: There might be possible regression I don't know of but I tried to check and there's none known to my knowledge