### PR TITLE
Update redis.rb

### DIFF
--- a/lib/sessions/store/redis.rb
+++ b/lib/sessions/store/redis.rb
@@ -60,7 +60,7 @@ class Sessions::Store::Redis
     key = client_messages_key(client_id)
     @redis.rpush(key, data.to_json).positive?
     # Make sure message keys are cleaned up even if they are no longer listed in 'sessions'.
-    @redis.expire(key, 1.hour, nx: true)
+    @redis.expire(key, 1.hour, NX: true)
   end
 
   def queue(client_id)


### PR DESCRIPTION
Error shown on UI:

" ERR wrong number of arguments for 'expire' command" 

Solution: 

> Need to correct typo for Redis expire command from "nx " to "NX"
> as mentioned: https://redis.io/commands/expire/

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
