### PR TITLE
Rename "contains" operators (e.g. Tags)  #4916

### DIFF
--- a/app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee
@@ -29,14 +29,14 @@ class App.UiElement.ApplicationSelector
       'integer$': [__('is'), __('is not'), __('is less than'), __('is less than or equal to'), __('is greater than'), __('is greater than or equal to')]
       '^radio$': [__('is'), __('is not')]
       '^select$': [__('is'), __('is not')]
-      '^multiselect$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+      '^multiselect$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
       '^tree_select$': [__('is'), __('is not')]
-      '^multi_tree_select$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+      '^multi_tree_select$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
       '^autocompletion_ajax_external_data_source$': [__('is'), __('is not')]
       '^input$': [__('contains'), __('contains not'), __('is any of'), __('is none of'), __('starts with one of'), __('ends with one of')]
       '^richtext$': [__('contains'), __('contains not')]
       '^textarea$': [__('contains'), __('contains not')]
-      '^tag$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+      '^tag$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
 
     if attribute.hasChanged
       operators_type =
@@ -47,14 +47,14 @@ class App.UiElement.ApplicationSelector
         'integer$': [__('is'), __('is not'),  __('is less than'), __('is less than or equal to'), __('is greater than'), __('is greater than or equal to'), __('has changed')]
         '^radio$': [__('is'), __('is not'), __('has changed')]
         '^select$': [__('is'), __('is not'), __('has changed')]
-        '^multiselect$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+        '^multiselect$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
         '^tree_select$': [__('is'), __('is not'), __('has changed')]
-        '^multi_tree_select$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+        '^multi_tree_select$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
         '^autocompletion_ajax_external_data_source$': [__('is'), __('is not'), __('has changed')]
         '^input$': [__('contains'), __('contains not'), __('has changed'), __('is any of'), __('is none of'), __('starts with one of'), __('ends with one of')]
         '^richtext$': [__('contains'), __('contains not'), __('has changed')]
         '^textarea$': [__('contains'), __('contains not'), __('has changed')]
-        '^tag$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+        '^tag$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
 
     if attribute.hasRegexOperators && App.Config.get('ticket_conditions_allow_regular_expression_operators')
       operators_type['^input$'].push(__('matches regex'), __('does not match regex'))

--- a/app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee
@@ -142,8 +142,8 @@ class App.UiElement.core_workflow_condition extends App.UiElement.ApplicationSel
       '^multiselect$': [
         __('contains'),
         __('contains not'),
-        __('contains all'),
-        __('contains all not'),
+        __('includes all'),
+        __('excludes all'),
         __('is set'),
         __('not set'),
         __('is modified'),
@@ -164,8 +164,8 @@ class App.UiElement.core_workflow_condition extends App.UiElement.ApplicationSel
       '^multi_tree_select$': [
         __('contains'),
         __('contains not'),
-        __('contains all'),
-        __('contains all not'),
+        __('includes all'),
+        __('excludes all'),
         __('is set'),
         __('not set'),
         __('is modified'),
@@ -212,10 +212,10 @@ class App.UiElement.core_workflow_condition extends App.UiElement.ApplicationSel
         __('just changed to')
       ]
       '^tag$': [
-        __('contains all'),
-        __('contains one'),
-        __('contains all not'),
-        __('contains one not')
+        __('includes all'),
+        __('includes any'),
+        __('excludes all'),
+        __('excludes any')
       ]
 
     operatorsName =

--- a/app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee
@@ -56,14 +56,14 @@ class App.UiElement.object_selector extends App.UiElement.ApplicationSelectorExp
       'integer$': [__('is'), __('is not'), __('is less than'), __('is less than or equal to'), __('is greater than'), __('is greater than or equal to')]
       '^radio$': [__('is'), __('is not')]
       '^select$': [__('is'), __('is not')]
-      '^multiselect$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+      '^multiselect$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
       '^tree_select$': [__('is'), __('is not')]
-      '^multi_tree_select$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+      '^multi_tree_select$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
       '^autocompletion_ajax_external_data_source$': [__('is'), __('is not')]
       '^input$': [__('contains'), __('contains not'), __('is any of'), __('is none of'), __('starts with one of'), __('ends with one of')]
       '^richtext$': [__('contains'), __('contains not')]
       '^textarea$': [__('contains'), __('contains not')]
-      '^tag$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+      '^tag$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
 
     if attribute.hasChanged
       operators_type =
@@ -74,14 +74,14 @@ class App.UiElement.object_selector extends App.UiElement.ApplicationSelectorExp
         'integer$': [__('is'), __('is not'), __('is less than'), __('is less than or equal to'), __('is greater than'), __('is greater than or equal to'), __('has changed')]
         '^radio$': [__('is'), __('is not'), __('has changed')]
         '^select$': [__('is'), __('is not'), __('has changed')]
-        '^multiselect$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+        '^multiselect$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
         '^tree_select$': [__('is'), __('is not'), __('has changed')]
-        '^multi_tree_select$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+        '^multi_tree_select$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
         '^autocompletion_ajax_external_data_source$': [__('is'), __('is not'), __('has changed')]
         '^input$': [__('contains'), __('contains not'), __('has changed'), __('is any of'), __('is none of'), __('starts with one of'), __('ends with one of')]
         '^richtext$': [__('contains'), __('contains not'), __('has changed')]
         '^textarea$': [__('contains'), __('contains not'), __('has changed')]
-        '^tag$': [__('contains all'), __('contains one'), __('contains all not'), __('contains one not')]
+        '^tag$': [__('includes all'), __('includes any'), __('excludes all'), __('excludes any')]
 
     if attribute.hasRegexOperators && App.Config.get('ticket_conditions_allow_regular_expression_operators')
       operators_type['^input$'].push(__('matches regex'), __('does not match regex'))

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -613,7 +613,7 @@ msgstr ""
 msgid "A test ticket has been created, you can find it in your overview \"%s\" %l."
 msgstr ""
 
-#: app/models/ticket.rb:295
+#: app/models/ticket.rb:296
 msgid "A ticket cannot be merged into itself."
 msgstr ""
 
@@ -1409,7 +1409,7 @@ msgid "Agent idle timeout"
 msgstr ""
 
 #: app/models/role.rb:151
-#: app/models/user.rb:756
+#: app/models/user.rb:757
 msgid "Agent limit exceeded, please check your account settings."
 msgstr ""
 
@@ -1992,7 +1992,7 @@ msgstr ""
 msgid "At least one filter must be provided."
 msgstr ""
 
-#: app/models/user.rb:658
+#: app/models/user.rb:659
 msgid "At least one identifier (firstname, lastname, phone, mobile or email) for user is required."
 msgstr ""
 
@@ -2005,7 +2005,7 @@ msgid "At least one object must be selected."
 msgstr ""
 
 #: app/models/role.rb:128
-#: app/models/user.rb:735
+#: app/models/user.rb:736
 msgid "At least one user needs to have admin permissions."
 msgstr ""
 
@@ -6038,7 +6038,7 @@ msgstr ""
 msgid "Email address"
 msgstr ""
 
-#: app/models/user.rb:668
+#: app/models/user.rb:669
 msgid "Email address '%{email}' is already used for another user."
 msgstr ""
 
@@ -8555,7 +8555,7 @@ msgstr ""
 msgid "Invalid client_id received!"
 msgstr ""
 
-#: app/models/user.rb:607
+#: app/models/user.rb:608
 msgid "Invalid email '%{email}'"
 msgstr ""
 
@@ -8719,7 +8719,7 @@ msgstr ""
 msgid "It is not possible to delete your current account."
 msgstr ""
 
-#: app/models/ticket.rb:293
+#: app/models/ticket.rb:294
 msgid "It is not possible to merge into an already merged ticket."
 msgstr ""
 
@@ -10127,7 +10127,7 @@ msgstr ""
 msgid "More information can be found here."
 msgstr ""
 
-#: app/models/user.rb:687
+#: app/models/user.rb:688
 msgid "More than 250 secondary organizations are not allowed."
 msgstr ""
 
@@ -10927,7 +10927,7 @@ msgstr ""
 msgid "No translation for this locale available"
 msgstr ""
 
-#: app/models/ticket.rb:418
+#: app/models/ticket.rb:419
 msgid "No triggers active"
 msgstr ""
 
@@ -13794,11 +13794,11 @@ msgstr ""
 msgid "Secondary organizations"
 msgstr ""
 
-#: app/models/user.rb:675
+#: app/models/user.rb:676
 msgid "Secondary organizations are only allowed when the primary organization is given."
 msgstr ""
 
-#: app/models/user.rb:681
+#: app/models/user.rb:682
 msgid "Secondary organizations cannot include the primary organization."
 msgstr ""
 
@@ -16366,7 +16366,7 @@ msgstr ""
 msgid "The server presented a certificate that could not be verified."
 msgstr ""
 
-#: lib/user_agent.rb:236
+#: lib/user_agent.rb:235
 msgid "The server returned a redirect response, but the current operation does not allow redirects."
 msgstr ""
 
@@ -17883,7 +17883,7 @@ msgstr ""
 msgid "Token-based API access has been disabled by the administrator."
 msgstr ""
 
-#: lib/user_agent.rb:240
+#: lib/user_agent.rb:239
 msgid "Too many redirections for the original URL, halting."
 msgstr ""
 
@@ -19781,7 +19781,7 @@ msgstr ""
 msgid "Zammad Helpdesk"
 msgstr ""
 
-#: lib/user_agent.rb:126
+#: lib/user_agent.rb:125
 msgid "Zammad User Agent"
 msgstr ""
 
@@ -20009,40 +20009,16 @@ msgstr ""
 msgid "connected"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
+#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:36
 #: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:143
-#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
+#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:63
 msgid "contains"
-msgstr ""
-
-#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
-#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:145
-#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
-msgid "contains all"
-msgstr ""
-
-#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
-#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:146
-#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
-msgid "contains all not"
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:36
 #: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:144
 #: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:63
 msgid "contains not"
-msgstr ""
-
-#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
-#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:216
-#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
-msgid "contains one"
-msgstr ""
-
-#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
-#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:218
-#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
-msgid "contains one not"
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:87
@@ -20258,6 +20234,18 @@ msgstr ""
 msgid "example macro"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
+#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:146
+#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
+msgid "excludes all"
+msgstr ""
+
+#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
+#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:218
+#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
+msgid "excludes any"
+msgstr ""
+
 #: db/seeds/ticket_article_types.rb:16
 msgid "facebook direct-message"
 msgstr ""
@@ -20457,6 +20445,18 @@ msgstr ""
 msgid "inactive"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
+#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:145
+#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
+msgid "includes all"
+msgstr ""
+
+#: app/assets/javascripts/app/controllers/_ui_element/_application_selector.coffee:32
+#: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:216
+#: app/assets/javascripts/app/controllers/_ui_element/object_selector.coffee:59
+msgid "includes any"
+msgstr ""
+
 #: app/assets/javascripts/app/controllers/_ui_element/_application_action.coffee:605
 #: app/assets/javascripts/app/controllers/knowledge_base/content_can_be_published_form.coffee:91
 msgid "internal"
@@ -20589,7 +20589,7 @@ msgstr ""
 msgid "is the wrong length (should be 1 character)"
 msgstr ""
 
-#: app/models/user.rb:872
+#: app/models/user.rb:873
 msgid "is too long"
 msgstr ""
 

--- a/lib/selector/search_index.rb
+++ b/lib/selector/search_index.rb
@@ -294,7 +294,7 @@ class Selector::SearchIndex < Selector::Base
       when 'is not', 'contains not', 'is none of'
         query_must_not.push t
       end
-    elsif ['contains all', 'contains one', 'contains all not', 'contains one not'].include?(data[:operator])
+    elsif ['includes all', 'includes any', 'excludes all', 'excludes any'].include?(data[:operator])
       values = data[:value]
       if data[:value].is_a?(String)
         values = values.split(',').map(&:strip)
@@ -302,16 +302,16 @@ class Selector::SearchIndex < Selector::Base
 
       t[:query_string] = {}
       case data[:operator]
-      when 'contains all'
+      when 'includes all'
         t[:query_string][:query] = "#{key_tmp}:(\"#{values.join('" AND "')}\")"
         query_must.push t
-      when 'contains one not'
+      when 'excludes any'
         t[:query_string][:query] = "#{key_tmp}:(\"#{values.join('" OR "')}\")"
         query_must_not.push t
-      when 'contains one'
+      when 'includes any'
         t[:query_string][:query] = "#{key_tmp}:(\"#{values.join('" OR "')}\")"
         query_must.push t
-      when 'contains all not'
+      when 'excludes all'
         t[:query_string][:query] = "#{key_tmp}:(\"#{values.join('" AND "')}\")"
         query_must_not.push t
       end

--- a/lib/selector/sql.rb
+++ b/lib/selector/sql.rb
@@ -6,11 +6,11 @@ class Selector::Sql < Selector::Base
     'after (relative)',
     'before (absolute)',
     'before (relative)',
-    'contains all not',
-    'contains all',
+    'excludes all',
+    'includes all',
     'contains not',
-    'contains one not',
-    'contains one',
+    'excludes any',
+    'includes any',
     'contains',
     'does not match regex',
     'ends with one of',
@@ -163,9 +163,9 @@ class Selector::Sql < Selector::Base
       block_condition[:value] = block_condition[:value].split(',').collect(&:strip)
     end
 
-    # Performance: use left join instead of sub select if tags value is only one element and contains all is used
-    if attribute_table == 'ticket' && attribute_name == 'tags' && block_condition[:operator] == 'contains all' && block_condition[:value].one?
-      block_condition[:operator] = 'contains one'
+    # Performance: use left join instead of sub select if tags value is only one element and includes all is used
+    if attribute_table == 'ticket' && attribute_name == 'tags' && block_condition[:operator] == 'includes all' && block_condition[:value].one?
+      block_condition[:operator] = 'includes any'
     end
 
     # User customer tickets last_contact_at
@@ -486,7 +486,7 @@ class Selector::Sql < Selector::Base
     elsif block_condition[:operator] == 'does not match regex'
       query << sql_helper.regex_match(attribute, negated: true)
       bind_params.push block_condition[:value]
-    elsif block_condition[:operator] == 'contains all'
+    elsif block_condition[:operator] == 'includes all'
       if attribute_table == 'ticket' && attribute_name == 'tags'
         query << "tickets.id IN (
                         SELECT
@@ -509,7 +509,7 @@ class Selector::Sql < Selector::Base
       elsif sql_helper.containable?(attribute_name)
         query << sql_helper.array_contains_all(attribute_name, block_condition[:value])
       end
-    elsif block_condition[:operator] == 'contains one'
+    elsif block_condition[:operator] == 'includes any'
       if attribute_name == 'tags' && attribute_table == 'ticket'
         tables |= ["LEFT JOIN tags ON tickets.id = tags.o_id LEFT JOIN tag_objects ON tag_objects.id = tags.tag_object_id AND tag_objects.name = 'Ticket' LEFT JOIN tag_items ON tag_items.id = tags.tag_item_id"]
         query << 'tag_items.name IN (?)'
@@ -518,7 +518,7 @@ class Selector::Sql < Selector::Base
       elsif sql_helper.containable?(attribute_name)
         query << sql_helper.array_contains_one(attribute_name, block_condition[:value])
       end
-    elsif block_condition[:operator] == 'contains all not'
+    elsif block_condition[:operator] == 'excludes all'
       if attribute_name == 'tags' && attribute_table == 'ticket'
         query << "tickets.id NOT IN (
                         SELECT
@@ -540,7 +540,7 @@ class Selector::Sql < Selector::Base
       elsif sql_helper.containable?(attribute_name)
         query << sql_helper.array_contains_all(attribute_name, block_condition[:value], negated: true)
       end
-    elsif block_condition[:operator] == 'contains one not'
+    elsif block_condition[:operator] == 'excludes any'
       if attribute_name == 'tags' && attribute_table == 'ticket'
         query << "tickets.id NOT IN (
                         SELECT

--- a/public/assets/tests/qunit/form_ticket_selector_expert_conditions.js
+++ b/public/assets/tests/qunit/form_ticket_selector_expert_conditions.js
@@ -391,22 +391,22 @@ QUnit.test('renders additional attributes correctly', (assert) => {
         },
         {
           name: 'ticket.tags',
-          operator: 'contains all',
+          operator: 'includes all',
           value: 'tag 1, tag 2',
         },
         {
           name: 'ticket.tags',
-          operator: 'contains one',
+          operator: 'includes any',
           value: 'tag 1',
         },
         {
           name: 'ticket.tags',
-          operator: 'contains all not',
+          operator: 'excludes all',
           value: 'tag 3, tag 4',
         },
         {
           name: 'ticket.tags',
-          operator: 'contains one not',
+          operator: 'excludes any',
           value: 'tag 3',
         },
         {
@@ -539,22 +539,22 @@ QUnit.test('renders additional attributes correctly', (assert) => {
         },
         {
           name: 'ticket.test_multiselect',
-          operator: 'contains all',
+          operator: 'includes all',
           value: ['a', 'b'],
         },
         {
           name: 'ticket.test_multiselect',
-          operator: 'contains one',
+          operator: 'includes any',
           value: ['c'],
         },
         {
           name: 'ticket.test_multiselect',
-          operator: 'contains all not',
+          operator: 'excludes all',
           value: ['b', 'c'],
         },
         {
           name: 'ticket.test_multiselect',
-          operator: 'contains one not',
+          operator: 'excludes any',
           value: ['a'],
         },
         {
@@ -569,22 +569,22 @@ QUnit.test('renders additional attributes correctly', (assert) => {
         },
         {
           name: 'ticket.test_multi_tree_select',
-          operator: 'contains all',
+          operator: 'includes all',
           value: ['a', 'a::b'],
         },
         {
           name: 'ticket.test_multi_tree_select',
-          operator: 'contains one',
+          operator: 'includes any',
           value: ['a::b::c'],
         },
         {
           name: 'ticket.test_multi_tree_select',
-          operator: 'contains all not',
+          operator: 'excludes all',
           value: ['a::b', 'a::b::c'],
         },
         {
           name: 'ticket.test_multi_tree_select',
-          operator: 'contains one not',
+          operator: 'excludes any',
           value: ['a'],
         },
         {
@@ -699,16 +699,16 @@ QUnit.test('renders additional attributes correctly', (assert) => {
 
   // Check ticket tag options.
   assert.equal(el.find('.js-filterElement:nth-child(21) .js-attributeSelector select option:selected').text(), 'Tags', 'tags attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(21) .js-operator select option:selected').text(), 'contains all', 'contains all operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(21) .js-operator select option:selected').text(), 'includes all', 'includes all operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(21) .js-value input.form-control').val(), 'tag 1, tag 2', 'tag 1, tag 2 input value')
   assert.equal(el.find('.js-filterElement:nth-child(22) .js-attributeSelector select option:selected').text(), 'Tags', 'tags attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(22) .js-operator select option:selected').text(), 'contains one', 'contains one operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(22) .js-operator select option:selected').text(), 'includes any', 'includes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(22) .js-value input.form-control').val(), 'tag 1', 'tag 1 input value')
   assert.equal(el.find('.js-filterElement:nth-child(23) .js-attributeSelector select option:selected').text(), 'Tags', 'tags attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(23) .js-operator select option:selected').text(), 'contains all not', 'contains all not operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(23) .js-operator select option:selected').text(), 'excludes all', 'excludes all operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(23) .js-value input.form-control').val(), 'tag 3, tag 4', 'tag 3, tag 4 input value')
   assert.equal(el.find('.js-filterElement:nth-child(24) .js-attributeSelector select option:selected').text(), 'Tags', 'tags attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(24) .js-operator select option:selected').text(), 'contains one not', 'contains one not operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(24) .js-operator select option:selected').text(), 'excludes any', 'excludes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(24) .js-value input.form-control').val(), 'tag 3', 'tag 3 input value')
 
   // Check custom text attribute options.
@@ -808,18 +808,18 @@ QUnit.test('renders additional attributes correctly', (assert) => {
 
   // Check custom multiselect attribute options.
   assert.equal(el.find('.js-filterElement:nth-child(49) .js-attributeSelector select option:selected').text(), 'test_multiselect', 'test_multiselect attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(49) .js-operator select option:selected').text(), 'contains all', 'contains all operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(49) .js-operator select option:selected').text(), 'includes all', 'includes all operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(49) .js-value select option:selected:nth-child(1)').text(), 'A', 'A value selected')
   assert.equal(el.find('.js-filterElement:nth-child(49) .js-value select option:selected:nth-child(2)').text(), 'B', 'B value selected')
   assert.equal(el.find('.js-filterElement:nth-child(50) .js-attributeSelector select option:selected').text(), 'test_multiselect'), 'test_multiselect attribute selected'
-  assert.equal(el.find('.js-filterElement:nth-child(50) .js-operator select option:selected').text(), 'contains one', 'contains one operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(50) .js-operator select option:selected').text(), 'includes any', 'includes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(50) .js-value select option:selected').text(), 'C', 'C value selected')
   assert.equal(el.find('.js-filterElement:nth-child(51) .js-attributeSelector select option:selected').text(), 'test_multiselect', 'test_multiselect attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(51) .js-operator select option:selected').text(), 'contains all not', 'contains all not operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(51) .js-operator select option:selected').text(), 'excludes all', 'excludes all operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(51) .js-value select option:selected:nth-child(2)').text(), 'B', 'B value selected')
   assert.equal(el.find('.js-filterElement:nth-child(51) .js-value select option:selected:nth-child(3)').text(), 'C', 'B value selected')
   assert.equal(el.find('.js-filterElement:nth-child(52) .js-attributeSelector select option:selected').text(), 'test_multiselect', 'test_multiselect attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(52) .js-operator select option:selected').text(), 'contains one not', 'contains one not operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(52) .js-operator select option:selected').text(), 'excludes any', 'excludes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(52) .js-value select option:selected').text(), 'A', 'A value selected')
 
   // Check custom tree select attribute options.
@@ -833,18 +833,18 @@ QUnit.test('renders additional attributes correctly', (assert) => {
 
   // Check custom multiselect attribute options.
   assert.equal(el.find('.js-filterElement:nth-child(55) .js-attributeSelector select option:selected').text(), 'test_multi_tree_select', 'test_multi_tree_select attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(55) .js-operator select option:selected').text(), 'contains all', 'contains all operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(55) .js-operator select option:selected').text(), 'includes all', 'includes all operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(55) .js-value select option:selected:nth-child(1)').text(), 'a', 'a value selected')
   assert.equal(el.find('.js-filterElement:nth-child(55) .js-value select option:selected:nth-child(2)').text(), 'a::b', 'a::b value selected')
   assert.equal(el.find('.js-filterElement:nth-child(56) .js-attributeSelector select option:selected').text(), 'test_multi_tree_select', 'test_multi_tree_select attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(56) .js-operator select option:selected').text(), 'contains one', 'contains one operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(56) .js-operator select option:selected').text(), 'includes any', 'includes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(56) .js-value select option:selected').text(), 'a::b::c', 'a::b::c value selected')
   assert.equal(el.find('.js-filterElement:nth-child(57) .js-attributeSelector select option:selected').text(), 'test_multi_tree_select', 'test_multi_tree_select attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(57) .js-operator select option:selected').text(), 'contains all not', 'contains all not operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(57) .js-operator select option:selected').text(), 'excludes all', 'excludes all operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(57) .js-value select option:selected:nth-child(1)').text(), 'a::b', 'a::b value selected')
   assert.equal(el.find('.js-filterElement:nth-child(57) .js-value select option:selected:nth-child(2)').text(), 'a::b::c', 'a::b::c value selected')
   assert.equal(el.find('.js-filterElement:nth-child(58) .js-attributeSelector select option:selected').text(), 'test_multi_tree_select', 'test_multi_tree_select attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(58) .js-operator select option:selected').text(), 'contains one not', 'contains one not operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(58) .js-operator select option:selected').text(), 'excludes any', 'excludes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(58) .js-value select option:selected').text(), 'a', 'a value selected')
 
   // Check customer VIP flag options (boolean).
@@ -1287,12 +1287,12 @@ QUnit.test('handles tags attribute without any errors #4507', (assert) => {
       conditions: [
         {
           name: 'ticket.tags',
-          operator: 'contains one',
+          operator: 'includes any',
           value: 'tag 1',
         },
         {
           name: 'ticket.tags',
-          operator: 'contains one not',
+          operator: 'excludes any',
           value: 'tag 2',
         },
       ],
@@ -1310,15 +1310,15 @@ QUnit.test('handles tags attribute without any errors #4507', (assert) => {
   })
 
   assert.equal(el.find('.js-filterElement:nth-child(2) .js-attributeSelector select option:selected').text(), 'Tags', 'tags attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(2) .js-operator select option:selected').text(), 'contains one', 'contains one operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(2) .js-operator select option:selected').text(), 'includes any', 'includes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(2) .js-value input.form-control').val(), 'tag 1', 'tag 1 input value')
   assert.equal(el.find('.js-filterElement:nth-child(3) .js-attributeSelector select option:selected').text(), 'Tags', 'tags attribute selected')
-  assert.equal(el.find('.js-filterElement:nth-child(3) .js-operator select option:selected').text(), 'contains one not', 'contains one not operator selected')
+  assert.equal(el.find('.js-filterElement:nth-child(3) .js-operator select option:selected').text(), 'excludes any', 'excludes any operator selected')
   assert.equal(el.find('.js-filterElement:nth-child(3) .js-value input.form-control').val(), 'tag 2', 'tag 2 input value')
 
-  el.find('.js-filterElement:nth-child(2) .js-operator select').val('contains all').trigger('change')
+  el.find('.js-filterElement:nth-child(2) .js-operator select').val('includes all').trigger('change')
   el.find('.js-filterElement:nth-child(2) .js-value input.form-control').val('tag 3, tag 4').trigger('change')
-  el.find('.js-filterElement:nth-child(3) .js-operator select').val('contains all not').trigger('change')
+  el.find('.js-filterElement:nth-child(3) .js-operator select').val('excludes all').trigger('change')
   el.find('.js-filterElement:nth-child(3) .js-value input.form-control').val('tag 5, tag 6').trigger('change')
 
   var params = App.ControllerForm.params(el)
@@ -1328,12 +1328,12 @@ QUnit.test('handles tags attribute without any errors #4507', (assert) => {
       conditions: [
         {
           name: 'ticket.tags',
-          operator: 'contains all',
+          operator: 'includes all',
           value: 'tag 3, tag 4',
         },
         {
           name: 'ticket.tags',
-          operator: 'contains all not',
+          operator: 'excludes all',
           value: 'tag 5, tag 6',
         },
       ],

--- a/spec/lib/report/ticket_generic_time_spec.rb
+++ b/spec/lib/report/ticket_generic_time_spec.rb
@@ -143,11 +143,11 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         )
       end
 
-      context 'with contains all' do
+      context 'with includes all' do
         let(:selector) do
           {
             'ticket.tags' => {
-              'operator' => 'contains all',
+              'operator' => 'includes all',
               'value'    => 'tag1, tag2'
             }
           }
@@ -158,11 +158,11 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         it_behaves_like 'getting the correct aggregated results'
       end
 
-      context 'with contains one not' do
+      context 'with excludes any' do
         let(:selector) do
           {
             'ticket.tags' => {
-              'operator' => 'contains one not',
+              'operator' => 'excludes any',
               'value'    => 'tag1, tag2'
             }
           }
@@ -173,11 +173,11 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         it_behaves_like 'getting the correct aggregated results'
       end
 
-      context 'with contains one' do
+      context 'with includes any' do
         let(:selector) do
           {
             'ticket.tags' => {
-              'operator' => 'contains one',
+              'operator' => 'includes any',
               'value'    => 'tag1, tag2'
             }
           }
@@ -188,11 +188,11 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         it_behaves_like 'getting the correct aggregated results'
       end
 
-      context 'with contains all not' do
+      context 'with excludes all' do
         let(:selector) do
           {
             'ticket.tags' => {
-              'operator' => 'contains all not',
+              'operator' => 'excludes all',
               'value'    => 'tag1, tag2'
             }
           }
@@ -340,7 +340,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains all',
+            'operator' => 'includes all',
             'value'    => 'aaa, bbb'
           }
         },
@@ -356,7 +356,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains all not',
+            'operator' => 'excludes all',
             'value'    => 'aaa, bbb'
           }
         },
@@ -372,7 +372,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains all',
+            'operator' => 'includes all',
             'value'    => 'aaa'
           }
         },
@@ -388,7 +388,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains all not',
+            'operator' => 'excludes all',
             'value'    => 'aaa'
           }
         },
@@ -404,7 +404,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains one not',
+            'operator' => 'excludes any',
             'value'    => 'aaa'
           }
         },
@@ -420,7 +420,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains one not',
+            'operator' => 'excludes any',
             'value'    => 'aaa, bbb'
           }
         },
@@ -436,7 +436,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains one',
+            'operator' => 'includes any',
             'value'    => 'aaa'
           }
         },
@@ -452,7 +452,7 @@ RSpec.describe Report::TicketGenericTime, searchindex: true do
         range_end:   Time.zone.parse('2015-12-31T23:59:59Z'),
         selector:    {
           'tags' => {
-            'operator' => 'contains one',
+            'operator' => 'includes any',
             'value'    => 'aaa, bbb'
           }
         },

--- a/spec/lib/search_index_backend_spec.rb
+++ b/spec/lib/search_index_backend_spec.rb
@@ -480,9 +480,9 @@ RSpec.describe SearchIndexBackend do
         expect(result).to eq({ count: 8, object_ids: [ticket8.id.to_s, ticket7.id.to_s, ticket6.id.to_s, ticket5.id.to_s, ticket4.id.to_s, ticket3.id.to_s, ticket2.id.to_s, ticket1.id.to_s] })
       end
 
-      it 'finds records with tags which contains all' do
+      it 'finds records with tags which includes all' do
         result = described_class.selectors('Ticket',
-                                           { 'ticket.tags'=>{ 'operator' => 'contains all', 'value' => 't1, t2' } },
+                                           { 'ticket.tags'=>{ 'operator' => 'includes all', 'value' => 't1, t2' } },
                                            {},
                                            {
                                              field: 'created_at', # sort to verify result
@@ -490,9 +490,9 @@ RSpec.describe SearchIndexBackend do
         expect(result).to eq({ count: 1, object_ids: [ticket3.id.to_s] })
       end
 
-      it 'finds records with tags which contains one' do
+      it 'finds records with tags which includes any' do
         result = described_class.selectors('Ticket',
-                                           { 'ticket.tags'=>{ 'operator' => 'contains one', 'value' => 't1, t2' } },
+                                           { 'ticket.tags'=>{ 'operator' => 'includes any', 'value' => 't1, t2' } },
                                            {},
                                            {
                                              field: 'created_at', # sort to verify result
@@ -500,9 +500,9 @@ RSpec.describe SearchIndexBackend do
         expect(result).to eq({ count: 3, object_ids: [ticket3.id.to_s, ticket2.id.to_s, ticket1.id.to_s] })
       end
 
-      it 'finds records with tags which contains all not' do
+      it 'finds records with tags which excludes all' do
         result = described_class.selectors('Ticket',
-                                           { 'ticket.tags'=>{ 'operator' => 'contains all not', 'value' => 't2' } },
+                                           { 'ticket.tags'=>{ 'operator' => 'excludes all', 'value' => 't2' } },
                                            {},
                                            {
                                              field: 'created_at', # sort to verify result
@@ -510,9 +510,9 @@ RSpec.describe SearchIndexBackend do
         expect(result).to eq({ count: 6, object_ids: [ticket8.id.to_s, ticket7.id.to_s, ticket6.id.to_s, ticket5.id.to_s, ticket4.id.to_s, ticket1.id.to_s] })
       end
 
-      it 'finds records with tags which contains one not' do
+      it 'finds records with tags which excludes any' do
         result = described_class.selectors('Ticket',
-                                           { 'ticket.tags'=>{ 'operator' => 'contains one not', 'value' => 't1' } },
+                                           { 'ticket.tags'=>{ 'operator' => 'excludes any', 'value' => 't1' } },
                                            {},
                                            {
                                              field: 'created_at', # sort to verify result

--- a/spec/lib/selector/base_spec.rb
+++ b/spec/lib/selector/base_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe Selector::Base, searchindex: true do
         conditions: [
           {
             name:     attribute.to_s,
-            operator: 'contains all',
+            operator: 'includes all',
             value:    ['Incident', 'Incident::Hardware'],
           }
         ]
@@ -529,7 +529,7 @@ RSpec.describe Selector::Base, searchindex: true do
       searchindex_model_reload([Ticket, User, Organization])
     end
 
-    it 'does support contains one for all objects' do # rubocop:disable RSpec/NoExpectationExample
+    it 'does support includes any for all objects' do # rubocop:disable RSpec/NoExpectationExample
       check_condition("ticket.#{field_name}")
       check_condition("customer.#{field_name}")
       check_condition("organization.#{field_name}")
@@ -544,13 +544,13 @@ RSpec.describe Selector::Base, searchindex: true do
         searchindex_model_reload([Ticket])
       end
 
-      it 'does return ticket by contains all string value', :aggregate_failures do
+      it 'does return ticket by includes all string value', :aggregate_failures do
         condition = {
           operator:   'AND',
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all',
+              operator: 'includes all',
               value:    'AAA, BBB',
             }
           ]
@@ -574,13 +574,13 @@ RSpec.describe Selector::Base, searchindex: true do
         searchindex_model_reload([Ticket])
       end
 
-      it 'does return ticket by contains all array value', :aggregate_failures do
+      it 'does return ticket by includes all array value', :aggregate_failures do
         condition = {
           operator:   'AND',
           conditions: [
             {
               name:     "ticket.#{field_name}",
-              operator: 'contains all',
+              operator: 'includes all',
               value:    ['Incident', 'Incident::Hardware'],
             }
           ]
@@ -808,14 +808,14 @@ RSpec.describe Selector::Base, searchindex: true do
       searchindex_model_reload([Ticket])
     end
 
-    describe 'contains all' do
+    describe 'includes all' do
       it 'checks tags a = 2', :aggregate_failures do
         condition = {
           operator:   'AND',
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all',
+              operator: 'includes all',
               value:    'a',
             },
           ]
@@ -834,7 +834,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all',
+              operator: 'includes all',
               value:    'a,b',
             },
           ]
@@ -853,7 +853,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all',
+              operator: 'includes all',
               value:    'a,c',
             },
           ]
@@ -872,7 +872,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all',
+              operator: 'includes all',
               value:    'a,b,c',
             },
           ]
@@ -891,7 +891,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all',
+              operator: 'includes all',
               value:    'c,d',
             },
           ]
@@ -910,7 +910,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all',
+              operator: 'includes all',
               value:    'd',
             },
           ]
@@ -924,14 +924,14 @@ RSpec.describe Selector::Base, searchindex: true do
       end
     end
 
-    describe 'contains one' do
+    describe 'includes any' do
       it 'checks tags a = 2', :aggregate_failures do
         condition = {
           operator:   'AND',
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one',
+              operator: 'includes any',
               value:    'a',
             },
           ]
@@ -950,7 +950,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one',
+              operator: 'includes any',
               value:    'a,b',
             },
           ]
@@ -969,7 +969,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one',
+              operator: 'includes any',
               value:    'a,c',
             },
           ]
@@ -988,7 +988,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one',
+              operator: 'includes any',
               value:    'a,b,c',
             },
           ]
@@ -1007,7 +1007,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one',
+              operator: 'includes any',
               value:    'c,d',
             },
           ]
@@ -1026,7 +1026,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one',
+              operator: 'includes any',
               value:    'd',
             },
           ]
@@ -1040,14 +1040,14 @@ RSpec.describe Selector::Base, searchindex: true do
       end
     end
 
-    describe 'contains all not' do
+    describe 'excludes all' do
       it 'checks tags a = 1', :aggregate_failures do
         condition = {
           operator:   'AND',
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all not',
+              operator: 'excludes all',
               value:    'a',
             },
           ]
@@ -1066,7 +1066,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all not',
+              operator: 'excludes all',
               value:    'a,b',
             },
           ]
@@ -1085,7 +1085,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all not',
+              operator: 'excludes all',
               value:    'a,c',
             },
           ]
@@ -1104,7 +1104,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all not',
+              operator: 'excludes all',
               value:    'a,b,c',
             },
           ]
@@ -1123,7 +1123,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all not',
+              operator: 'excludes all',
               value:    'c,d',
             },
           ]
@@ -1142,7 +1142,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains all not',
+              operator: 'excludes all',
               value:    'd',
             },
           ]
@@ -1156,14 +1156,14 @@ RSpec.describe Selector::Base, searchindex: true do
       end
     end
 
-    describe 'contains one not' do
+    describe 'excludes any' do
       it 'checks tags a = 1', :aggregate_failures do
         condition = {
           operator:   'AND',
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one not',
+              operator: 'excludes any',
               value:    'a',
             },
           ]
@@ -1182,7 +1182,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one not',
+              operator: 'excludes any',
               value:    'a,b',
             },
           ]
@@ -1201,7 +1201,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one not',
+              operator: 'excludes any',
               value:    'a,c',
             },
           ]
@@ -1220,7 +1220,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one not',
+              operator: 'excludes any',
               value:    'a,b,c',
             },
           ]
@@ -1239,7 +1239,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one not',
+              operator: 'excludes any',
               value:    'c,d',
             },
           ]
@@ -1258,7 +1258,7 @@ RSpec.describe Selector::Base, searchindex: true do
           conditions: [
             {
               name:     'ticket.tags',
-              operator: 'contains one not',
+              operator: 'excludes any',
               value:    'd',
             },
           ]

--- a/spec/models/core_workflow/conditions_spec.rb
+++ b/spec/models/core_workflow/conditions_spec.rb
@@ -583,7 +583,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains all',
+                     operator: 'includes all',
                      value:    ['special'],
                    },
                  })
@@ -604,7 +604,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains all',
+                     operator: 'includes all',
                      value:    ['NOPE'],
                    },
                  })
@@ -631,7 +631,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains all',
+                     operator: 'includes all',
                      value:    ['special'],
                    },
                  })
@@ -648,7 +648,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains all',
+                     operator: 'includes all',
                      value:    ['NOPE'],
                    },
                  })
@@ -671,7 +671,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains all',
+                     operator: 'includes all',
                      value:    ['special'],
                    },
                  })
@@ -692,7 +692,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains all',
+                     operator: 'includes all',
                      value:    ['NOPE'],
                    },
                  })
@@ -704,7 +704,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
       end
     end
 
-    context 'when contains one' do
+    context 'when includes any' do
       context 'when match' do
         let(:payload) do
           base_payload.merge('params' => { 'tags' => 'special, special2' })
@@ -715,7 +715,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains one',
+                     operator: 'includes any',
                      value:    ['special'],
                    },
                  })
@@ -736,7 +736,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
                  object:             'Ticket',
                  condition_selected: {
                    'ticket.tags': {
-                     operator: 'contains one',
+                     operator: 'includes any',
                      value:    ['NOPE'],
                    },
                  })
@@ -1230,7 +1230,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
              object:             'Ticket',
              condition_selected: {
                "ticket.#{field_name}": {
-                 operator: 'contains all',
+                 operator: 'includes all',
                  value:    %w[key_1 key_2],
                },
              })
@@ -1298,7 +1298,7 @@ RSpec.describe 'CoreWorkflow > Conditions', type: :model do
              object:             'Ticket',
              condition_selected: {
                "ticket.#{field_name}": {
-                 operator: 'contains all not',
+                 operator: 'excludes all',
                  value:    %w[key_1 key_2],
                },
              })

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe Job, type: :model do
           end
 
           describe 'use case: deleting tickets based on tag' do
-            let(:condition) { { 'ticket.tags' => { 'operator' => 'contains one', 'value' => 'spam' } } }
+            let(:condition) { { 'ticket.tags' => { 'operator' => 'includes any', 'value' => 'spam' } } }
             let(:perform)             { { 'ticket.action' => { 'value' => 'delete' } } }
             let!(:matching_ticket)    { create(:ticket).tap { |t| t.tag_add('spam', 1) } }
             let!(:nonmatching_ticket) { create(:ticket) }

--- a/spec/models/tag/item_spec.rb
+++ b/spec/models/tag/item_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Tag::Item do
 
       context "with reference to renamed tag in its #{method} hash (contains-one)" do
         let(:object)      { create(object_klass.name.underscore, method => { label => tag_matcher }) }
-        let(:tag_matcher) { { operator: 'contains one', value: 'test1' } }
+        let(:tag_matcher) { { operator: 'includes any', value: 'test1' } }
 
         it 'updates reference with new tag name' do
           expect { described_class.rename(id: item.id, name: 'test1_renamed') }
@@ -93,7 +93,7 @@ RSpec.describe Tag::Item do
                        conditions: [
                          {
                            name:     label,
-                           operator: 'contains one',
+                           operator: 'includes any',
                            value:    'test1',
                          },
                        ]
@@ -115,7 +115,7 @@ RSpec.describe Tag::Item do
                        'conditions' => [
                          {
                            'name'     => label,
-                           'operator' => 'contains one',
+                           'operator' => 'includes any',
                            'value'    => 'test2',
                          },
                          {
@@ -123,7 +123,7 @@ RSpec.describe Tag::Item do
                            'conditions' => [
                              {
                                'name'     => label,
-                               'operator' => 'contains one',
+                               'operator' => 'includes any',
                                'value'    => 'test1',
                              },
                            ],
@@ -143,7 +143,7 @@ RSpec.describe Tag::Item do
 
       context "with reference to renamed tag in its #{method} hash (contains-all)" do
         let(:object) { create(object_klass.name.underscore, method => { label => tag_matcher }) }
-        let(:tag_matcher) { { operator: 'contains all', value: 'test1, test2, test3' } }
+        let(:tag_matcher) { { operator: 'includes all', value: 'test1, test2, test3' } }
 
         it 'updates reference with new tag name' do
           expect { described_class.rename(id: item.id, name: 'test1_renamed') }
@@ -160,7 +160,7 @@ RSpec.describe Tag::Item do
                        conditions: [
                          {
                            name:     label,
-                           operator: 'contains all',
+                           operator: 'includes all',
                            value:    'test1, test2, test3',
                          },
                        ]
@@ -182,7 +182,7 @@ RSpec.describe Tag::Item do
                        'conditions' => [
                          {
                            'name'     => label,
-                           'operator' => 'contains one',
+                           'operator' => 'includes any',
                            'value'    => 'test2',
                          },
                          {
@@ -190,7 +190,7 @@ RSpec.describe Tag::Item do
                            'conditions' => [
                              {
                                'name'     => label,
-                               'operator' => 'contains one',
+                               'operator' => 'includes any',
                                'value'    => 'test1',
                              },
                            ],

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe Trigger, type: :model do
         context 'mix of recipient group keyword and single recipient users' do
           let(:recipient) { [ 'ticket_customer', "userid_#{recipient1.id}", "userid_#{recipient2.id}", "userid_#{recipient3.id}" ] }
 
-          it 'contains all recipients' do
+          it 'includes all recipients' do
             expect(ticket.articles.last.to).to eq("#{ticket.customer.email}, #{recipient1.email}, #{recipient2.email}, #{recipient3.email}")
           end
 
@@ -293,7 +293,7 @@ RSpec.describe Trigger, type: :model do
         context 'list of single users only' do
           let(:recipient) { [ "userid_#{recipient1.id}", "userid_#{recipient2.id}", "userid_#{recipient3.id}" ] }
 
-          it 'contains all recipients' do
+          it 'includes all recipients' do
             expect(ticket.articles.last.to).to eq("#{recipient1.email}, #{recipient2.email}, #{recipient3.email}")
           end
 
@@ -1181,8 +1181,8 @@ RSpec.describe Trigger, type: :model do
         end
       end
 
-      context "with 'contains all' used" do
-        let(:operator) { 'contains all' }
+      context "with 'includes all' used" do
+        let(:operator) { 'includes all' }
 
         context 'when updated value is the same with trigger value' do
           let(:ticket_multiselect_values) { trigger_values }
@@ -1208,7 +1208,7 @@ RSpec.describe Trigger, type: :model do
           it_behaves_like 'updating the ticket with the trigger condition'
         end
 
-        context 'when updated value contains one of the trigger value' do
+        context 'when updated value includes any of the trigger value' do
           let(:ticket_multiselect_values) { [trigger_values.first] }
 
           it_behaves_like 'not updating the ticket with the trigger condition'
@@ -1221,8 +1221,8 @@ RSpec.describe Trigger, type: :model do
         end
       end
 
-      context "with 'contains one' used" do
-        let(:operator) { 'contains one' }
+      context "with 'includes any' used" do
+        let(:operator) { 'includes any' }
 
         context 'when updated value is the same with trigger value' do
           let(:ticket_multiselect_values) { trigger_values }
@@ -1261,8 +1261,8 @@ RSpec.describe Trigger, type: :model do
         end
       end
 
-      context "with 'contains all not' used" do
-        let(:operator) { 'contains all not' }
+      context "with 'excludes all' used" do
+        let(:operator) { 'excludes all' }
 
         context 'when updated value is the same with trigger value' do
           let(:ticket_multiselect_values) { trigger_values }
@@ -1301,8 +1301,8 @@ RSpec.describe Trigger, type: :model do
         end
       end
 
-      context "with 'contains one not' used" do
-        let(:operator) { 'contains one not' }
+      context "with 'excludes any' used" do
+        let(:operator) { 'excludes any' }
 
         context 'when updated value is the same with trigger value' do
           let(:ticket_multiselect_values) { trigger_values }

--- a/spec/system/manage/overviews_expert_conditions_spec.rb
+++ b/spec/system/manage/overviews_expert_conditions_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'Expert conditions in Manage > Overviews', type: :system do
         within '.ticket_selector' do
           toggle_expert_mode(true)
 
-          set_condition(2, 'Tags', 'contains all', value_token_input: %w[tag1 tag2])
+          set_condition(2, 'Tags', 'includes all', value_token_input: %w[tag1 tag2])
         end
 
         click '.js-submit'
@@ -125,7 +125,7 @@ RSpec.describe 'Expert conditions in Manage > Overviews', type: :system do
           'conditions' => [
             {
               'name'     => 'ticket.tags',
-              'operator' => 'contains all',
+              'operator' => 'includes all',
               'value'    => %w[tag1 tag2].join(', '),
             },
           ],
@@ -405,12 +405,12 @@ RSpec.describe 'Expert conditions in Manage > Overviews', type: :system do
               'conditions' => [
                 {
                   'name'     => 'ticket.tags',
-                  'operator' => 'contains one',
+                  'operator' => 'includes any',
                   'value'    => %w[tag1 tag2].join(', '),
                 },
                 {
                   'name'     => 'ticket.tags',
-                  'operator' => 'contains one not',
+                  'operator' => 'excludes any',
                   'value'    => %w[tag3 tag4].join(', '),
                 },
               ],
@@ -423,11 +423,11 @@ RSpec.describe 'Expert conditions in Manage > Overviews', type: :system do
             within '.ticket_selector' do
               check_expert_mode(true)
               check_subclause_selector(1, 'Match any (OR)')
-              check_condition(2, 'Tags', 'contains one', value_token_input: %w[tag1 tag2])
-              check_condition(3, 'Tags', 'contains one not', value_token_input: %w[tag3 tag4])
+              check_condition(2, 'Tags', 'includes any', value_token_input: %w[tag1 tag2])
+              check_condition(3, 'Tags', 'excludes any', value_token_input: %w[tag3 tag4])
 
-              set_condition(2, 'Tags', 'contains all', value_token_input: %w[tag5 tag6])
-              set_condition(3, 'Tags', 'contains all not', value_token_input: %w[tag7])
+              set_condition(2, 'Tags', 'includes all', value_token_input: %w[tag5 tag6])
+              set_condition(3, 'Tags', 'excludes all', value_token_input: %w[tag7])
             end
 
             click '.js-submit'
@@ -438,12 +438,12 @@ RSpec.describe 'Expert conditions in Manage > Overviews', type: :system do
               'conditions' => [
                 {
                   'name'     => 'ticket.tags',
-                  'operator' => 'contains all',
+                  'operator' => 'includes all',
                   'value'    => %w[tag5 tag6].join(', '),
                 },
                 {
                   'name'     => 'ticket.tags',
-                  'operator' => 'contains all not',
+                  'operator' => 'excludes all',
                   'value'    => %w[tag7].join(', '),
                 },
               ],

--- a/spec/system/manage/trigger_spec.rb
+++ b/spec/system/manage/trigger_spec.rb
@@ -203,8 +203,8 @@ RSpec.describe 'Manage > Trigger', type: :system do
       end
     end
 
-    context "with 'contains all' used" do
-      let(:operator) { 'contains all' }
+    context "with 'includes all' used" do
+      let(:operator) { 'includes all' }
 
       context 'when updated value is the same with trigger value' do
         let(:ticket_multiselect_values) { trigger_values }
@@ -219,8 +219,8 @@ RSpec.describe 'Manage > Trigger', type: :system do
       end
     end
 
-    context "with 'contains one' used" do
-      let(:operator) { 'contains one' }
+    context "with 'includes any' used" do
+      let(:operator) { 'includes any' }
 
       context 'when updated value is the same with trigger value' do
         let(:ticket_multiselect_values) { trigger_values }
@@ -247,8 +247,8 @@ RSpec.describe 'Manage > Trigger', type: :system do
       end
     end
 
-    context "with 'contains all not' used" do
-      let(:operator) { 'contains all not' }
+    context "with 'excludes all' used" do
+      let(:operator) { 'excludes all' }
 
       context 'when updated value is different from the trigger value' do
         let(:ticket_multiselect_values) { options.values - trigger_values }
@@ -269,8 +269,8 @@ RSpec.describe 'Manage > Trigger', type: :system do
       end
     end
 
-    context "with 'contains one not' used" do
-      let(:operator) { 'contains one not' }
+    context "with 'excludes any' used" do
+      let(:operator) { 'excludes any' }
 
       context 'when updated value is different from the trigger value' do
         let(:ticket_multiselect_values) { options.values - trigger_values }

--- a/test/unit/ticket_selector_test.rb
+++ b/test/unit/ticket_selector_test.rb
@@ -1050,10 +1050,10 @@ class TicketSelectorTest < ActiveSupport::TestCase
       created_by_id: 1,
     )
 
-    # search all with contains all
+    # search all with includes all
     condition = {
       'ticket.tags' => {
-        operator: 'contains all',
+        operator: 'includes all',
         value:    'contains_all_1, contains_all_2, contains_all_3',
       },
     }
@@ -1062,17 +1062,17 @@ class TicketSelectorTest < ActiveSupport::TestCase
 
     condition = {
       'ticket.tags' => {
-        operator: 'contains all',
+        operator: 'includes all',
         value:    'contains_all_1, contains_all_2, contains_all_3, xxx',
       },
     }
     ticket_count, _tickets = Ticket.selectors(condition, limit: 10, current_user: @agent1)
     assert_equal(0, ticket_count)
 
-    # search all with contains one
+    # search all with includes any
     condition = {
       'ticket.tags' => {
-        operator: 'contains one',
+        operator: 'includes any',
         value:    'contains_all_1, contains_all_2, contains_all_3',
       },
     }
@@ -1081,17 +1081,17 @@ class TicketSelectorTest < ActiveSupport::TestCase
 
     condition = {
       'ticket.tags' => {
-        operator: 'contains one',
+        operator: 'includes any',
         value:    'contains_all_1, contains_all_2'
       },
     }
     ticket_count, _tickets = Ticket.selectors(condition, limit: 10, current_user: @agent1)
     assert_equal(1, ticket_count)
 
-    # search all with contains one not
+    # search all with excludes any
     condition = {
       'ticket.tags' => {
-        operator: 'contains one',
+        operator: 'includes any',
         value:    'contains_all_1, contains_all_3'
       },
     }
@@ -1100,7 +1100,7 @@ class TicketSelectorTest < ActiveSupport::TestCase
 
     condition = {
       'ticket.tags' => {
-        operator: 'contains one',
+        operator: 'includes any',
         value:    'contains_all_1, contains_all_2, contains_all_3'
       },
     }

--- a/test/unit/ticket_trigger_recursive_disabled_test.rb
+++ b/test/unit/ticket_trigger_recursive_disabled_test.rb
@@ -3563,8 +3563,8 @@ class TicketTriggerRecursiveDisabledTest < ActiveSupport::TestCase
           'value'    => Ticket::State.lookup(name: 'new').id.to_s,
         },
         'ticket.tags'     => {
-          'operator' => 'contains one not',
-          # 'operator' => 'contains all not',
+          'operator' => 'excludes any',
+          # 'operator' => 'excludes all',
           'value'    => 'sender1, sender2',
         },
       },
@@ -3972,7 +3972,7 @@ class TicketTriggerRecursiveDisabledTest < ActiveSupport::TestCase
           'operator' => 'has changed',
         },
         'ticket.tags'     => {
-          'operator' => 'contains one not',
+          'operator' => 'excludes any',
           'value'    => 'nosendmail test123'
         }
       },
@@ -4001,7 +4001,7 @@ class TicketTriggerRecursiveDisabledTest < ActiveSupport::TestCase
           'operator' => 'has changed',
         },
         'ticket.tags'     => {
-          'operator' => 'contains one not',
+          'operator' => 'excludes any',
           'value'    => 'nosendmail2',
         }
       },

--- a/test/unit/ticket_trigger_test.rb
+++ b/test/unit/ticket_trigger_test.rb
@@ -3602,8 +3602,8 @@ class TicketTriggerTest < ActiveSupport::TestCase
           'value'    => Ticket::State.lookup(name: 'new').id.to_s,
         },
         'ticket.tags'     => {
-          'operator' => 'contains one not',
-          # 'operator' => 'contains all not',
+          'operator' => 'excludes any',
+          # 'operator' => 'excludes all',
           'value'    => 'sender1, sender2',
         },
       },
@@ -4011,7 +4011,7 @@ class TicketTriggerTest < ActiveSupport::TestCase
           'operator' => 'has changed',
         },
         'ticket.tags'     => {
-          'operator' => 'contains one not',
+          'operator' => 'excludes any',
           'value'    => 'nosendmail test123'
         }
       },
@@ -4040,7 +4040,7 @@ class TicketTriggerTest < ActiveSupport::TestCase
           'operator' => 'has changed',
         },
         'ticket.tags'     => {
-          'operator' => 'contains one not',
+          'operator' => 'excludes any',
           'value'    => 'nosendmail2',
         }
       },


### PR DESCRIPTION
### Summary

This PR updates all occurrences of the following operators to improve clarity and consistency based on community feedback in issue #4916:

| Old Name           | New Name        |
|--------------------|-----------------|
| contains one       | includes any    |
| contains all       | includes all    |
| contains one not   | excludes any    |
| contains all not   | excludes all    |

### Changes

- Updated all backend, frontend, and specs reference to the renamed operators 
- Regenerated the translation catalog (`i18n/zammad.pot`) using:
  ```bash
  rails generate zammad:translation_catalog

### Related Issue

Fixes #4916


