### PR TITLE
No need to echo the token in monitoring/health_check

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -40,7 +40,6 @@ curl http://localhost/api/v1/monitoring/health_check?token=XXX
       message: health_status.message,
       issues:  health_status.response.issues,
       actions: health_status.response.actions,
-      token:   token,
     }
     render json: result
   end

--- a/spec/requests/integration/monitoring_spec.rb
+++ b/spec/requests/integration/monitoring_spec.rb
@@ -57,12 +57,6 @@ RSpec.describe 'Monitoring', type: :request, authenticated_as: :admin do
 
     it_behaves_like 'accessible', token: true, admin: true, agent: false
 
-    it 'returns matching token' do
-      make_call
-
-      expect(json_response['token']).to eq access_token
-    end
-
     it 'returns health status' do
       allow_any_instance_of(MonitoringHelper::HealthChecker) # rubocop:disable RSpec/AnyInstance
         .to receive(:response)


### PR DESCRIPTION
I noticed that the token we use for the monitoring Health Check is echoed back in every request.

This causes it to be exposed in the logs on our monitoring servers.

It's not highly critical, but I see no reason why it should be returned in the first place.