### PR TITLE
Update `websocket` server to bind to IPv6

### DIFF
--- a/contrib/docker/docker-entrypoint.sh
+++ b/contrib/docker/docker-entrypoint.sh
@@ -164,7 +164,7 @@ elif [ "$1" = 'zammad-websocket' ]; then
 
   echo "starting websocket server..."
 
-  exec bundle exec script/websocket-server.rb -b 0.0.0.0 -p "${ZAMMAD_WEBSOCKET_PORT}" start
+  exec bundle exec script/websocket-server.rb -b :: -p "${ZAMMAD_WEBSOCKET_PORT}" start
 
 # zammad-backup
 elif [ "$1" = 'zammad-backup' ]; then


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
This pull request updates the websocket server configuration to bind to an IPv6 address instead of IPv4.
The `railsserver` is already configured to bind to IPv6, and this change ensures the `websocket` server is consistent with that setup.

Currently, the websocket server binds to an IPv4 address, which prevents deployment in IPv6-only environments.
By updating the bind address, it can now support IPv6-only deployments and improve consistency between the `railsserver` and the `websocket` server.