### PR TITLE
Set SAML ServiceName attribute based on the configured product name

### DIFF
--- a/lib/omni_auth/strategies/saml_database.rb
+++ b/lib/omni_auth/strategies/saml_database.rb
@@ -18,6 +18,7 @@ class OmniAuth::Strategies::SamlDatabase < OmniAuth::Strategies::SAML
     config = auth_saml_credentials.compact_blank
       .merge(
         assertion_consumer_service_url: assertion_consumer_service_url,
+        attribute_service_name:         Setting.get('product_name'),
         sp_entity_id:                   entity_id,
         single_logout_service_url:      single_logout_service_url,
         idp_slo_session_destroy:        proc { |env, session| destroy_session(env, session) },


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
After configuring SAML login, the metadata provided by Zammad at /auth/saml/metadata currently returns the string "Required attributes" for the Service name. This seems to be a placeholder value from the Omniauth library (https://github.com/omniauth/omniauth-saml/blob/master/lib/omniauth/strategies/saml.rb).

Here's the tail of the metadata where you can see the issue:
```
<md:AttributeConsumingService index="1" isDefault="true">
<md:ServiceName xml:lang="en">Required attributes</md:ServiceName>
<md:RequestedAttribute FriendlyName="Email address" Name="email" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" isRequired="false"/>
<md:RequestedAttribute FriendlyName="Full name" Name="name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" isRequired="false"/>
<md:RequestedAttribute FriendlyName="Given name" Name="first_name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" isRequired="false"/>
<md:RequestedAttribute FriendlyName="Family name" Name="last_name" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic" isRequired="false"/>
</md:AttributeConsumingService>
</md:SPSSODescriptor>
</md:EntityDescriptor>
```

SAML IDPs like Shibboleth may display the ServiceName attribute on the login screen. This pull requests sets this value to the product name that the admin can configure in the branding tab. As I'm neither familiar with Ruby nor the Zammad codebase, I hope this is an appropriate fix. I tested it with my local system.