### PR TITLE
Show reply all button when cc

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
@@ -15,6 +15,8 @@ class EmailReply extends App.Controller
 
       # check if reply all needs to be shown
       recipients = []
+      recipientsCC = []
+
       if article.sender.name is 'Customer'
         if article.from
           localRecipients = emailAddresses.parseAddressList(article.from)
@@ -28,6 +30,7 @@ class EmailReply extends App.Controller
         localRecipients = emailAddresses.parseAddressList(article.cc)
         if localRecipients
           recipients = recipients.concat localRecipients
+          recipientsCC = recipients.concat localRecipients
 
       # remove system addresses
       localAddresses = App.EmailAddress.all()
@@ -48,7 +51,7 @@ class EmailReply extends App.Controller
               foreignRecipients.push recipient
 
       # check if reply all is needed
-      if foreignRecipients.length > 1
+      if foreignRecipients.length > 1 || recipientsCC.length > 0
         actions.push {
           name: __('reply all')
           type: 'emailReplyAll'

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
@@ -15,7 +15,7 @@ class EmailReply extends App.Controller
 
       # check if reply all needs to be shown
       recipients = []
-      recipientsCC = []
+      recipientsHasCC = false
 
       if article.sender.name is 'Customer'
         if article.from
@@ -30,7 +30,7 @@ class EmailReply extends App.Controller
         localRecipients = emailAddresses.parseAddressList(article.cc)
         if localRecipients
           recipients = recipients.concat localRecipients
-          recipientsCC = recipientsCC.concat localRecipients
+          recipientsHasCC = true
 
       # remove system addresses
       localAddresses = App.EmailAddress.all()
@@ -51,7 +51,7 @@ class EmailReply extends App.Controller
               foreignRecipients.push recipient
 
       # check if reply all is needed
-      if foreignRecipients.length > 1 || recipientsCC.length > 0
+      if foreignRecipients.length > 1 or recipientsHasCC
         actions.push {
           name: __('reply all')
           type: 'emailReplyAll'

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
@@ -51,7 +51,7 @@ class EmailReply extends App.Controller
               foreignRecipients.push recipient
 
       # check if reply all is needed
-      if foreignRecipients.length > 1 or recipientsHasCC
+      if foreignRecipients.length > 1 || recipientsHasCC
         actions.push {
           name: __('reply all')
           type: 'emailReplyAll'

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_action/email_reply.coffee
@@ -30,7 +30,7 @@ class EmailReply extends App.Controller
         localRecipients = emailAddresses.parseAddressList(article.cc)
         if localRecipients
           recipients = recipients.concat localRecipients
-          recipientsCC = recipients.concat localRecipients
+          recipientsCC = recipientsCC.concat localRecipients
 
       # remove system addresses
       localAddresses = App.EmailAddress.all()


### PR DESCRIPTION
This PR fixes #4325 however as I was looking at this code I became unsure of the desired functionality.

I was also unable to find the original PR that added this functionality in the first place.

I'm not sure if the debate should be here or in the issue, so first let me offer my apologies for this triple failure on my part :)

TLDR: When do we show the 'Reply-all' button in an email ticket? The current code counts how many non-agents (foreignRecipients) are in the to/from/cc fields combined. If this total is more than 1, show the 'Reply-all' button.

I assume this was an attempt to spare various agents a lot of email - but the current code does not actually remove any email addresses or spare them from getting an email; except if they are CC'd in a ticket, then they are un-CC'd since there is no 'Reply-all' button.

Personally - if the email address was included in the to/from/cc headers, I would like that person to get an email. I think this is the expected behavior from most of our agents. In this case, most of this code can be removed and a simple counter over the to/from/cc with > 2 will suffice.

