### PR TITLE
Remove inline image styling before showing modal

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
@@ -32,7 +32,6 @@ class App.TicketZoomArticleImageView extends App.ControllerModal
 
   content: ->
     @image = @image.replace(/view=preview/, 'view=inline')
-    @image = @image.replace(/style="[^"]*"/, '')
     "<div class=\"centered imagePreview\">#{@image}</div>"
 
   onSubmit: =>

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_image_view.coffee
@@ -32,6 +32,7 @@ class App.TicketZoomArticleImageView extends App.ControllerModal
 
   content: ->
     @image = @image.replace(/view=preview/, 'view=inline')
+    @image = @image.replace(/style="[^"]*"/, '')
     "<div class=\"centered imagePreview\">#{@image}</div>"
 
   onSubmit: =>

--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -10123,8 +10123,9 @@ label + .wizard-buttonList {
   }
 
   img {
-    max-width: 100%;
-    max-height: calc(100vh - 218px);
+    width: auto !important;
+    max-width: 100% !important;
+    max-height: calc(100vh - 218px) !important;
   }
 }
 


### PR DESCRIPTION
Hi there :wave: 

I propose adding this change to strip the inline styling of images in articles so they can be shown in full size
when viewing them in the image modal.

Without this change:
<img src="https://user-images.githubusercontent.com/6693160/203431735-3107ed50-3b71-4750-bf9b-57a4103af8fb.gif" width="300">
With this change:
<img src="https://user-images.githubusercontent.com/6693160/203431761-84d8b5e0-f8a9-4c47-b7eb-8fe1e6a6bd8c.gif" width="300">

See [this related thread](https://community.zammad.org/t/remove-inline-image-styling-before-showing-preview/10229) for more info.