### PR TITLE
Allow Asset Precompilation Without PostgreSQL Connection

### DIFF
--- a/config/initializers/models_preload.rb
+++ b/config/initializers/models_preload.rb
@@ -7,5 +7,7 @@ Rails.application.reloader.to_prepare do
     Models.all
   rescue ActiveRecord::StatementInvalid
     nil
+  rescue ActiveRecord::ConnectionNotEstablished
+    Zammad::SafeMode.continue_or_exit!
   end
 end

--- a/config/initializers/zzz_action_cable_preferences.rb
+++ b/config/initializers/zzz_action_cable_preferences.rb
@@ -33,5 +33,7 @@ Rails.application.reloader.to_prepare do
     Rails.logger.info { "ActionCable is configured to accept requests from #{request_origins.join(', ')}." }
   rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
     Rails.logger.warn { "Database doesn't exist. Skipping allowed_request_origins configuration." }
+  rescue ActiveRecord::ConnectionNotEstablished
+    Zammad::SafeMode.continue_or_exit!
   end
 end

--- a/contrib/docker/setup.sh
+++ b/contrib/docker/setup.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$1" = 'builder' ]; then
-  PACKAGES="build-essential curl git libimlib2-dev libpq-dev shared-mime-info postgresql"
+  PACKAGES="build-essential curl git libimlib2-dev libpq-dev"
 elif [ "$1" = 'runner' ]; then
   PACKAGES="curl libimlib2 libpq5 nginx gnupg postgresql-client"
 fi
@@ -14,11 +14,6 @@ apt-get install -y --no-install-recommends ${PACKAGES}
 rm -rf /var/lib/apt/lists/*
 
 if [ "$1" = 'builder' ]; then
-  # Create an empty DB just so that the Rails stack can run.
-  /etc/init.d/postgresql start
-  su - postgres bash -c "createuser zammad -R -S"
-  su - postgres bash -c "createdb --encoding=utf8 --owner=zammad zammad"
-
   cd "${ZAMMAD_DIR}"
   bundle config set --local without 'test development mysql'
   # Don't use the 'deployment' switch here as it would require always using 'bundle exec'
@@ -27,7 +22,7 @@ if [ "$1" = 'builder' ]; then
   bundle install
 
   touch db/schema.rb
-  ZAMMAD_SAFE_MODE=1 DATABASE_URL=postgresql://zammad:/zammad bundle exec rake assets:precompile # Don't require Redis.
+  ZAMMAD_SAFE_MODE=1 DATABASE_URL=postgresql://zammad:/zammad bundle exec rake assets:precompile # Don't require Redis or Postgres.
 
   script/build/cleanup.sh
 fi


### PR DESCRIPTION
Currently, when running `rake assets:precompile`, the system requires a PostgreSQL connection even though it's not actually needed for asset compilation. This is because some Rails initializers try to connect to the database during startup.

For example, in the Docker build process (`contrib/docker/setup.sh`), there is a step to install and start PostgreSQL before assets can be compiled, which is unnecessary overhead.

### Solution

This PR allows running asset precompilation without a PostgreSQL connection by using Zammad's existing Safe Mode feature. 

### Changes Made

1. Added `Zammad::SafeMode` support to two initializers that try to connect to PostgreSQL:
   - `config/initializers/models_preload.rb`
   - `config/initializers/zzz_action_cable_preferences.rb`

2. When these initializers fail to connect to PostgreSQL, they now use the same Safe Mode behavior that's already used for Redis connections.

### How to Use

You can now compile assets without PostgreSQL by running:
```bash
ZAMMAD_SAFE_MODE=1 bundle exec rake assets:precompile
```

### Important Notes

- Safe Mode already exists in Zammad and is documented for running console without a dependency on Redis
- This change extends the same pattern to PostgreSQL connections
- Regular operations (like `rails console`) will still work normally when PostgreSQL is available
- The way Safe Mode is used here only prevents errors during initialization when PostgreSQL isn't available
- In `rails console` usage, if PG is unavailable `ActiveRecord::Base.connected?` will be false, as is standard Rails behavior for this scenario.

### Alternative Considered

I considered creating a new environment variable like `RAILS_ASSETS_PRECOMPILE=1` specifically for this purpose, but decided to reuse the existing `ZAMMAD_SAFE_MODE` feature since it already handles similar cases with Redis. I can revisit this if preferable.

### My Use Case

Building the Docker images in a build environment where it's not practical to have Postgres running (even temporarily)