### PR TITLE
Fixes #4775 - healthcheck: return 504 if not healthy

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -45,7 +45,13 @@ curl http://localhost/api/v1/monitoring/health_check?token=XXX
       result[:token] = Setting.get('monitoring_token')
     end
 
-    render json: result
+    status = :ok
+    if !health_status.healthy?
+      status = :service_unavailable
+    end
+
+    render json: result, status: status
+
   end
 
 =begin


### PR DESCRIPTION
Hi,
By returning 504 if Zammad is not healthy, it is easy to add this url on monitoring tools that do not support parsing json (.healthy)
Cheers !

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
