### PR TITLE
Typo fix in `locales.yml` for 'sl'

### DIFF
--- a/config/locales.yml
+++ b/config/locales.yml
@@ -136,7 +136,7 @@
   dir: ltr
 - locale: sl
   alias: ''
-  name: Slovenian (Slovenčina)
+  name: Slovenian (Slovenščina)
   active: true
   dir: ltr
 - locale: sv-se


### PR DESCRIPTION
Minor typo fix.