### PR TITLE
Update last contact on merge

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -307,6 +307,23 @@ returns
       # which might be a long time ago
       target_ticket.updated_at = Time.zone.now
 
+      # update last contact on target ticket depending on setting or if agent already had responded
+      if Setting.get('ticket_last_contact_behaviour') == 'based_on_customer_reaction' ||
+         target_ticket.agent_responded? || agent_responded?
+        if last_contact_customer_at.to_i > target_ticket.last_contact_customer_at.to_i
+          # set last_contact_at customer
+          target_ticket.last_contact_customer_at = last_contact_customer_at
+        end
+
+        if last_contact_at.to_i > target_ticket.last_contact_at.to_i
+          # set last_contact
+          target_ticket.last_contact_at = last_contact_at
+        end
+
+        # save target ticket
+        target_ticket.save!
+      end
+
       # add merge event to both ticket's history (Issue #2469 - Add information "Ticket merged" to History)
       target_ticket.history_log(
         'received_merge',

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -320,6 +320,11 @@ returns
           target_ticket.last_contact_at = last_contact_at
         end
 
+        if last_contact_agent_at.to_i > target_ticket.last_contact_agent_at.to_i
+          # set last_contact_at agent
+          target_ticket.last_contact_agent_at = last_contact_agent_at
+        end
+
         # save target ticket
         target_ticket.save!
       end

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -333,17 +333,21 @@ RSpec.describe Ticket, type: :model do
           end
 
           it 'when agent already replied on target ticket' do
-            target_ticket['last_contact_agent_at'] = 5.minutes.ago
+            agent_timestamp = 5.minutes.ago
+            target_ticket['last_contact_agent_at'] = agent_timestamp
             target_ticket.save!
             expect { ticket.merge_to(ticket_id: target_ticket.id, user_id: merge_user.id) }
               .to change { target_ticket.reload.last_contact_customer_at }.to(ticket['last_contact_customer_at'])
+            expect(target_ticket.reload.last_contact_agent_at).to be_within(1.minute).of(agent_timestamp)
           end
 
           it 'when agent already replied on origin ticket' do
-            ticket['last_contact_agent_at'] = 5.minutes.ago
+            agent_timestamp = 5.minutes.ago
+            ticket['last_contact_agent_at'] = agent_timestamp
             ticket.save!
             expect { ticket.merge_to(ticket_id: target_ticket.id, user_id: merge_user.id) }
               .to change { target_ticket.reload.last_contact_customer_at }.to(ticket['last_contact_customer_at'])
+            expect(target_ticket.reload.last_contact_agent_at).to be_within(1.minute).of(agent_timestamp)
           end
         end
 
@@ -372,17 +376,21 @@ RSpec.describe Ticket, type: :model do
           end
 
           it 'not when agent already replied on target ticket' do
-            target_ticket['last_contact_agent_at'] = 5.minutes.ago
+            agent_timestamp = 5.minutes.ago
+            target_ticket['last_contact_agent_at'] = agent_timestamp
             target_ticket.save!
             ticket.merge_to(ticket_id: target_ticket.id, user_id: merge_user.id)
             expect(target_ticket.reload.last_contact_customer_at).not_to eq ticket.reload.last_contact_customer_at
+            expect(target_ticket.reload.last_contact_agent_at).to be_within(1.minute).of(agent_timestamp)
           end
 
           it 'not when agent already replied on origin ticket' do
-            ticket['last_contact_agent_at'] = 5.minutes.ago
+            agent_timestamp = 5.minutes.ago
+            ticket['last_contact_agent_at'] = agent_timestamp
             ticket.save!
             ticket.merge_to(ticket_id: target_ticket.id, user_id: merge_user.id)
             expect(target_ticket.reload.last_contact_customer_at).not_to eq ticket.reload.last_contact_customer_at
+            expect(target_ticket.reload.last_contact_agent_at).to be_within(1.minute).of(agent_timestamp)
           end
         end
       end


### PR DESCRIPTION
Hi! :wave: 

In this PR I've adjusted ticket merging to update `last_contact_customer_at` and `last_contact_at` as described in [this community post](https://community.zammad.org/t/update-last-contact-on-ticket-merge-if-using-latest-customer-article-time/9666).

I've also added updating `last_contact_agent_at` as it seemed sensible.

![image](https://user-images.githubusercontent.com/6693160/179417695-03704132-78a5-41ab-8b89-c0d4c0d257c8.png)