### PR TITLE
Allow pointer events on input:readonly fields to make it copy-/selectable

### DIFF
--- a/app/assets/stylesheets/zammad.scss
+++ b/app/assets/stylesheets/zammad.scss
@@ -2100,6 +2100,11 @@ fieldset > .form-group {
   &.is-readonly .controls:not(.ignore-readonly) {
     pointer-events: none;
     cursor: not-allowed !important;
+
+    input:read-only.form-control {
+      pointer-events: auto;
+      cursor: not-allowed;
+    }
   }
 
   &.form-group--nested {


### PR DESCRIPTION
Fixes #5172

The commit introduces an additional css rule to modify the cursor and pointer event of the readonly input elements directly. Since changing it in line [2101](https://github.com/binsky08/zammad/blob/6e71bbfc68d4d26f7aa6bf0f89f640ca5f778d7b/app/assets/stylesheets/zammad.scss#L2101) could introduce unexpected side effects in other places, this change should only improve the ux without damaging anything else.

Change preview:

[issue-5172-readonly-input.webm](https://github.com/user-attachments/assets/ee467f8b-1464-4b25-b009-c5cfc3fedb57)
