### PR TITLE
Feature: Modernize developer workflow.

### DIFF
--- a/.dev/.env.dist
+++ b/.dev/.env.dist
@@ -1,0 +1,27 @@
+RAILS_ENV=development
+REDIS_URL=redis://localhost:6379
+
+# Zammad configuration.
+
+ZAMMAD_BIND_IP=0.0.0.0
+DB_ADAPTER=postgresql
+DB_PASSWORD=zammad
+REDIS_URL=redis://redis:6379
+ELASTICSEARCH_URL=http://elasticsearch:9200
+DB_ADAPTER=postgresql
+DB_HOST=zammad-postgresql
+DB_NAME=zammad
+DB_USER=zammad
+DB_PASSWORD=zammad
+
+# PostgreSQL configuration.
+
+POSTGRESQL_PASS=zammad
+POSTGRESQL_USER=zammad
+POSTGRESQL_HOST=zammad-postgresql
+POSTGRESQL_PORT=5432
+POSTGRESQL_DB=zammad
+POSTGRESQL_OPTIONS=
+
+# Elasticsearch configuration.
+ELASTICSEARCH_HOST=elasticsearch

--- a/.dev/docker-compose.yml
+++ b/.dev/docker-compose.yml
@@ -1,0 +1,65 @@
+services:
+  zammad-postgresql:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: zammad
+      POSTGRES_PASSWORD: zammad
+      POSTGRES_DB: zammad
+    volumes:
+      - zammad_pg_data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+
+  redis:
+    image: redis:7
+    volumes:
+      - zammad_redis_data:/data
+    ports:
+      - '6379:6379'
+
+  zammad-elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.6
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 2g
+    ports:
+      - '9200:9200'
+    volumes:
+      - zammad_elasticsearch_data:/usr/share/elasticsearch/data
+      - ./es-plugins.sh:/usr/share/elasticsearch/plugins_install.sh
+    entrypoint: ["/bin/bash", "-c", "/usr/share/elasticsearch/plugins_install.sh && /usr/local/bin/docker-entrypoint.sh"]
+
+  zammad:
+    image: zammad-dev:latest
+    command: pnpm run dev
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:3000 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    build:
+      context: ..
+      args:
+        COMMIT_SHA: ${COMMIT_SHA:-dev}
+        RAILS_ENV: "development"
+    depends_on:
+      - zammad-postgresql
+      - redis
+      - zammad-elasticsearch
+    env_file: .env
+    ports:
+      - '3000:3000'
+      - '6042:6042'
+      - '3036:3036'
+    volumes:
+      - ..:/opt/zammad
+
+volumes:
+  zammad_pg_data:
+  zammad_redis_data:
+  zammad_elasticsearch_data:

--- a/.dev/es-plugins.sh
+++ b/.dev/es-plugins.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+PLUGINS=(
+  "ingest-attachment"
+  # Add more here if needed in future
+)
+
+for plugin in "${PLUGINS[@]}"; do
+  if ! elasticsearch-plugin list | grep -q "$plugin"; then
+    echo "Installing plugin: $plugin"
+    elasticsearch-plugin install --batch "$plugin"
+  else
+    echo "Plugin already installed: $plugin"
+  fi
+done

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,13 @@ schema.graphql
 
 # Packages
 *.zpm
+
+# Environment
+.env
+
+# Shell history (local dev only)
+/.bash_history
+
+# Local config and state
+.cache
+.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN contrib/docker/setup.sh builder
 FROM ruby:3.3.8-slim-bookworm
 ARG DEBIAN_FRONTEND=noninteractive
 ARG ZAMMAD_USER=zammad
-ENV RAILS_ENV=production
+ARG RAILS_ENV=production
+ENV RAILS_ENV=${RAILS_ENV}
 ENV RAILS_LOG_TO_STDOUT=true
 ENV ZAMMAD_DIR=/opt/zammad
 
@@ -30,6 +31,26 @@ COPY --from=builder ${ZAMMAD_DIR} .
 COPY --from=builder /usr/local/bundle /usr/local/bundle
 COPY --from=builder ${ZAMMAD_DIR}/contrib/docker/docker-entrypoint.sh /
 RUN contrib/docker/setup.sh runner
+
+RUN if [ "$RAILS_ENV" = "development" ]; then \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    nodejs \
+    npm \
+    curl \
+    ca-certificates \
+    git \
+    golang && \
+  npm install -g corepack && \
+  corepack enable && \
+  corepack prepare pnpm@10.9.0 --activate && \
+  mkdir -p /tmp/go/src/github.com/ddollar && \
+  git clone https://github.com/ddollar/forego.git /tmp/go/src/github.com/ddollar/forego && \
+  cd /tmp/go/src/github.com/ddollar/forego && \
+  GOPATH=/tmp/go GO111MODULE=off go build -o /usr/local/bin/forego && \
+  chmod +x /usr/local/bin/forego && \
+  rm -rf /tmp/go /var/lib/apt/lists/*; \
+fi
 
 USER zammad:zammad
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PROJECT_NAME=zammad-dev
+COMPOSE_FILE=".dev/docker-compose.yml"
+ENV_FILE=".dev/.env"
+ENV_TEMPLATE=".dev/.env.dist"
+
+# Ensure .env exists
+if [ ! -f "$ENV_FILE" ]; then
+  echo "📝 .env file not found, copying default from .env.dist"
+  cp "$ENV_TEMPLATE" "$ENV_FILE"
+fi
+
+echo "🧹 Removing previous containers..."
+docker-compose -f "$COMPOSE_FILE" down --volumes --remove-orphans || true
+
+echo "🔧 Building and starting containers..."
+COMMIT_SHA=$(git rev-parse HEAD) RAILS_ENV=development docker-compose -f "$COMPOSE_FILE" up -d --remove-orphans
+
+echo "⚙️  Running one-shot DB initializer..."
+docker compose -f "$COMPOSE_FILE" run --rm zammad zammad-init
+
+echo "✅ Zammad is running at: http://localhost:3000"


### PR DESCRIPTION
Modernize Developer Workflow with Docker-Based Dev Mode
This PR improves the development experience by allowing contributors to run Zammad entirely within Docker—no need to install Ruby, Node, pnpm, or other tools on the host machine.

✅ What’s included

- Adds conditional installation of dev-only tools (pnpm, forego, golang, etc.) when RAILS_ENV=development.
- Preserves the small image size for production.
- Ensures full frontend + backend development is possible from within a single container.
- Automatically runs pnpm install on container startup to support the Vite dev server.
- Allows Vite to bind to 0.0.0.0 via ZAMMAD_BIND_IP so it's accessible externally.

🤝 Why this is useful

- No local setup is needed—just clone and run ./dev.sh.
- Great for contributors who prefer isolated dev environments.
- More consistent onboarding and testing experience.

🙏 Request for feedback
I tried to keep things clean, minimal and consistent, but I may be missing something. Please let me know if there are better places to hook this in or any conventions I should align with.

Thanks!