### PR TITLE
Update how-to-set-up-a-development-environment.md

### DIFF
--- a/doc/developer_manual/development_environment/how-to-set-up-a-development-environment.md
+++ b/doc/developer_manual/development_environment/how-to-set-up-a-development-environment.md
@@ -22,7 +22,7 @@ brew install postgresql forego imlib2 openssl@1.1 direnv geckodriver chromedrive
 For Linux:
 
 ```screen
-sudo apt install postgresql libimlib2 openssl direnv shellcheck
+sudo apt install postgresql libimlib2 libimlib2-dev openssl direnv shellcheck
 ```
 
 Unfortunately there is no `forego` package / binary available for Linux. We recommend to build


### PR DESCRIPTION
I added `libimlib2-dev` ~~& `libmysqlclient-dev`~~ to the list of packages to install on Linux
Before installing that package, I got the following error messages when I tried to run `bundle install`

before installing `libimlib2-dev`
```log
Using rails 6.1.7.3
Using rails-controller-testing 1.0.5
GemWrappers: Can not wrap not executable file: rake
GemWrappers: Can not wrap not executable file: rake
GemWrappers: Can not wrap not executable file: rake
GemWrappers: Can not wrap not executable file: rake
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/work/.rvm/gems/ruby-3.1.3/gems/rszr-1.3.0/ext/rszr
/usr/share/rvm/rubies/ruby-3.1.3/bin/ruby -I /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0 extconf.rb
checking for Imlib2.h... no
imlib2 development headers are missing
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/share/rvm/rubies/ruby-3.1.3/bin/$(RUBY_BASE_NAME)
	--with-imlib2-dir
	--without-imlib2-dir
	--with-imlib2-include
	--without-imlib2-include=${imlib2-dir}/include
	--with-imlib2-lib
	--without-imlib2-lib=${imlib2-dir}/lib
	--with-imlib2-config
	--without-imlib2-config
	--with-pkg-config
	--without-pkg-config

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /home/work/.rvm/gems/ruby-3.1.3/extensions/x86_64-linux/3.1.0/rszr-1.3.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /home/work/.rvm/gems/ruby-3.1.3/gems/rszr-1.3.0 for inspection.
Results logged to /home/work/.rvm/gems/ruby-3.1.3/extensions/x86_64-linux/3.1.0/rszr-1.3.0/gem_make.out

  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:102:in `run'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/ext_conf_builder.rb:28:in `build'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:171:in `build_extension'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:205:in `block in build_extensions'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:202:in `each'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:202:in `build_extensions'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/installer.rb:843:in `build_extensions'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/source/rubygems.rb:200:in `install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/gem_installer.rb:54:in `install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/parallel_installer.rb:155:in `do_install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/parallel_installer.rb:146:in `block in worker_pool'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:62:in `apply_func'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:57:in `block in process_queue'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:54:in `loop'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:54:in `process_queue'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing rszr (1.3.0), and Bundler cannot continue.

In Gemfile:
  rszr

```

~~before installing `libmysqlclient-dev`~~
```log
Using rails 6.1.7.3
GemWrappers: Can not wrap not executable file: rake
GemWrappers: Can not wrap not executable file: rake
GemWrappers: Can not wrap not executable file: rake
GemWrappers: Can not wrap not executable file: rake
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/work/.rvm/gems/ruby-3.1.3/gems/mysql2-0.5.5/ext/mysql2
/usr/share/rvm/rubies/ruby-3.1.3/bin/ruby -I /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0 extconf.rb
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for rb_gc_mark_movable()... yes
checking for rb_wait_for_single_fd()... yes
checking for rb_enc_interned_str() in ruby.h... yes
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/share/rvm/rubies/ruby-3.1.3/bin/$(RUBY_BASE_NAME)
	--with-openssl-dir
	--without-openssl-dir
	--with-mysql-dir
	--without-mysql-dir
	--with-mysql-include
	--without-mysql-include=${mysql-dir}/include
	--with-mysql-lib
	--without-mysql-lib=${mysql-dir}/lib
	--with-mysql-config
	--without-mysql-config
	--with-mysqlclient-dir
	--without-mysqlclient-dir
	--with-mysqlclient-include
	--without-mysqlclient-include=${mysqlclient-dir}/include
	--with-mysqlclient-lib
	--without-mysqlclient-lib=${mysqlclient-dir}/lib
	--with-mysqlclientlib
	--without-mysqlclientlib
/usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1083:in `block in find_library': undefined method `split' for nil:NilClass (NoMethodError)

    paths = paths.flat_map {|path| path.split(File::PATH_SEPARATOR)}
                                       ^^^^^^
	from /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1083:in `each'
	from /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1083:in `flat_map'
	from /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/mkmf.rb:1083:in `find_library'
	from extconf.rb:131:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /home/work/.rvm/gems/ruby-3.1.3/extensions/x86_64-linux/3.1.0/mysql2-0.5.5/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /home/work/.rvm/gems/ruby-3.1.3/gems/mysql2-0.5.5 for inspection.
Results logged to /home/work/.rvm/gems/ruby-3.1.3/extensions/x86_64-linux/3.1.0/mysql2-0.5.5/gem_make.out

  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:102:in `run'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/ext_conf_builder.rb:28:in `build'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:171:in `build_extension'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:205:in `block in build_extensions'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:202:in `each'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/ext/builder.rb:202:in `build_extensions'
  /usr/share/rvm/rubies/ruby-3.1.3/lib/ruby/3.1.0/rubygems/installer.rb:843:in `build_extensions'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/source/rubygems.rb:200:in `install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/gem_installer.rb:54:in `install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/parallel_installer.rb:155:in `do_install'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/installer/parallel_installer.rb:146:in `block in worker_pool'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:62:in `apply_func'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:57:in `block in process_queue'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:54:in `loop'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:54:in `process_queue'
  /home/work/.rvm/gems/ruby-3.1.3/gems/bundler-2.4.1/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing mysql2 (0.5.5), and Bundler cannot continue.

In Gemfile:
  mysql2

```
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
