### PR TITLE
Sanitize FQDN by removing port to comply with RFC 5321 (HELO/EHLO)

### DIFF
--- a/app/models/channel/driver/smtp.rb
+++ b/app/models/channel/driver/smtp.rb
@@ -57,6 +57,8 @@ class Channel::Driver::Smtp < Channel::Driver::BaseEmailOutbound
           fqdn = domain
         end
       end
+      # remove :port, is not allowed by RFC 5321 / 4.1.1.1. EHLO/HELO
+      fqdn = fqdn.split(':').first
       options[:domain] = fqdn
     end
 


### PR DESCRIPTION
This change removes any port number from the FQDN before it is used in the SMTP HELO/EHLO command. According to RFC 5321 section 4.1.1.1, the domain name used in HELO/EHLO must be a valid FQDN without a port.

In some environments, the FQDN may include a port (e.g., xyz.example.com:8080), which leads to SMTP errors such as:

501 5.5.4 Invalid domain name

To address this, we strip the port using:

fqdn = fqdn.split(':').first

This ensures compatibility with SMTP servers and avoids invalid domain errors during mail delivery.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
