### PR TITLE
health checker: add missing check for oversized mails

### DIFF
--- a/lib/monitoring_helper/health_checker/oversized_mail.rb
+++ b/lib/monitoring_helper/health_checker/oversized_mail.rb
@@ -1,0 +1,18 @@
+# Copyright (C) 2023-2023 Intevation GmbH, https://intevation.de/
+
+module MonitoringHelper
+  class HealthChecker
+    class OversizedMail < Backend
+
+      def run_health_check
+        return if !File.exist?(Channel::EmailParser::OVERSIZED_MAIL_DIRECTORY)
+
+        count = Dir.glob("#{Channel::EmailParser::OVERSIZED_MAIL_DIRECTORY}/*.eml").count
+
+        return if count.zero?
+
+        response.issues.push "oversized mails: #{count}"
+      end
+    end
+  end
+end

--- a/spec/lib/monitoring_helper/health_checker/oversized_mail_spec.rb
+++ b/spec/lib/monitoring_helper/health_checker/oversized_mail_spec.rb
@@ -1,0 +1,33 @@
+# Copyright (C) 2023-2023 Intevation GmbH, https://intevation.de/
+
+require 'rails_helper'
+
+RSpec.describe MonitoringHelper::HealthChecker::OversizedMail do
+  let(:instance)  { described_class.new }
+  let(:folder)    { SecureRandom.hex }
+  let(:directory) { Rails.root.join('tmp', folder) }
+
+  before { stub_const('Channel::EmailParser::OVERSIZED_MAIL_DIRECTORY', directory) }
+  after { FileUtils.rm_r(directory) if File.exist?(directory) }
+
+  describe '#check_health' do
+    it 'does nothing if directory missing' do
+      expect(instance.check_health.issues).to be_blank
+    end
+
+    it 'does nothing if no matching files' do
+      FileUtils.mkdir_p directory
+      FileUtils.touch("#{directory}/test.not.email")
+
+      expect(instance.check_health.issues).to be_blank
+    end
+
+    it 'adds issue if oversized mails found' do
+      FileUtils.mkdir_p directory
+      FileUtils.touch("#{directory}/test.not.email")
+      FileUtils.touch("#{directory}/test.eml")
+
+      expect(instance.check_health.issues.first).to eq 'oversized mails: 1'
+    end
+  end
+end


### PR DESCRIPTION
the health checker endpoint only reported unprocessable mails, but not oversized mails that made custom monitoring solutions necessary, or - if not present - could lead to undetected operational issues this adds a check if (and how many) oversized mails are present in the OVERSIZED_MAIL directory

with mails present in the oversized mails directory, the health check output now looks like:

{"healthy":false,"message":"oversized mails: 4","issues":["oversized mails: 4"],"actions":[]}

see also https://community.zammad.org/t/new-unprocessable-mail-directory-does-not-exist-on-zammad-6/11787