### PR TITLE
Better: remove useless symbolize keys

### DIFF
--- a/app/models/application_model/can_associations.rb
+++ b/app/models/application_model/can_associations.rb
@@ -361,7 +361,6 @@ returns
         data[key.to_sym] = value
       end
 
-      data.symbolize_keys!
       available_attributes = attribute_names
       reflect_on_all_associations.map do |assoc|
 


### PR DESCRIPTION
Hey, I stumbled upon this while integrating Zammad to our stack.

Keys are already symbolised when we fill the hash content on line 361.