### PR TITLE
Maintenance: Generate docker tags for Zammad major.minor and major versions

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - stable
       - develop
+      - develop-*
     tags:
       - '*'
 
@@ -59,14 +60,14 @@ jobs:
           tags: |
             type=sha,suffix=-${{ matrix.runs-on.platform }}
 
-      - name: Build and push
-        id: docker_build
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+      # - name: Build and push
+      #   id: docker_build
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     labels: ${{ steps.meta.outputs.labels }}
+      #     push: true
+      #     tags: ${{ steps.meta.outputs.tags }}
 
   docker-create-multiarch-manifest:
     runs-on: ubuntu-22.04
@@ -124,8 +125,14 @@ jobs:
           tags: |
             type=sha,suffix=-arm64
 
-      - name: Get version tag in the old way
+      - name: Get incrementing Zammad version from the most recent tag
         run: echo ZAMMAD_VERSION="$(git describe --tags | sed -e 's/-[a-z0-9]\{8,\}.*//g')" >> $GITHUB_ENV
+
+      - name: Get Zammad major.minor version from the most recent tag
+        run: echo ZAMMAD_VERSION_MAJOR_MINOR="$(git describe --tags | cut -f1-2 -d.)" >> $GITHUB_ENV
+
+      - name: Get Zammad major version from the most recent tag
+        run: echo ZAMMAD_VERSION_MAJOR="$(git describe --tags | cut -f1 -d.)" >> $GITHUB_ENV
 
       - name: Get tags for final multiarch reference
         id: meta
@@ -135,18 +142,16 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
             type=raw,value=${{ env.ZAMMAD_VERSION }},enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
-            type=raw,value=zammad-${{ env.ZAMMAD_VERSION }},enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
+            type=raw,value=${{ env.ZAMMAD_VERSION_MAJOR_MINOR }},enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
+            type=raw,value=${{ env.ZAMMAD_VERSION_MAJOR }},enable=${{ github.ref == format('refs/heads/{0}', 'stable') }}
             type=ref,event=branch
             type=ref,event=tag
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
             type=sha
 
-      - name: Create manifest list and push
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") ${{ steps.meta_arch_amd64.outputs.tags }} ${{ steps.meta_arch_arm64.outputs.tags }}
+      # - name: Create manifest list and push
+      #   run: |
+      #     docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") ${{ steps.meta_arch_amd64.outputs.tags }} ${{ steps.meta_arch_arm64.outputs.tags }}
 
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ matrix.target.image }}:${{ steps.meta.outputs.version }}
+      # - name: Inspect image
+      #   run: |
+      #     docker buildx imagetools inspect ${{ matrix.target.image }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - stable
       - develop
-      - develop-*
     tags:
       - '*'
 
@@ -60,14 +59,14 @@ jobs:
           tags: |
             type=sha,suffix=-${{ matrix.runs-on.platform }}
 
-      # - name: Build and push
-      #   id: docker_build
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     context: .
-      #     labels: ${{ steps.meta.outputs.labels }}
-      #     push: true
-      #     tags: ${{ steps.meta.outputs.tags }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
 
   docker-create-multiarch-manifest:
     runs-on: ubuntu-22.04
@@ -148,10 +147,10 @@ jobs:
             type=ref,event=tag
             type=sha
 
-      # - name: Create manifest list and push
-      #   run: |
-      #     docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") ${{ steps.meta_arch_amd64.outputs.tags }} ${{ steps.meta_arch_arm64.outputs.tags }}
+      - name: Create manifest list and push
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") ${{ steps.meta_arch_amd64.outputs.tags }} ${{ steps.meta_arch_arm64.outputs.tags }}
 
-      # - name: Inspect image
-      #   run: |
-      #     docker buildx imagetools inspect ${{ matrix.target.image }}:${{ steps.meta.outputs.version }}
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ matrix.target.image }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
This change will
- add `major.minor` and `major` docker tags that can be used to get automatic updates with docker-compose and helm
- remove the dysfunctional `semver` tag configuration - does not work because we don't use semver tags with `v1.2.3`
- stop creating the duplicated `zammad-*` tags