### PR TITLE
Feature/get roles from saml

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -37,6 +37,12 @@ class Authorization < ApplicationModel
         end
       end
 
+      if Setting.get('auth_saml_credentials')['role_sync']
+        # set roles according to the SAML response
+        saml_roles = Role.get_role_names_from_saml(hash)
+        user.role_ids = Role.get_matching_role_ids(saml_roles) if saml_roles
+      end
+
       # update image if needed
       if hash['info']['image'].present?
         avatar = Avatar.add(

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -84,6 +84,46 @@ returns
 
 =begin
 
+get array of role names provided by the SAML response hash, returning nil when roles are not provided in hash
+
+  Role.get_role_names_from_saml(saml_hash)
+
+returns
+
+  [roleName1, roleName2, ...]
+
+=end
+
+  def self.get_role_names_from_saml(hash)
+    all_raw_info = hash.dig(:extra, :raw_info)&.all
+    all_raw_info.nil? ? nil : all_raw_info['Role']
+  end
+
+=begin
+
+intersect the input role names with all role names in Zammad and return the ids of matching roles
+raises an UnprocessableEntity Exception when no matching roles exist
+
+  Role.get_matching_role_ids(input_roles)
+
+returns
+
+  [roleId1, roleId2, ...]
+
+=end
+
+  def self.get_matching_role_ids(input_roles)
+    matching_role_ids = []
+    input_roles.each do |input_role_name|
+      zammad_role = Role.find_by(name: input_role_name)
+      matching_role_ids << zammad_role.id if zammad_role
+    end
+
+    matching_role_ids
+  end
+
+=begin
+
 get signup role ids
 
   Role.signup_role_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -368,6 +368,12 @@ returns
 =end
 
   def self.create_from_hash!(hash)
+    matching_role_ids = nil
+    if Setting.get('auth_saml_credentials')['role_sync']
+      # set roles according to the SAML response
+      saml_roles = Role.get_role_names_from_saml(hash)
+      matching_role_ids = Role.get_matching_role_ids(saml_roles) if saml_roles
+    end
 
     url = ''
     hash['info']['urls']&.each_value do |local_url|
@@ -385,7 +391,7 @@ returns
         address:       hash['info']['location'],
         note:          hash['info']['description'],
         source:        hash['provider'],
-        role_ids:      Role.signup_role_ids,
+        role_ids:      (matching_role_ids.presence || Role.signup_role_ids),
         updated_by_id: 1,
         created_by_id: 1,
       }

--- a/db/migrate/20220810090250_add_role_integration_to_saml_settings.rb
+++ b/db/migrate/20220810090250_add_role_integration_to_saml_settings.rb
@@ -1,0 +1,24 @@
+# Copyright (C) 2012-2023 Zammad Foundation, https://zammad-foundation.org/
+
+class AddRoleIntegrationToSamlSettings < ActiveRecord::Migration[6.1]
+  def up
+    return if !Setting.exists?(name: 'system_init_done')
+
+    setting = Setting.find_by(name: 'auth_saml_credentials')
+    return if !setting
+
+    form = setting.options[:form]
+    form <<
+      {
+        display: 'Synchronize roles',
+        null:    true,
+        name:    'role_sync',
+        tag:     'boolean',
+        options: {
+          true  => 'yes',
+          false => 'no',
+        },
+      }
+    setting.save!
+  end
+end

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -1911,6 +1911,16 @@ Setting.create_if_not_exists(
         tag:      'auth_provider',
         provider: 'auth_saml',
       },
+      {
+        display: __('Synchronize roles'),
+        null:    true,
+        name:    'role_sync',
+        tag:     'boolean',
+        options: {
+          true  => 'yes',
+          false => 'no',
+        },
+      },
     ],
   },
   state:       {},

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -9770,6 +9770,10 @@ msgstr ""
 msgid "Sync with computer"
 msgstr ""
 
+#: db/seeds/settings.rb
+msgid "Synchronize roles"
+msgstr ""
+
 #: app/assets/javascripts/app/controllers/_manage/system.coffee
 #: app/assets/javascripts/app/controllers/manage.coffee
 #: db/seeds/permissions.rb


### PR DESCRIPTION
Hi there!

We've implemented role mappings for SAML authentication as described in [this community post](https://community.zammad.org/t/feature-request-saml-group-mappings/9204/2). This is our first time contributing to this project, so feel free to point out any aspects we've not handled as intended.

### How to use the SAML role synchronization?

1. Set up SAML authentication as you would normally (see [the documentation](https://admin-docs.zammad.org/en/latest/settings/security/third-party/saml.html)).
1. Add a mapper to the client that you use with your Zammad instance (for example, a Keycloak instance). This mapper must have the `Mapper Type` `Role list`, the `Role attribute name` must be `Role`, `SAML Attribute NameFormat` must be set to `Basic`, and `Single Role Attribute` must be disabled.
1. Make sure that `role_list` is added to the assigned default client scopes.
1. To synchronize roles, the same role names must exist in your client and in Zammad. Note that additional roles that may be assigned to users are not harmful, there just must be at least one matching role.
1. Enable role synchronization in Zammad's SAML settings.