### PR TITLE
Fix misleading language used for SAML TLS verification

### DIFF
--- a/app/models/setting/validation/saml/tls.rb
+++ b/app/models/setting/validation/saml/tls.rb
@@ -34,9 +34,9 @@ class Setting::Validation::Saml::TLS < Setting::Validation::Base
     Rails.logger.error("SAML: TLS verification failed for '#{url}': #{resp.error}")
 
     if resp.error.starts_with?('#<OpenSSL::SSL::SSLError')
-      __('The verification of the TLS connection failed. Please check the SAML IDP certificate.')
+      __('The verification of the TLS connection to the IDP SSO target URL failed. Please check the SAML IDP HTTPs certificate.')
     else
-      __('The verification of the TLS connection is not possible. Please check the SAML IDP connection.')
+      __('The verification of the TLS connection to the IDP SSO target URL is not possible. Please check the connection.')
     end
   end
 end

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -1946,7 +1946,7 @@ Setting.create_if_not_exists(
           false => 'no',
         },
         default: true,
-        help:    __('Turning off SSL verification is a security risk and should be used only temporary. Use this option at your own risk!'),
+        help:    __('This option only checks if the SSL connection is properly configured. Deactivating it has no security impact.'),
       },
       {
         display: __('Signing & Encrypting'),


### PR DESCRIPTION
As brought up in #5225 the language used for the SAML TLS verification is quite misleading.
This PR changes the language to clearly state that the SSL verification setting does have no security impact.
It also changes the language of the error message to clearly state that the HTTPs connection to the IDP SSO target URL is the one that breaks.