### PR TITLE
Avoid creating link when source and dest is same

### DIFF
--- a/lib/tasks/zammad/setup/auto_wizard.rake
+++ b/lib/tasks/zammad/setup/auto_wizard.rake
@@ -10,7 +10,10 @@ namespace :zammad do
       Rails.cache.clear # In case we're coming from `zammad:bootstrap:reset`.
 
       source = args.fetch(:source, Rails.root.join('contrib/auto_wizard_test.json'))
-      FileUtils.ln(source, Rails.root.join('auto_wizard.json'), force: true)
+      dest = Rails.root.join('auto_wizard.json')
+      if File.expand_path(source) != File.expand_path(dest)
+        FileUtils.ln(source, dest, force: true)
+      end
 
       AutoWizard.setup
 


### PR DESCRIPTION
### Changes
Add path check to avoid creating link when source file is the `auto_wizard.json` in root folder.

### Reason
When installing with **Docker Compose**, if use the `AUTOWIZARD_JSON` environment variable, the specified configuration data will be saved into the `auto_wizard.json` file in root folder.
Please refer to line 71~75 of the [docker-entrypoint.sh](https://github.com/zammad/zammad-docker-compose/blob/master/containers/zammad/docker-entrypoint.sh) file.

In another case, user may create the `auto_wizard.json` file in root folder by `docker cp` command, just like the `build-and-run-docker-compose` job defined in the [ci.yaml](https://github.com/zammad/zammad-docker-compose/blob/master/.github/workflows/ci.yaml) file.

Then, as mentioned in [getting-started.md](https://github.com/zammad/zammad/blob/develop/doc/developer_manual/development_environment/getting-started.md), one option of the next step is to run `rake zammad:setup:auto_wizard` with source of `auto_wizard.json`. 

However, previous code fails due to creating link to the file itself.

### Test Environment
OS: Ubuntu 20.04
Arch: x86_64

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
