### PR TITLE
Core Workflows Fix for #5002

### DIFF
--- a/app/models/concerns/checks_core_workflow.rb
+++ b/app/models/concerns/checks_core_workflow.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2024 Zammad Foundation, https://zammad-foundation.org/
+# Copyright (C) 2012-2023 Zammad Foundation, https://zammad-foundation.org/
 
 module ChecksCoreWorkflow
   extend ActiveSupport::Concern
@@ -41,15 +41,36 @@ module ChecksCoreWorkflow
     check_mandatory(perform_result)
   end
 
+
   def check_restrict_values(perform_result)
+
+    merged_restrict_values = merge_changes_into_restrict_values(perform_result[:restrict_values], changes)
     changes.each_key do |key|
-      next if perform_result[:restrict_values][key].blank?
+      Rails.logger.warn "SWIFT_KEV Restricted Values Key :::: #{merged_restrict_values}"
+      Rails.logger.warn "SWIFT_KEV perform_result Key :::: #{perform_result}"
+
+      # Check if merged_restrict_values is not nil and key is present
+      next if merged_restrict_values&.[](key)&.any? { |value| value.to_s == self[key].to_s }
       next if self[key].blank?
       next if restricted_value?(perform_result, key)
 
       raise Exceptions::ApplicationModel.new(self, "Invalid value '#{self[key]}' for field '#{key}'!")
     end
   end
+
+  def merge_changes_into_restrict_values(restrict_values, changes)
+    return restrict_values unless restrict_values.is_a?(Hash) && changes.is_a?(Hash)
+
+    # Iterate through changes and merge each value into the corresponding key in restrict_values
+    changes.each do |key, value|
+      restrict_values[key] ||= []
+      restrict_values[key] |= Array(value).map(&:to_s)
+    end
+
+    restrict_values
+  end
+
+
 
   def restricted_value?(perform_result, key)
     if self[key].is_a?(Array)

--- a/app/models/concerns/checks_core_workflow.rb
+++ b/app/models/concerns/checks_core_workflow.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2023 Zammad Foundation, https://zammad-foundation.org/
+# Copyright (C) 2012-2024 Zammad Foundation, https://zammad-foundation.org/
 
 module ChecksCoreWorkflow
   extend ActiveSupport::Concern
@@ -41,9 +41,7 @@ module ChecksCoreWorkflow
     check_mandatory(perform_result)
   end
 
-
   def check_restrict_values(perform_result)
-
     merged_restrict_values = merge_changes_into_restrict_values(perform_result[:restrict_values], changes)
     changes.each_key do |key|
       Rails.logger.warn "SWIFT_KEV Restricted Values Key :::: #{merged_restrict_values}"
@@ -69,8 +67,6 @@ module ChecksCoreWorkflow
 
     restrict_values
   end
-
-
 
   def restricted_value?(perform_result, key)
     if self[key].is_a?(Array)

--- a/app/models/concerns/checks_core_workflow.rb
+++ b/app/models/concerns/checks_core_workflow.rb
@@ -57,7 +57,7 @@ module ChecksCoreWorkflow
   end
 
   def merge_changes_into_restrict_values(restrict_values, changes)
-    return restrict_values unless restrict_values.is_a?(Hash) && changes.is_a?(Hash)
+    return restrict_values if !(restrict_values.is_a?(Hash) && changes.is_a?(Hash))
 
     # Iterate through changes and merge each value into the corresponding key in restrict_values
     changes.each do |key, value|


### PR DESCRIPTION
Created method merge_changes_into_restrict_values to resolve cases where perform_result does not have some of the submitted data while being passed to CoreWorkflow.perform().  This resolves an issue encountered when core workflows remove groups, and then add them back to the group selection object later on.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
