### PR TITLE
Fixes #4364 - Remove ticket hook when pasting into ticket link dialog

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_link_add.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_link_add.coffee
@@ -49,6 +49,17 @@ class App.TicketLinkAdd extends App.ControllerModal
       $(e.target).parents().find('[name="radio"]').prop('checked', false)
     )
 
+    content.on('paste', '[name="ticket_number"]', (e) =>
+      execute = ->
+        # remove ticket hook if present
+        if e.target && e.target.value
+          $('[name="ticket_number"]').val( e.target.value.replace(App.Config.get('ticket_hook'), '') )
+
+      @delay( execute, 0)
+
+      return
+    )
+
     content.on('click', '[name="radio"]', (e) ->
       if $(e.target).prop('checked')
         ticket_id = $(e.target).val()


### PR DESCRIPTION
Pretty much identical to how it was done for the ticket merge dialog:

https://github.com/zammad/zammad/blob/bc431cb660e2ec3fc0a3a01611daf2f36f623793/app/assets/javascripts/app/controllers/agent_ticket_merge.coffee#L56-L65