### PR TITLE
feat: Allow use message_thread_id as chat_id in telegram channel

### DIFF
--- a/app/assets/javascripts/app/views/telegram/bot_add.jst.eco
+++ b/app/assets/javascripts/app/views/telegram/bot_add.jst.eco
@@ -37,4 +37,12 @@
       <div class="js-messagesGroup"></div>
     </div>
   </div>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="message_thread_id_as_chat_id"><%- @T('Use thread id as chat id in Telegram Forums.') %></label>
+    </div>
+    <div class="controls">
+      <input id="message_thread_id_as_chat_id" type="checkbox" name="message_thread_id_as_chat_id" value="1">
+    </div>
+  </div>
 </fieldset>

--- a/app/assets/javascripts/app/views/telegram/bot_edit.jst.eco
+++ b/app/assets/javascripts/app/views/telegram/bot_edit.jst.eco
@@ -34,4 +34,12 @@
       <div class="js-messagesGroup"></div>
     </div>
   </div>
+  <div class="input form-group">
+    <div class="formGroup-label">
+      <label for="message_thread_id_as_chat_id"><%- @T('Use thread id as chat id in Telegram Forums.') %></label>
+    </div>
+    <div class="controls">
+      <input id="message_thread_id_as_chat_id" type="checkbox" name="message_thread_id_as_chat_id" value="1">
+    </div>
+  </div>
 </fieldset>


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

Good day, guys. Thank you for your work!

This PR allows to use message thread id as chat id to identify issue (see [message object structure](https://core.telegram.org/bots/api#message)). This is useful only in telegram supergroups (aka forums).

Sure thing I missed lot's here, so feel free to show me what I haven't done!
