### PR TITLE
Group Permissions: Limit users to posting interally

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/internal.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/internal.coffee
@@ -2,6 +2,8 @@ class Internal
   @action: (actions, ticket, article, ui) ->
     return actions if !ticket.editable()
     return actions if ticket.currentView() is 'customer'
+    # Even if above satisfied, still don't display the external/internal toggle if user doesn't have external or full access to group
+    return actions if (!ticket.userGroupAccess('external') or !ticket.userGroupAccess('full'))
 
     if article.internal is true
       actions.push {

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_new.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_new.coffee
@@ -38,7 +38,8 @@ class App.TicketZoomArticleNew extends App.Controller
     @type = @defaults['type'] || 'note'
     @setPossibleArticleTypes()
 
-    if @ticket.currentView() is 'agent'
+    # If you're an agent, and you have external or full group access, you can access the internal selector
+    if @ticket.currentView() is 'agent' and (@ticket.userGroupAccess('external') or @ticket.userGroupAccess('full'))
       @internalSelector = true
 
     @textareaHeight =
@@ -424,6 +425,10 @@ class App.TicketZoomArticleNew extends App.Controller
     for articleTypeConfig in @articleTypes
       if articleTypeConfig.name is type
         config = articleTypeConfig
+
+    # Automatically select internal on the new article if the user doesn't have external or full access
+    if (!@ticket.userGroupAccess('external') and !@ticket.userGroupAccess('full'))
+      config.internal = true
 
     if config
       if config.internal

--- a/app/assets/javascripts/app/models/group.coffee
+++ b/app/assets/javascripts/app/models/group.coffee
@@ -44,6 +44,7 @@ class App.Group extends App.Model
     read: __('Read')
     create: __('Create')
     change: __('Change')
+    external: __('External') # External role allows posting articles with internal = false
     overview: __('Overview')
     full: __('Full')
 

--- a/app/controllers/concerns/creates_ticket_articles.rb
+++ b/app/controllers/concerns/creates_ticket_articles.rb
@@ -51,6 +51,11 @@ module CreatesTicketArticles # rubocop:disable Metrics/ModuleLength
       clean_params[:internal] = false
     end
 
+    # Do not allow creation if you don't have external or full group access
+    if clean_params[:internal] == false
+      authorize!(ticket, :external?) # TODO: This might stop those with 'full' access from posting, check it doesn't
+    end
+
     article = Ticket::Article.new(clean_params)
     article.ticket_id = ticket.id
     article.check_mentions_raises_error = true

--- a/app/controllers/ticket_articles_controller.rb
+++ b/app/controllers/ticket_articles_controller.rb
@@ -114,6 +114,10 @@ class TicketArticlesController < ApplicationController
                                                        }
                                                      ))
     end
+    # Do not allow changing status to external if you don't have external or full group access
+    if clean_params[:internal] == false
+      authorize!(article, :external?) # TODO: This might stop those with 'full' access from posting, check it doesn't
+    end
 
     article.update!(clean_params)
 

--- a/app/policies/ticket/article_policy.rb
+++ b/app/policies/ticket/article_policy.rb
@@ -10,6 +10,10 @@ class Ticket::ArticlePolicy < ApplicationPolicy
     access?(__method__)
   end
 
+  def external?
+    access?(__method__)
+  end
+
   def update?
     ticket_policy.agent_update_access?
   end

--- a/app/policies/ticket_policy.rb
+++ b/app/policies/ticket_policy.rb
@@ -16,6 +16,10 @@ class TicketPolicy < ApplicationPolicy
     access?('change')
   end
 
+  def external?
+    access?('external')
+  end
+  
   def destroy?
     return true if user.permissions?('admin')
 


### PR DESCRIPTION
Hello Zammad Team,

You have an amazing product here - thanks for open sourcing it. It's been a pleasure to poke around in.

### Overview of Proposed Feature

So far I've been evaluating it for a somewhat novel application, and I found a missing feature which is a blocker for me. Competing platforms like Zendesk and even open source competitors like osTicket have the ability to restrict users to only posting internally. 

I wasn't able to find this feature in Zammad - the permissions system doesn't seem to dig in a very granular fashion into the functionality that's available. However, you have such a great system for distinguishing between internal/external correspondence. It's all there - so I figured it can't be too hard to build the feature.

The main problem I'm trying to solve is to give access to Agents that shouldn't be able to accidentally send external correspondence. Instead, the Agents are able to assist more senior Agents by creating drafts and internal comments on tickets, subject to group access. The senior Agents can then review and respond using their external access permissions. 

I thought the implementation best into Group/Role access permissions, because it means that you can have some Agents with full access to some Groups, but only read or internal access on other Groups. So it adds more flexibility.

See below for a visual guide of what I've changed in this PR.

### Role Permissions

There is a new item in the Role Permissions that allows you to select 'External' for a Group.

![Screenshot from 2024-02-16 17-53-06](https://github.com/zammad/zammad/assets/35259264/383fb88d-9d82-4d02-8b6c-4cc6a10c264f)

In this example, this role can post externally for tickets in the Users group but not the Random Group, where they are limited to internal.

Below you can see a Role can be created called 'Internal Agent' where you can configure what groups this Agent has access to. This allows you to setup a role where all access will be internal to every Group, perfect for what I'm after.

![Screenshot from 2024-02-16 17-53-37](https://github.com/zammad/zammad/assets/35259264/733c1740-510c-4ee5-80f0-fadc09e6060c)

Then below you can see what a Limited User's access looks like in the Ticket Zoom overview. It disables the visual buttons to toggle tickets internal/externally, and by default any type of channel will be marked as internal correspondence.

![Screenshot from 2024-02-16 17-56-00](https://github.com/zammad/zammad/assets/35259264/18ccfa19-da0b-4d0b-9009-73ff2658c0b6)

![Screenshot from 2024-02-16 17-56-11](https://github.com/zammad/zammad/assets/35259264/64050457-1a6a-4657-8a82-98844d304ad9)

### What this PR doesn't address (yet)

1. **Tests** - I have not written any tests for this code, I could use some guidance on doing so. The testing section in your developer documentation is not terrible, but I haven't yet had time to setup the different front-end and back-end testing suites.
2. **API Permissions** - I am not sure if the external correspondence can be controlled via the API or whether this needs addressing
3. **Use of 'Full' Permissions** - I am not 100% certain whether changes in the `creates_ticket_articles.rb` will be sufficient to cover a case where a User or a Role has 'full' permissions, it might still prevent them from posting externally because `authorise!(ticket, :external?)` doesn't allow. I've run out of testing time.

### Next Steps

It would be great if this feature was implemented. If it's not on the roadmap, I'd be interested in any advice on how to create it as a package/add-on. I haven't yet explored that because I wanted to see if there was genuine interest in merging it into the product.

Thanks for your time!