### PR TITLE
Added passthrough to entrypoint for alternative `docker run` commands.

### DIFF
--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -160,3 +160,6 @@ if [ "$1" = 'zammad-websocket' ]; then
 
   exec bundle exec script/websocket-server.rb -b 0.0.0.0 -p "${ZAMMAD_WEBSOCKET_PORT}" start
 fi
+
+# Pass all other container commands to shell
+exec "$@"

--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -110,11 +110,9 @@ if [ "$1" = 'zammad-init' ]; then
 
   # chown var
   chown -R zammad:zammad "${ZAMMAD_DIR}/var"
-fi
-
 
 # zammad nginx
-if [ "$1" = 'zammad-nginx' ]; then
+elif [ "$1" = 'zammad-nginx' ]; then
   check_zammad_ready
 
   # configure nginx
@@ -128,38 +126,33 @@ if [ "$1" = 'zammad-nginx' ]; then
   echo "starting nginx..."
 
   exec /usr/sbin/nginx -g 'daemon off;'
-fi
-
 
 # zammad-railsserver
-if [ "$1" = 'zammad-railsserver' ]; then
+elif [ "$1" = 'zammad-railsserver' ]; then
   check_zammad_ready
 
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
   exec bundle exec puma -b tcp://[::]:"${ZAMMAD_RAILSSERVER_PORT}" -w "${ZAMMAD_WEB_CONCURRENCY}" -e "${RAILS_ENV}"
-fi
-
 
 # zammad-scheduler
-if [ "$1" = 'zammad-scheduler' ]; then
+elif [ "$1" = 'zammad-scheduler' ]; then
   check_zammad_ready
 
   echo "starting background services..."
 
   exec bundle exec script/background-worker.rb start
-fi
-
 
 # zammad-websocket
-if [ "$1" = 'zammad-websocket' ]; then
+elif [ "$1" = 'zammad-websocket' ]; then
   check_zammad_ready
 
   echo "starting websocket server..."
 
   exec bundle exec script/websocket-server.rb -b 0.0.0.0 -p "${ZAMMAD_WEBSOCKET_PORT}" start
-fi
 
 # Pass all other container commands to shell
-exec "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

This PR will resolve three issues from the `zammad-docker-compose` repository: [Issue 355](https://github.com/zammad/zammad-docker-compose/issues/355
), [Issue 356](https://github.com/zammad/zammad-docker-compose/issues/356) and [Issue 358](https://github.com/zammad/zammad-docker-compose/issues/358). It will also make [PR #357](https://github.com/zammad/zammad-docker-compose/pull/357) unnecessary.

The fundamental issue is that running commands such as `docker exec -it zammad rake zammad:searchindex:rebuild` would fail, since the process does not initiate with the required environment variables (such as `ELASTICSEARCH_HOST`) which are defined (when absent) by the entrypoint script. This PR adds a passthrough to the end of the entrypoint script, which is a common practice. For example, this is used [in the postgres entrypoint](https://github.com/docker-library/postgres/blob/master/docker-entrypoint.sh#L346).

With this change in place, we will be able to execute `elasticsearch-reindex` jobs et. al. via `docker run` commands. For example, with a `zammad-docker-compose` deployment we could run:
```
docker compose run zammad-scheduler rake zammad:searchindex:rebuild
```
as opposed to the old `exec` which currently doesn't work:
```
docker compose exec zammad-scheduler rake zammad:searchindex:rebuild
```

Thanks to the dev team for developing such an invaluable product!