### PR TITLE
Fixes #849 - Allow additional usage of Ticket Number in (Zoom) URL

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_number.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_number.coffee
@@ -8,6 +8,25 @@ class TicketZoomHookRouter extends App.ControllerPermanent
     if (target_ticket)
       window.location.replace(target_ticket.uiUrl())
     else
-      window.location.replace("#ticket/zoom/0")
+      App.Ajax.request(
+        type:  'GET'
+        url:   "#{@apiPath}/search"
+        data:
+          query: ''
+          condition: [{ 'ticket.number': { operator: 'is', value: params.ticket_number } }]
+          limit: 1
+        processData: true
+        success: (data, status, xhr) =>
+          for item in data.result
+            continue if item.type isnt 'Ticket'
+            App.Collection.loadAssets(data.assets)
+            target_ticket = App.Ticket.findNative(item.id)
+            if (target_ticket)
+              window.location.replace(target_ticket.uiUrl())
+            return
+          window.location.replace('#ticket/zoom/0')
+        error: =>
+          window.location.replace('#ticket/zoom/0')
+      )
 
 App.Config.set('ticket/number/:ticket_number', TicketZoomHookRouter, 'Routes')

--- a/app/assets/javascripts/app/controllers/ticket_number.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_number.coffee
@@ -1,0 +1,13 @@
+class TicketZoomHookRouter extends App.ControllerPermanent
+  requiredPermission: ['ticket.agent', 'ticket.customer']
+  constructor: (params) ->
+    super
+
+    target_ticket = App.Ticket.findByAttribute('number', params.ticket_number);
+
+    if (target_ticket)
+      window.location.replace(target_ticket.uiUrl())
+    else
+      window.location.replace("#ticket/zoom/0")
+
+App.Config.set('ticket/number/:ticket_number', TicketZoomHookRouter, 'Routes')

--- a/spec/system/ticket/zoom_spec.rb
+++ b/spec/system/ticket/zoom_spec.rb
@@ -2833,9 +2833,9 @@ RSpec.describe 'Ticket zoom', type: :system do
     end
 
     it 'when not found' do
-      visit "#ticket/number/123456789"
+      visit '#ticket/number/123456789'
       wait(5, interval: 1).until_constant { current_url }
-      expect(current_url).to include("ticket/zoom/0")
+      expect(current_url).to include('ticket/zoom/0')
     end
   end
 end

--- a/spec/system/ticket/zoom_spec.rb
+++ b/spec/system/ticket/zoom_spec.rb
@@ -2824,4 +2824,18 @@ RSpec.describe 'Ticket zoom', type: :system do
       expect(field.text).to eq(expected_clipboard_content)
     end
   end
+
+  describe 'Redirects from ticket number' do
+    it 'when found' do
+      visit "#ticket/number/#{ticket.number}"
+      wait(5, interval: 1).until_constant { current_url }
+      expect(current_url).to include("ticket/zoom/#{ticket.id}")
+    end
+
+    it 'when not found' do
+      visit "#ticket/number/123456789"
+      wait(5, interval: 1).until_constant { current_url }
+      expect(current_url).to include("ticket/zoom/0")
+    end
+  end
 end


### PR DESCRIPTION
Hi! :smile: 

I've implemented a ticket linking functionality to Zammad as requested in this [community forum post](https://community.zammad.org/t/open-detail-page-for-ticket-with-ticket-number-via-url/9197).

Visiting #ticket/number/xxxxx automatically redirects to the correct zoom view.


I wasn't able to test my tests as I don't have Selenium set up, hope they work as expected. :sweat_smile: 