### PR TITLE
Feature: make action mailer configurable via environment variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -102,4 +102,17 @@ Rails.application.configure do
   # ignored for Session logging and fall back to localhost
   # see https://github.com/zammad/zammad/issues/742
   config.action_dispatch.trusted_proxies = ['127.0.0.1', '::1']
+
+  # configure action mailer via SMTP_URL environment variable
+  if ENV['SMTP_URL']
+    smtp_url = URI.parse(ENV['SMTP_URL'])
+    smtp_params = Rack::Utils.parse_nested_query(smtp_url.query)
+    config.action_mailer.smtp_settings = {
+      address:              smtp_url.host || 'localhost',
+      port:                 smtp_url.port || 25,
+      user_name:            smtp_url.user,
+      password:             smtp_url.password,
+      enable_starttls_auto: smtp_params['tls'].in?(['true', '1', 1, true, 'True', 'TRUE']),
+    }
+  end
 end


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a Pull Request 😍. Please ensure the following things before creation - thank you!

- Create your Pull Request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Don't run `bundle update`. It's a honorable thought of you but some dependency versions (e.g. pg) are broken 😢 Just use `bundle install` if you introduce new dependencies instead.
- Run `rubocop` and `coffeelint` on your changes to respect the code style guide.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

When I run Zammad in containers [zammad/zamamd-docker-compose](https://github.com/zammad/zammad-docker-compose) the password reset mails can not be sent, because there is no MTA in the container. To use a different MTA it would be great to have an environment variable `SMTP_URL` which configures the MTA for `ActionMailer`.

I added some lines which set up the `action_mailer.smtp_settings` if there is an environment variable `SMTP_URL`.