### PR TITLE
Fixes #4186 - Multiselect does not show values properly in reports.

### DIFF
--- a/lib/excel_sheet.rb
+++ b/lib/excel_sheet.rb
@@ -143,9 +143,6 @@ class ExcelSheet
     if !value && additional && additional[attribute.to_sym]
       value = additional[attribute.to_sym]
     end
-    if value.is_a?(Array)
-      value = value.join(',')
-    end
     value
   end
 
@@ -158,9 +155,16 @@ class ExcelSheet
     case object[:data_type]
     when 'boolean', %r{^(multi|tree_)?select$}
       if object[:data_option].present? && object[:data_option]['options'].present?
-        value = ObjectManager::Attribute.data_options_hash(object[:data_option]['options'])[value]
+        if value.is_a?(Array)
+          displays = []
+          value.each do |key|
+            displays.push(ObjectManager::Attribute.data_options_hash(object[:data_option]['options'])[key])
+          end
+          value = displays.join(',')
+        else
+          value = ObjectManager::Attribute.data_options_hash(object[:data_option]['options'])[value]
+        end
       end
-
       @worksheet.write_string(@current_row, @current_column, value) if value.present?
     when 'datetime'
       @worksheet.write_date_time(@current_row, @current_column, timestamp_in_localtime(value), @format_time) if value.present?


### PR DESCRIPTION
Generated .xls reports show the "Key" name for custom multiselect attributes/objects when they should show the "Display" name.

The old code creates an array of Keys and turns it into a comma-separated string of Keys. Then the old code tries to get the Display value of that comma-separated string of Keys. It should try to get the Display value of each Key individually.

The new code retrieves the Display value of each Key, then joins those values into a comma-separated string.

More information here:
https://community.zammad.org/t/custom-multiselect-object-attribute-shows-key-name-in-excel-report/9037