### PR TITLE
Added chat-no-jquery.js details to Chat page

### DIFF
--- a/app/assets/javascripts/app/views/channel/chat.jst.eco
+++ b/app/assets/javascripts/app/views/channel/chat.jst.eco
@@ -138,25 +138,37 @@
   <p><%- marked(@T('Insert the widget code into the source code of every page the chat shall be visible on. It should be placed at the end of the page\'s source code before the §</body>§ closing tag.')) %></p>
 
   <h3><%- @T('Requirements') %></h3>
-  <p><%- @T("Zammad Chat requires jQuery. If you don't already use it on your website, you can add it like this:") %></p>
+  <p><%- @T("The default version of Zammad Chat requires jQuery. If you don't already use it on your website, you can add it like this:") %></p>
   <pre><code class="language-html js-code">&lt;script src="https://code.jquery.com/jquery-3.6.0.min.js"&gt;&lt;/script&gt;</code></pre>
 
   <h3><%- @T('Show chat automatically') %> (<%- @T('default') %>)</h3>
   <p><%- @T('The chat will show up once the connection to the server got established and if there is an operator online to chat with.') %></p>
 
-  <pre><code class="language-html js-code">&lt;script src="<%= @baseurl %>/assets/chat/chat.min.js"&gt;&lt;/script&gt;
+  <pre><code class="language-html js-code">&lt;!-- With jQuery --&gt;
+&lt;script src="<%= @baseurl %>/assets/chat/chat.min.js"&gt;&lt;/script&gt;
 &lt;script&gt;
 $(function() {
   new ZammadChat({
 <span class="js-modal-params"></span>
   });
 });
+&lt;/script&gt;
+
+&lt;!-- Without jQuery --&gt;
+&lt;script src="<%= @baseurl %>/assets/chat/chat-no-jquery.min.js"&gt;&lt;/script&gt;
+&lt;script&gt;
+(function() {
+  new ZammadChat({
+<span class="js-modal-params"></span>
+  });
+})();
 &lt;/script&gt;</code></pre>
 
   <h3><%- @T('Manually open chat') %></h3>
   <p><%- @T('If you want to open the chat by clicking a button, set the option §show§ to §false§ and add the class §open-zammad-chat§ to the button.') %></p>
   <pre><code class="language-html js-code">&lt;button class="open-zammad-chat"&gt;Chat with us&lt;/button&gt;
 
+&lt;!-- With jQuery --&gt;
 &lt;script src="<%= @baseurl %>/assets/chat/chat.min.js"&gt;&lt;/script&gt;
 &lt;script&gt;
 $(function() {
@@ -165,6 +177,17 @@ $(function() {
     show: false
   });
 });
+&lt;/script&gt;
+
+&lt;!-- Without jQuery --&gt;
+&lt;script src="<%= @baseurl %>/assets/chat/chat-no-jquery.min.js"&gt;&lt;/script&gt;
+&lt;script&gt;
+(function() {
+  new ZammadChat({
+<span class="js-modal-params"></span>,
+    show: false
+  });
+})();
 &lt;/script&gt;</code></pre>
 
   <h3><%- @T("Why doesn't the chat show up?") %></h3>


### PR DESCRIPTION
Added details on how to add chat-no-jquery.js to the Chat page. Wrapped it in an IIFE to preserve the same separation as in jQuery.

Wanted to set up the chat without jQuery on my website, but I could only find information about it from other issues, so thought I could update the information here as well. First time working with Eco template, so hope everything is fine!