### PR TITLE
Fix scrolling image view when using arrow keys

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom.coffee
@@ -337,7 +337,7 @@ class App.TicketZoom extends App.Controller
 
   hide: =>
     @activeState = false
-    $('body > .modal').modal('hide')
+    $('body > .modal').modal('hide') if @shown
     @positionPageHeaderStop()
     @autosaveStop()
     @shortcutNavigationstop()

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
@@ -21,12 +21,12 @@ class App.TicketZoomArticleImageView extends App.ControllerModal
     )
 
   nextRight: =>
-    this.nextElement = @parentElement.closest('.attachment').next('.attachment.attachment--preview')
+    @nextElement = @parentElement.closest('.attachment').next('.attachment.attachment--preview')
     return if @nextElement.length is 0
     @close()
 
   nextLeft: =>
-    this.nextElement = @parentElement.closest('.attachment').prev('.attachment.attachment--preview')
+    @nextElement = @parentElement.closest('.attachment').prev('.attachment.attachment--preview')
     return if @nextElement.length is 0
     @close()
 
@@ -47,7 +47,7 @@ class App.TicketZoomArticleImageView extends App.ControllerModal
     @unbindAll()
 
   onClosed: =>
-    this.nextElement.find('img').trigger('click') if this.nextElement
+    @nextElement.find('img').trigger('click') if @nextElement
 
   unbindAll: ->
     $(document).off('keydown.image_preview')

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
@@ -5,6 +5,7 @@ class App.TicketZoomArticleImageView extends App.ControllerModal
   buttonClass: 'btn--success'
   head: ''
   veryLarge: true
+  nextElement: null
 
   events:
     'submit form':      'submit'
@@ -20,16 +21,14 @@ class App.TicketZoomArticleImageView extends App.ControllerModal
     )
 
   nextRight: =>
-    nextElement = @parentElement.closest('.attachment').next('.attachment.attachment--preview')
-    return if nextElement.length is 0
+    this.nextElement = @parentElement.closest('.attachment').next('.attachment.attachment--preview')
+    return if @nextElement.length is 0
     @close()
-    nextElement.find('img').trigger('click')
 
   nextLeft: =>
-    prevElement = @parentElement.closest('.attachment').prev('.attachment.attachment--preview')
-    return if prevElement.length is 0
+    this.nextElement = @parentElement.closest('.attachment').prev('.attachment.attachment--preview')
+    return if @nextElement.length is 0
     @close()
-    prevElement.find('img').trigger('click')
 
   content: ->
     @image = @image.replace(/view=preview/, 'view=inline')
@@ -40,8 +39,15 @@ class App.TicketZoomArticleImageView extends App.ControllerModal
     url = "#{$(@image).attr('src')}?disposition=attachment"
     window.open(url, '_blank')
 
+  onShow: =>
+    @el.attr('tabindex', '-1')
+    $('.modal').focus()
+
   onClose: =>
     @unbindAll()
+
+  onClosed: =>
+    this.nextElement.find('img').trigger('click') if this.nextElement
 
   unbindAll: ->
     $(document).off('keydown.image_preview')


### PR DESCRIPTION
Hi! :wave: 

This fixes two bugs when switching between multiple image views using arrow keys; one being sometimes the modal not showing a scroll bar (and not being scroll-able) even though it is too tall to fit, and the other not being able to scroll using arrows up and down.

As a note; changing that the next modal only opens on `onClosed` does not seem like the best fix for the scroll bar bug, as it seems to be an underlying bug in the general modal code and potentially is already an issue in other places as well.