### PR TITLE
contrib/backup/functions: support backup of storage directory when it is a symlink

### DIFF
--- a/contrib/backup/functions
+++ b/contrib/backup/functions
@@ -155,9 +155,11 @@ function backup_files () {
       chown -R zammad:zammad ${ZAMMAD_DIR}/storage/
     fi
 
-      tar -C / -czf ${BACKUP_DIR}/${TIMESTAMP}_zammad_files.tar.gz ${ZAMMAD_DIR#/}/storage/ ${ZAMMAD_DIR#/}/var/
+    storage_dir=$(realpath ${ZAMMAD_DIR}/storage/)
+    tar -C / -czf ${BACKUP_DIR}/${TIMESTAMP}_zammad_files.tar.gz\
+	    ${storage_dir#/}
 
-      state=$?
+    state=$?
   fi
 
   if [ $state == '2' ]; then


### PR DESCRIPTION
Fixes #4585

