### PR TITLE
Translation introduction text shows wrong keyboard shortcut 

### DIFF
--- a/app/assets/javascripts/app/controllers/translation.coffee
+++ b/app/assets/javascripts/app/controllers/translation.coffee
@@ -27,7 +27,7 @@ class Translation extends App.ControllerSubContent
         currentLanguage = locale.name
     @html App.view('translation/index')(
       currentLanguage: currentLanguage
-      inlineTranslationKey: App.Browser.hotkeys().split('+').reverse() + ' t'
+      inlineTranslationKey: App.Browser.hotkeys().split('+').reverse().join("+") + '+t'
     )
     @load('render')
 

--- a/app/assets/javascripts/app/controllers/translation.coffee
+++ b/app/assets/javascripts/app/controllers/translation.coffee
@@ -27,6 +27,7 @@ class Translation extends App.ControllerSubContent
         currentLanguage = locale.name
     @html App.view('translation/index')(
       currentLanguage: currentLanguage
+      inlineTranslationKey: App.Browser.hotkeys().split('+').reverse() + '+t'
     )
     @load('render')
 

--- a/app/assets/javascripts/app/controllers/translation.coffee
+++ b/app/assets/javascripts/app/controllers/translation.coffee
@@ -27,7 +27,7 @@ class Translation extends App.ControllerSubContent
         currentLanguage = locale.name
     @html App.view('translation/index')(
       currentLanguage: currentLanguage
-      inlineTranslationKey: App.Browser.hotkeys().split('+').reverse() + '+t'
+      inlineTranslationKey: App.Browser.hotkeys().split('+').reverse() + ' t'
     )
     @load('render')
 

--- a/app/assets/javascripts/app/views/translation/index.jst.eco
+++ b/app/assets/javascripts/app/views/translation/index.jst.eco
@@ -18,7 +18,7 @@
 
   <div class="box box--message">
     <h2><%- @T('Inline translation') %></h2>
-    <p><%- @T('To make translations easier you can enable and disable the inline translation feature by pressing ') %><%= @inlineTranslationKey%></p>
+    <p><%- @T('To make translations easier you can enable and disable the inline translation feature by pressing "%s".', @inlineTranslationKey ) %></p>
     <p><%- @T('Text with disabled inline translations looks like') %> <button class="btn btn-primary"><%- @Ti('Some Text') %></button></p>
     <p><%- @T('Text with enabled inline translations looks like') %> <button class="btn btn-primary"><span class="translation" contenteditable="true"><%- @Ti('Some Text') %></button></span></p>
     <p><%- @T('Just click into the highlighted area and update the words right there. Enjoy!') %></p>

--- a/app/assets/javascripts/app/views/translation/index.jst.eco
+++ b/app/assets/javascripts/app/views/translation/index.jst.eco
@@ -18,7 +18,7 @@
 
   <div class="box box--message">
     <h2><%- @T('Inline translation') %></h2>
-    <p><%- @T('To make translations easier you can enable and disable the inline translation feature by pressing "%s".', 'ctrl+alt+t') %></p>
+    <p><%- @T('To make translations easier you can enable and disable the inline translation feature by pressing ') %><%= @inlineTranslationKey%></p>
     <p><%- @T('Text with disabled inline translations looks like') %> <button class="btn btn-primary"><%- @Ti('Some Text') %></button></p>
     <p><%- @T('Text with enabled inline translations looks like') %> <button class="btn btn-primary"><span class="translation" contenteditable="true"><%- @Ti('Some Text') %></button></span></p>
     <p><%- @T('Just click into the highlighted area and update the words right there. Enjoy!') %></p>

--- a/spec/system/system/translations_spec.rb
+++ b/spec/system/system/translations_spec.rb
@@ -126,4 +126,15 @@ RSpec.describe 'System > Translations', type: :system do
     end
   end
 
+  context 'when transaltion settings page is visited' do
+    let(:translation_shortkey)  { @inlineTranslationKey }
+
+    it 'shows a dynamic keyboard shortcut according to the OS' do
+      visit '/#system/translation'
+      within :active_content do
+        expect(page).to have_text(translation_shortkey)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
## Issue Description
When opening the translation menu within the admin settings, the introduction text will show the keyboard shortcut for inline translation for macOS, no matter if you're on macOS or not.

[Issue Link]()https://github.com/zammad/zammad/issues/2885

## Proposed Solution
Create a variable for the enable/disable inline translation inside the view template in translation.coffee file, then call it inside the app/assets/javascript/app/view/translation/index.jst.eco file to replace the hardcoded inline translation shortcut.

## Screenshots  <!-- Optional, very helpful for the reviewer colleagues from other teams -->

### Before

![zammad](https://user-images.githubusercontent.com/44624138/155853491-d1c199d4-278c-4efb-9923-be83739da4ef.png)
![zammad3](https://user-images.githubusercontent.com/44624138/155853495-3d2921a9-e0f8-4aab-9179-3431d6557b7d.png)


### After
- MacOS
![screenshot (11)](https://user-images.githubusercontent.com/44624138/155853509-5c8997e5-2554-4f73-b147-1c98695c723b.png)


- Windows / Linux
![screenshot (12)](https://user-images.githubusercontent.com/44624138/155853522-c2e0e075-27bd-4f6f-b362-27f73274cae1.png)


## Code Changes
- Modify translation.coffee file.
- Remove hardcoded shortcut form pp/assets/javascript/app/view/translation/index.jst.eco file.