### PR TITLE
Feature/assets precompile upon upgrade

### DIFF
--- a/contrib/packager.io/functions
+++ b/contrib/packager.io/functions
@@ -309,6 +309,11 @@ function update_or_install () {
   chmod 600 ${ZAMMAD_DIR}/config/database.yml
 }
 
+function assets_precompile () {
+  echo "# Precompiling assets"
+  zammad run rake assets:precompile
+}
+
 function set_env_vars () {
   zammad config:set RUBY_MALLOC_ARENA_MAX=${ZAMMAD_RUBY_MALLOC_ARENA_MAX:=2}
   zammad config:set RUBY_GC_MALLOC_LIMIT=${ZAMMAD_RUBY_GC_MALLOC_LIMIT:=1077216}

--- a/contrib/packager.io/postinstall.sh
+++ b/contrib/packager.io/postinstall.sh
@@ -30,6 +30,8 @@ stop_zammad
 
 update_or_install
 
+assets_precompile
+
 set_env_vars
 
 start_zammad


### PR DESCRIPTION
I would like to add a function to precompile the assets after a package upgrade for those that have some customizations to CSS and/or JS. I have added a new function that calls the rake command before restarting the server after an upgrade to the DEB/RPM package. Upon first install, the command will also probably be called, but should not matter as the assets would be the same.