### PR TITLE
Add S3 backend as Storage option Closes #660

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,6 +170,9 @@ gem 'viewpoint', require: false
 # integrations - S/MIME
 gem 'openssl'
 
+# storage - S3 backend
+gem 'aws-sdk-s3'
+
 # Translation sync
 gem 'byk', require: false
 gem 'PoParser', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,22 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.717.0)
+    aws-sdk-core (3.170.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.62.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.119.1)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     biz (1.8.2)
@@ -245,6 +261,7 @@ GEM
     inflection (1.0.0)
     iniparse (1.5.0)
     interception (0.5)
+    jmespath (1.6.2)
     json (2.6.3)
     jwt (2.3.0)
     kgio (2.11.4)
@@ -629,6 +646,7 @@ DEPENDENCIES
   argon2
   autodiscover!
   autoprefixer-rails
+  aws-sdk-s3
   biz
   bootsnap
   brakeman

--- a/app/assets/javascripts/app/views/settings/storage_provider.jst.eco
+++ b/app/assets/javascripts/app/views/settings/storage_provider.jst.eco
@@ -13,6 +13,11 @@
   <code>
   rails&gt; Store::File.move('DB', 'File')
   </code>
+    <p class="help-text"><%- @T('Move all from "%s" to "%s":', 'database', 's3') %></p>
+  </p>
+  <code>
+  rails&gt; Store::File.move('DB', 'S3')
+  </code>
   <br>
   <br>
   <div class="horizontal end">

--- a/app/models/store/provider/s3.rb
+++ b/app/models/store/provider/s3.rb
@@ -31,13 +31,17 @@ class Store::Provider::S3
   end
 
   def self.client
-    Aws::S3::Client.new(
-      region:      Setting.get('storage_provider_s3_region'),
-      credentials: Aws::Credentials.new(
+    options = {
+      force_path_style: Setting.get('storage_provider_s3_path_style_access'),
+      region:           Setting.get('storage_provider_s3_region'),
+      credentials:      Aws::Credentials.new(
         Setting.get('storage_provider_s3_access_key'),
         Setting.get('storage_provider_s3_secret_key')
       )
-    )
+    }
+    endpoint = Setting.get('storage_provider_s3_endpoint')
+    options[:endpoint] = endpoint if !endpoint.empty?
+    Aws::S3::Client.new(options)
   end
 
   def self.create_bucket

--- a/app/models/store/provider/s3.rb
+++ b/app/models/store/provider/s3.rb
@@ -1,0 +1,52 @@
+# Copyright (C) 2012-2023 Zammad Foundation, https://zammad-foundation.org/
+
+require 'aws-sdk-s3'
+
+class Store::Provider::S3
+  def self.add(data, sha)
+    begin
+      client.put_object({
+                          body:   data,
+                          bucket: bucket_name,
+                          key:    sha,
+                        })
+    rescue Aws::S3::Errors::NoSuchBucket
+      create_bucket
+      add(data, sha)
+    end
+  end
+
+  def self.get(sha)
+    client.get_object({
+                        bucket: bucket_name,
+                        key:    sha,
+                      }).body.read
+  end
+
+  def self.delete(sha)
+    client.delete_object({
+                           bucket: bucket_name,
+                           key:    sha,
+                         })
+  end
+
+  def self.client
+    Aws::S3::Client.new(
+      region:      Setting.get('storage_provider_s3_region'),
+      credentials: Aws::Credentials.new(
+        Setting.get('storage_provider_s3_access_key'),
+        Setting.get('storage_provider_s3_secret_key')
+      )
+    )
+  end
+
+  def self.create_bucket
+    client.create_bucket({
+                           bucket: bucket_name
+                         })
+  end
+
+  def self.bucket_name
+    "zammad-#{Rails.env}"
+  end
+end

--- a/db/migrate/20230228185213_issue660_update_storage_provider_setting_s3.rb
+++ b/db/migrate/20230228185213_issue660_update_storage_provider_setting_s3.rb
@@ -1,0 +1,108 @@
+# Copyright (C) 2012-2023 Zammad Foundation, https://zammad-foundation.org/
+
+class Issue660UpdateStorageProviderSettingS3 < ActiveRecord::Migration[6.1]
+  def change
+    # return if it's a new setup
+    return if !Setting.exists?(name: 'system_init_done')
+
+    storage_provider = Setting.find_by(name: 'storage_provider')
+    storage_provider.description = '"Database" stores all attachments in the database (not recommended for storing large amounts of data). "Filesystem" stores the data in the filesystem. "S3" stores the data in a AWS S3 compatible service. You can switch between the modules even on a system that is already in production without any loss of data.'
+    storage_provider.options = {
+      form: [
+        {
+          display:   '',
+          null:      true,
+          name:      'storage_provider',
+          tag:       'select',
+          tranlate:  true,
+          options:   {
+            'DB'   => 'Database',
+            'File' => 'Filesystem',
+            'S3'   => 'S3',
+          },
+          translate: true,
+        },
+      ]
+    }
+    storage_provider.preferences = {
+      controller:             'SettingsAreaStorageProvider',
+      prio:                   1,
+      online_service_disable: true,
+      permission:             ['admin.system'],
+    }
+    storage_provider.save!
+
+    Setting.create_if_not_exists(
+      title:       'Storage S3 access key',
+      name:        'storage_provider_s3_access_key',
+      area:        'System::Storage',
+      description: 'S3 access key',
+      options:     {
+        form: [
+          {
+            display: '',
+            null:    false,
+            name:    'storage_provider_s3_access_key',
+            tag:     'input',
+          },
+        ],
+      },
+      state:       '',
+      preferences: {
+        online_service_disable: true,
+        prio:                   2,
+        permission:             ['admin.system'],
+      },
+      frontend:    false
+    )
+
+    Setting.create_if_not_exists(
+      title:       'Storage S3 secret key',
+      name:        'storage_provider_s3_secret_key',
+      area:        'System::Storage',
+      description: 'S3 secret access key',
+      options:     {
+        form: [
+          {
+            display: '',
+            null:    false,
+            name:    'storage_provider_s3_secret_key',
+            tag:     'input',
+          },
+        ],
+      },
+      state:       '',
+      preferences: {
+        online_service_disable: true,
+        prio:                   3,
+        permission:             ['admin.system'],
+      },
+      frontend:    false
+    )
+
+    Setting.create_if_not_exists(
+      title:       'Storage S3 region',
+      name:        'storage_provider_s3_region',
+      area:        'System::Storage',
+      description: 'S3 region name',
+      options:     {
+        form: [
+          {
+            display:     '',
+            null:        false,
+            name:        'storage_provider_s3_region',
+            tag:         'input',
+            placeholder: 'us-west-2',
+          },
+        ],
+      },
+      state:       '',
+      preferences: {
+        online_service_disable: true,
+        prio:                   4,
+        permission:             ['admin.system'],
+      },
+      frontend:    false
+    )
+  end
+end

--- a/db/migrate/20230228185213_issue660_update_storage_provider_setting_s3.rb
+++ b/db/migrate/20230228185213_issue660_update_storage_provider_setting_s3.rb
@@ -104,5 +104,59 @@ class Issue660UpdateStorageProviderSettingS3 < ActiveRecord::Migration[6.1]
       },
       frontend:    false
     )
+
+    Setting.create_if_not_exists(
+      title:       'Storage S3 endpoint',
+      name:        'storage_provider_s3_endpoint',
+      area:        'System::Storage',
+      description: 'S3 endpoint url',
+      options:     {
+        form: [
+          {
+            display:     '',
+            null:        true,
+            name:        'storage_provider_s3_endpoint',
+            tag:         'input',
+            placeholder: '',
+          },
+        ],
+      },
+      state:       '',
+      preferences: {
+        online_service_disable: true,
+        prio:                   5,
+        permission:             ['admin.system'],
+      },
+      frontend:    false
+    )
+
+    Setting.create_if_not_exists(
+      title:       'Storage S3 path style access',
+      name:        'storage_provider_s3_path_style_access',
+      area:        'System::Storage',
+      description: 'S3 path style access instead of virtual host',
+      options:     {
+        form: [
+          {
+            display:   '',
+            null:      false,
+            name:      'storage_provider_s3_path_style_access',
+            tag:       'boolean',
+            translate: true,
+            options:   {
+              true  => 'yes',
+              false => 'no',
+            },
+          },
+        ],
+      },
+      state:       '',
+      preferences: {
+        online_service_disable: true,
+        prio:                   6,
+        permission:             ['admin.system'],
+      },
+      frontend:    false
+    )
   end
 end

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -340,7 +340,7 @@ Setting.create_if_not_exists(
   title:       __('Storage Mechanism'),
   name:        'storage_provider',
   area:        'System::Storage',
-  description: __('"Database" stores all attachments in the database (not recommended for storing large amounts of data). "Filesystem" stores the data in the filesystem. You can switch between the modules even on a system that is already in production without any loss of data.'),
+  description: __('"Database" stores all attachments in the database (not recommended for storing large amounts of data). "Filesystem" stores the data in the filesystem. "S3" stores the data in a AWS S3 compatible service. You can switch between the modules even on a system that is already in production without any loss of data.'),
   options:     {
     form: [
       {
@@ -352,6 +352,7 @@ Setting.create_if_not_exists(
         options:   {
           'DB'   => __('Database'),
           'File' => __('Filesystem'),
+          'S3'   => __('S3'),
         },
         translate: true,
       },
@@ -360,7 +361,81 @@ Setting.create_if_not_exists(
   state:       'DB',
   preferences: {
     controller:             'SettingsAreaStorageProvider',
+    prio:                   1,
     online_service_disable: true,
+    permission:             ['admin.system'],
+  },
+  frontend:    false
+)
+
+Setting.create_if_not_exists(
+  title:       __('Storage S3 access key'),
+  name:        'storage_provider_s3_access_key',
+  area:        'System::Storage',
+  description: __('S3 access key'),
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    false,
+        name:    'storage_provider_s3_access_key',
+        tag:     'input',
+      },
+    ],
+  },
+  state:       '',
+  preferences: {
+    online_service_disable: true,
+    prio:                   2,
+    permission:             ['admin.system'],
+  },
+  frontend:    false
+)
+
+Setting.create_if_not_exists(
+  title:       __('Storage S3 secret key'),
+  name:        'storage_provider_s3_secret_key',
+  area:        'System::Storage',
+  description: __('S3 secret access key'),
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    false,
+        name:    'storage_provider_s3_secret_key',
+        tag:     'input',
+      },
+    ],
+  },
+  state:       '',
+  preferences: {
+    online_service_disable: true,
+    prio:                   3,
+    permission:             ['admin.system'],
+  },
+  frontend:    false
+)
+
+Setting.create_if_not_exists(
+  title:       __('Storage S3 region'),
+  name:        'storage_provider_s3_region',
+  area:        'System::Storage',
+  description: __('S3 region name'),
+  options:     {
+    form: [
+      {
+        display:     '',
+        null:        false,
+        name:        'storage_provider_s3_region',
+        tag:         'input',
+        placeholder: 'us-west-2',
+      },
+    ],
+  },
+  state:       '',
+  preferences: {
+    online_service_disable: true,
+    prio:                   4,
     permission:             ['admin.system'],
   },
   frontend:    false

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -442,6 +442,60 @@ Setting.create_if_not_exists(
 )
 
 Setting.create_if_not_exists(
+  title:       __('Storage S3 endpoint'),
+  name:        'storage_provider_s3_endpoint',
+  area:        'System::Storage',
+  description: __('S3 endpoint url'),
+  options:     {
+    form: [
+      {
+        display:     '',
+        null:        true,
+        name:        'storage_provider_s3_endpoint',
+        tag:         'input',
+        placeholder: '',
+      },
+    ],
+  },
+  state:       '',
+  preferences: {
+    online_service_disable: true,
+    prio:                   5,
+    permission:             ['admin.system'],
+  },
+  frontend:    false
+)
+
+Setting.create_if_not_exists(
+  title:       __('Storage S3 path style access'),
+  name:        'storage_provider_s3_path_style_access',
+  area:        'System::Storage',
+  description: __('S3 path style access instead of virtual host'),
+  options:     {
+    form: [
+      {
+        display:   '',
+        null:      false,
+        name:      'storage_provider_s3_path_style_access',
+        tag:       'boolean',
+        translate: true,
+        options:   {
+          true  => 'yes',
+          false => 'no',
+        },
+      },
+    ],
+  },
+  state:       '',
+  preferences: {
+    online_service_disable: true,
+    prio:                   6,
+    permission:             ['admin.system'],
+  },
+  frontend:    false
+)
+
+Setting.create_if_not_exists(
   title:       __('Image Service'),
   name:        'image_backend',
   area:        'System::Services',


### PR DESCRIPTION
I have added S3 storage backend support - I'm not a Rails person. I was not able to create a settings page that will only show the S3 access key, secret key and region configuration settings if Storage is S3. 

If you wish such a page, please give me some hints to do :)

I have already added some docs but not created yet a PR: https://github.com/hggh/zammad-admin-documentation/commit/79cd8aeb8c7c083c382c133bfd3fc68991bd2959

Closes: https://github.com/zammad/zammad/issues/660