### PR TITLE
Remove timeout option from db connection configuration

### DIFF
--- a/config/database/database.yml
+++ b/config/database/database.yml
@@ -5,7 +5,6 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 50
-  timeout: 5000
   encoding: utf8
 
   ##### postgresql config #####


### PR DESCRIPTION
The `timeout` connection option is only relevant for `sqlite3` connections, and it seems those are not supported anymore. This option can thus be removed.