### PR TITLE
added variable to deactivate IPv6

### DIFF
--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -115,20 +115,18 @@ if [ "$1" = 'zammad-init' ]; then
 elif [ "$1" = 'zammad-nginx' ]; then
   check_zammad_ready
 
-  IPV6_PATTERN="listen \[::\]:80;"
-  if [ "$ZAMMAD_IPV6" -ne 0 ]; then
-    IPV6_PATTERN="non_existent_ipv6_pattern"
-  fi
-
-
   # configure nginx
   sed -e "s#\(listen\)\(.*\)80#\1\2${NGINX_PORT}#g" \
       -e "s#proxy_set_header X-Forwarded-Proto .*;#proxy_set_header X-Forwarded-Proto ${NGINX_SERVER_SCHEME};#g" \
       -e "s#server .*:3000#server ${ZAMMAD_RAILSSERVER_HOST}:${ZAMMAD_RAILSSERVER_PORT}#g" \
       -e "s#server .*:6042#server ${ZAMMAD_WEBSOCKET_HOST}:${ZAMMAD_WEBSOCKET_PORT}#g" \
       -e "s#server_name .*#server_name ${NGINX_SERVER_NAME};#g" \
-      -e "s#${IPV6_PATTERN}##g" \
       -e 's#/var/log/nginx/zammad.\(access\|error\).log#/dev/stdout#g' < contrib/nginx/zammad.conf > /etc/nginx/sites-enabled/default
+
+  IPV6_PATTERN="listen \[::\]:80;"
+  if [ "$ZAMMAD_DISABLE_IPV6"==1 ]; then
+    sed -e "s#${IPV6_PATTERN}##g" < /etc/nginx/sites-enabled/default > /etc/nginx/sites-enabled/default
+  fi
 
   echo "starting nginx..."
 
@@ -141,9 +139,7 @@ elif [ "$1" = 'zammad-railsserver' ]; then
   echo "starting railsserver... with WEB_CONCURRENCY=${ZAMMAD_WEB_CONCURRENCY}"
 
   #shellcheck disable=SC2101
-  if [ "$ZAMMAD_IPV6" -ne 0 ]; then
-    exec bundle exec puma -b tcp://[::]:"${ZAMMAD_RAILSSERVER_PORT}" -w "${ZAMMAD_WEB_CONCURRENCY}" -e "${RAILS_ENV}"
-  else
+  if [ "$ZAMMAD_DISABLE_IPV6"==1 ]; then
     exec bundle exec puma -b tcp://0.0.0.0:"${ZAMMAD_RAILSSERVER_PORT}" -w "${ZAMMAD_WEB_CONCURRENCY}" -e "${RAILS_ENV}"
   fi
 


### PR DESCRIPTION
Zammad docker-compose setup fails to start when IPv6 is not activated on the source system, because nginx and puma tries to listen on IPv6 addresses.

https://community.zammad.org/t/docker-setup-and-resources/12305

Original pull request: https://github.com/zammad/zammad/pull/4850