### PR TITLE
Fixes #5017 - No "From"-Field in Articles created on behalf of a customer with auto-generated login

### DIFF
--- a/app/models/ticket/article/adds_metadata_general.rb
+++ b/app/models/ticket/article/adds_metadata_general.rb
@@ -63,7 +63,7 @@ module Ticket::Article::AddsMetadataGeneral
     type        = Ticket::Article::Type.lookup(id: type_id)
     is_customer = !author.permissions?('ticket.agent')
 
-    self.from = if %w[web phone].include?(type.name) && is_customer
+    self.from = if %w[web phone].include?(type.name) && is_customer && !author.email.empty?
                   Channel::EmailBuild.recipient_line "#{author.firstname} #{author.lastname}", author.email
                 else
                   "#{author.firstname} #{author.lastname}"


### PR DESCRIPTION
If the customer for which a ticket is created has no email-address currently no creator is shown for the first article in the ticket.
This patch uses just the firstname and the lastname in the from-field of the article instead of using an empty string.
Fixes #5017 as now the name of the customer gets shown.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
