### PR TITLE
Remove rsync from docker files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ FROM node:16.18.0-slim as node
 FROM ruby:3.1.3-slim AS builder
 ARG DEBIAN_FRONTEND=noninteractive
 ARG RAILS_ENV=production
-ARG ZAMMAD_TMP_DIR=/tmp/zammad
+ARG ZAMMAD_DIR=/opt/zammad
 COPY --from=node /opt /opt
 COPY --from=node /usr/local/bin /usr/local/bin
 SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
-WORKDIR ${ZAMMAD_TMP_DIR}
+WORKDIR ${ZAMMAD_DIR}
 COPY . .
 RUN contrib/docker/setup.sh builder
 
@@ -21,12 +21,10 @@ ARG ZAMMAD_USER=zammad
 ENV RAILS_ENV=production
 ENV RAILS_LOG_TO_STDOUT=true
 ENV ZAMMAD_DIR=/opt/zammad
-ENV ZAMMAD_TMP_DIR=/tmp/zammad
-COPY --from=builder ${ZAMMAD_TMP_DIR} ${ZAMMAD_TMP_DIR}
-COPY --from=builder /usr/local/bundle /usr/local/bundle
-COPY --from=builder ${ZAMMAD_TMP_DIR}/contrib/docker/docker-entrypoint.sh /
-WORKDIR ${ZAMMAD_TMP_DIR}
-RUN contrib/docker/setup.sh runner
-ENTRYPOINT ["/docker-entrypoint.sh"]
-USER zammad
 WORKDIR ${ZAMMAD_DIR}
+COPY --from=builder ${ZAMMAD_DIR} .
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+COPY --from=builder ${ZAMMAD_DIR}/contrib/docker/docker-entrypoint.sh /
+RUN contrib/docker/setup.sh runner
+USER zammad:zammad
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -27,7 +27,6 @@ set -e
 : "${ZAMMAD_RAILSSERVER_HOST:=zammad-railsserver}"
 : "${ZAMMAD_RAILSSERVER_PORT:=3000}"
 : "${ZAMMAD_READY_FILE:=${ZAMMAD_DIR}/tmp/zammad.ready}"
-: "${ZAMMAD_TMP_DIR:=/tmp/zammad}"
 : "${ZAMMAD_WEBSOCKET_HOST:=zammad-websocket}"
 : "${ZAMMAD_WEBSOCKET_PORT:=6042}"
 : "${ZAMMAD_WEB_CONCURRENCY:=0}"
@@ -44,11 +43,7 @@ function check_zammad_ready {
 if [ "$1" = 'zammad-init' ]; then
   # install / update zammad
   test -f "${ZAMMAD_READY_FILE}" && rm "${ZAMMAD_READY_FILE}"
-  # shellcheck disable=SC2086
-  rsync -a ${RSYNC_ADDITIONAL_PARAMS} --delete --exclude 'public/assets/images/*' --exclude 'storage/fs/*' "${ZAMMAD_TMP_DIR}/" "${ZAMMAD_DIR}"
-  # shellcheck disable=SC2086
-  rsync -a ${RSYNC_ADDITIONAL_PARAMS} "${ZAMMAD_TMP_DIR}"/public/assets/images/ "${ZAMMAD_DIR}"/public/assets/images
-
+  
   until (echo > /dev/tcp/"${POSTGRESQL_HOST}"/"${POSTGRESQL_PORT}") &> /dev/null; do
     echo "zammad railsserver waiting for postgresql server to be ready..."
     sleep 5

--- a/contrib/docker/setup.sh
+++ b/contrib/docker/setup.sh
@@ -4,7 +4,7 @@ set -e
 if [ "$1" = 'builder' ]; then
   PACKAGES="build-essential curl git libimlib2-dev libpq-dev shared-mime-info"
 elif [ "$1" = 'runner' ]; then
-  PACKAGES="curl libimlib2 libpq5 nginx rsync"
+  PACKAGES="curl libimlib2 libpq5 nginx"
 fi
 
 apt-get update
@@ -14,7 +14,7 @@ apt-get install -y --no-install-recommends ${PACKAGES}
 rm -rf /var/lib/apt/lists/*
 
 if [ "$1" = 'builder' ]; then
-  cd "${ZAMMAD_TMP_DIR}"
+  cd "${ZAMMAD_DIR}"
   bundle config set without 'test development mysql'
   bundle install
   sed -e 's#.*adapter: postgresql#  adapter: nulldb#g' -e 's#.*username:.*#  username: postgres#g' -e 's#.*password:.*#  password: \n  host: zammad-postgresql\n#g' < contrib/packager.io/database.yml.pkgr > config/database.yml
@@ -30,5 +30,5 @@ if [ "$1" = 'runner' ]; then
   useradd -M -d "${ZAMMAD_DIR}" -s /bin/bash -u 1000 -g 1000 "${ZAMMAD_USER}"
   sed -i -e "s#user www-data;##g" -e 's#/var/log/nginx/\(access\|error\).log#/dev/stdout#g' -e 's#pid /run/nginx.pid;#pid /tmp/nginx.pid;#g' /etc/nginx/nginx.conf
   mkdir -p "${ZAMMAD_DIR}" /var/log/nginx
-  chown -R "${ZAMMAD_USER}":"${ZAMMAD_USER}" /etc/nginx /var/lib/nginx /var/log/nginx "${ZAMMAD_DIR}" "${ZAMMAD_TMP_DIR}"
+  chown -R "${ZAMMAD_USER}":"${ZAMMAD_USER}" /etc/nginx /var/lib/nginx /var/log/nginx "${ZAMMAD_DIR}"
 fi


### PR DESCRIPTION
* get rid of /tmp/zammad and rsync to /opt/zammad in the docker container
  * migration of stuff from the filesystem should not be needed anymore as all data goes to postgres already

