### PR TITLE
feat: Set default locale to Persian

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,9 @@ module Zammad
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
+    # Set default locale to Persian.
+    config.i18n.default_locale = :fa
+
     Rails.autoloaders.each do |autoloader|
       autoloader.ignore            "#{config.root}/app/frontend"
       autoloader.do_not_eager_load "#{config.root}/lib/core_ext"


### PR DESCRIPTION
Sets the default locale to Persian (`fa`).
This makes the UI default to Persian with an RTL layout.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
