### PR TITLE
Fallback to /proc/meminfo when lshw is unavailable

### DIFF
--- a/app/models/system_report/plugin/hardware.rb
+++ b/app/models/system_report/plugin/hardware.rb
@@ -14,11 +14,11 @@ class SystemReport::Plugin::Hardware < SystemReport::Plugin
   def total_memory
     memory = open3_data&.dig('children')&.find { |entry| entry['description'].downcase == 'motherboard' }&.dig('children')&.find { |entry| entry['description'].downcase == 'system memory' }&.dig('size')
 
-    return memory unless memory.nil?
+    return memory if !memory.nil?
 
     # Fallback to /proc/meminfo if lshw is missing or fails
     begin
-      mem_kb = File.read('/proc/meminfo')[/MemTotal:\s+(\d+) kB/, 1].to_i
+      mem_kb = File.read('/proc/meminfo')[%r{MemTotal:\s+(\d+) kB}, 1].to_i
       mem_kb * 1024
     rescue
       nil

--- a/app/models/system_report/plugin/hardware.rb
+++ b/app/models/system_report/plugin/hardware.rb
@@ -12,7 +12,17 @@ class SystemReport::Plugin::Hardware < SystemReport::Plugin
   end
 
   def total_memory
-    open3_data&.dig('children')&.find { |entry| entry['description'].downcase == 'motherboard' }&.dig('children')&.find { |entry| entry['description'].downcase == 'system memory' }&.dig('size')
+    memory = open3_data&.dig('children')&.find { |entry| entry['description'].downcase == 'motherboard' }&.dig('children')&.find { |entry| entry['description'].downcase == 'system memory' }&.dig('size')
+
+    return memory unless memory.nil?
+
+    # Fallback to /proc/meminfo if lshw is missing or fails
+    begin
+      mem_kb = File.read('/proc/meminfo')[/MemTotal:\s+(\d+) kB/, 1].to_i
+      mem_kb * 1024
+    rescue
+      nil
+    end
   end
 
   def df_zammad_root


### PR DESCRIPTION
In Docker containers, `lshw` is often missing, causing Zammad’s system report to return `null` for total memory.

As a fallback, use `/proc/meminfo`. Note that values may slightly differ due to reserved memory.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
