### PR TITLE
Add notification volume slider

### DIFF
--- a/app/assets/javascripts/app/controllers/_profile/notification.coffee
+++ b/app/assets/javascripts/app/controllers/_profile/notification.coffee
@@ -94,6 +94,7 @@ class ProfileNotification extends App.ControllerSubContent
       groups: groups
       config: config
       sounds: @sounds
+      soundVolume: App.LocalStorage.get('notification_sound_volume', @Session.get('id')) || 1
       notificationSoundEnabled: App.OnlineNotification.soundEnabled()
 
   update: (e) =>
@@ -158,6 +159,9 @@ class ProfileNotification extends App.ControllerSubContent
     else
       params.notification_sound.enabled = true
 
+    if params.notification_sound.volume
+      App.LocalStorage.set('notification_sound_volume', params.notification_sound.volume, App.Session.get('id'))
+
     # get data
     @ajax(
       id:          'preferences'
@@ -194,6 +198,7 @@ class ProfileNotification extends App.ControllerSubContent
     params = @formParam(e.target)
     return if !params.notification_sound
     return if !params.notification_sound.file
-    App.OnlineNotification.play(params.notification_sound.file)
+    return if !params.notification_sound.volume
+    App.OnlineNotification.play(params.notification_sound.file, params.notification_sound.volume)
 
 App.Config.set('Notifications', { prio: 2600, name: __('Notifications'), parent: '#profile', target: '#profile/notifications', permission: ['user_preferences.notifications+ticket.agent'], controller: ProfileNotification }, 'NavBarProfile')

--- a/app/assets/javascripts/app/models/online_notification.coffee
+++ b/app/assets/javascripts/app/models/online_notification.coffee
@@ -7,13 +7,16 @@ class App.OnlineNotification extends App.Model
 
   App.OnlineNotification.play()
 
-  App.OnlineNotification.play('bell.mp3')
+  App.OnlineNotification.play('Bell.mp3')
+
+  App.OnlineNotification.play('Bell.mp3', 0.5)
 
   ###
 
-  @play: (file) ->
+  @play: (file, soundVolume) ->
     if file
       sound = new Audio("assets/sounds/#{file}")
+      sound.volume = soundVolume if soundVolume
       sound.play()
       return
     preferences = App.Session.get('preferences')
@@ -23,6 +26,7 @@ class App.OnlineNotification extends App.Model
     return if sound && !sound.ended
     file = App.OnlineNotification.soundFile()
     sound = new Audio("assets/sounds/#{file}")
+    sound.volume = App.LocalStorage.get('notification_sound_volume', App.Session.get('id')) || 1
     App.Config.set('latest_online_notification_sond', sound)
     sound.play()
 

--- a/app/assets/javascripts/app/views/profile/notification.jst.eco
+++ b/app/assets/javascripts/app/views/profile/notification.jst.eco
@@ -108,6 +108,12 @@
       <%- @T('Play user interface sound effects') %>
     </label>
   </div>
+  <div class="form-group">
+    <div class="formGroup-label">
+      <label for="notification-sound-volume"><%- @T('Notification Volume') %></label>
+    </div>
+     <input class="range-horizontal js-notificationSound" type="range" id="notification-sound-volume" name="notification_sound::volume" min="0.01" max="1" step="0.01" value="<%= @soundVolume %>">
+  </div>
 
   <button type="submit" class="btn btn--primary"><%- @T( 'Submit' ) %></button>
 </form>

--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -14008,3 +14008,11 @@ span.is-disabled {
     }
   }
 }
+
+input[type='range'] {
+  accent-color: hsl(203, 53%, 49%);
+
+  &.range-horizontal {
+    max-width: 360px;
+  }
+}

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -6687,6 +6687,10 @@ msgstr ""
 msgid "Notification Sound"
 msgstr ""
 
+#: app/assets/javascripts/app/views/profile/notification.jst.eco
+msgid "Notification Volume"
+msgstr ""
+
 #: app/assets/javascripts/app/controllers/_plugin/keyboard_shortcuts.coffee
 #: app/assets/javascripts/app/controllers/_profile/notification.coffee
 #: app/assets/javascripts/app/views/profile/notification.jst.eco


### PR DESCRIPTION
Hello! :wave: 

I added a volume slider for notifications as described in this [community post](https://community.zammad.org/t/notification-volume-slider/9061).

![image](https://user-images.githubusercontent.com/6693160/170831866-8f6d0195-e569-4390-ad7a-808f7bcd1b6a.png)

It uses the personal localStorge as different agents might have different audio volume preferences depending on which device they are using.

(Just a note: The PR creation template asked me to run coffeelint, however you've removed this gem in https://github.com/zammad/zammad/commit/6fbdb3ca2abca5e937a3b19701218259254665a8, is this still expected to be run?
Running `coffeelint.rb coffeelint.json -r src/` manually at least seemed to have caused no complaints for this change. :smile: )