### PR TITLE
Maintenance: Drop zammad.ready file from docker entrypoint.

### DIFF
--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -35,7 +35,7 @@ ESCAPED_POSTGRESQL_PASS=$(echo "$POSTGRESQL_PASS" | sed -e 's/[\/&]/\\&/g')
 export DATABASE_URL="postgres://${POSTGRESQL_USER}:${ESCAPED_POSTGRESQL_PASS}@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DB}${POSTGRESQL_OPTIONS}"
 
 function check_zammad_ready {
-  until RAILS_CHECK_PENDING_MIGRATIONS=1 bundle exec rails r true &> /dev/null; do
+  until bundle exec rails r ActiveRecord::Migration.check_pending! &> /dev/null; do
     echo "waiting for init container to finish install or update..."
     sleep 5
   done

--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 : "${AUTOWIZARD_JSON:=''}"
-: "${AUTOWIZARD_RELATIVE_PATH:='var/auto_wizard.json'}"
+: "${AUTOWIZARD_RELATIVE_PATH:='tmp/auto_wizard.json'}"
 : "${ELASTICSEARCH_ENABLED:=true}"
 : "${ELASTICSEARCH_HOST:=zammad-elasticsearch}"
 : "${ELASTICSEARCH_PORT:=9200}"
@@ -27,7 +27,6 @@ set -e
 : "${ZAMMAD_DIR:=/opt/zammad}"
 : "${ZAMMAD_RAILSSERVER_HOST:=zammad-railsserver}"
 : "${ZAMMAD_RAILSSERVER_PORT:=3000}"
-: "${ZAMMAD_READY_FILE:=${ZAMMAD_DIR}/var/zammad.ready}"
 : "${ZAMMAD_WEBSOCKET_HOST:=zammad-websocket}"
 : "${ZAMMAD_WEBSOCKET_PORT:=6042}"
 : "${ZAMMAD_WEB_CONCURRENCY:=0}"
@@ -36,18 +35,15 @@ ESCAPED_POSTGRESQL_PASS=$(echo "$POSTGRESQL_PASS" | sed -e 's/[\/&]/\\&/g')
 export DATABASE_URL="postgres://${POSTGRESQL_USER}:${ESCAPED_POSTGRESQL_PASS}@${POSTGRESQL_HOST}:${POSTGRESQL_PORT}/${POSTGRESQL_DB}${POSTGRESQL_OPTIONS}"
 
 function check_zammad_ready {
-  sleep 15
-  until [ -f "${ZAMMAD_READY_FILE}" ]; do
+  until RAILS_CHECK_PENDING_MIGRATIONS=1 bundle exec rails r true &> /dev/null; do
     echo "waiting for init container to finish install or update..."
-    sleep 10
+    sleep 5
   done
 }
 
 # zammad init
 if [ "$1" = 'zammad-init' ]; then
   # install / update zammad
-  test -f "${ZAMMAD_READY_FILE}" && rm "${ZAMMAD_READY_FILE}"
-
   until (echo > /dev/tcp/"${POSTGRESQL_HOST}"/"${POSTGRESQL_PORT}") &> /dev/null; do
     echo "waiting for postgresql server to be ready..."
     sleep 5
@@ -113,12 +109,6 @@ if [ "$1" = 'zammad-init' ]; then
       fi
     fi
   fi
-
-  # create install ready file
-  echo 'zammad-init' > "${ZAMMAD_READY_FILE}"
-
-  # chown var
-  chown -R zammad:zammad "${ZAMMAD_DIR}/var"
 
 # zammad nginx
 elif [ "$1" = 'zammad-nginx' ]; then


### PR DESCRIPTION
Zammad 6.3 will drop the `var/` folder, so that no share is needed any more for it. That's a good chance to improve the container waiting in the docker compose context as well.

Rather than placing a file in the `var` share to signal readiness, we can simply call the rails stack and ask it to fail if migrations are pending. Other parts in the `zammad-init` container such as `Translation.sync` can happen later and are not a requirement for services to start. This will also reduce start time / upgrade downtime significantly.

zammad-helm will soon handle it in a similar way (see https://github.com/zammad/zammad-helm/pull/243).
