### PR TITLE
Update EN password change notification

### DIFF
--- a/app/views/mailer/password_change/en.html.erb
+++ b/app/views/mailer/password_change/en.html.erb
@@ -4,6 +4,6 @@ Your #{config.product_name} password has been changed
 <br>
 <p>The password for your #{config.product_name} account <b>#{user.login}</b> has been changed recently.</p>
 <br>
-<p>This activity is not known to you? If not, contact your system administrator.</p>
+<p>If you did not initiate this change, please contact your system administrator.</p>
 <br>
 <p>Your #{config.product_name} Team</p>


### PR DESCRIPTION
The current notification text for a password change may sound a bit strange to a native English speaker. This change tries to fix that.