### PR TITLE
Getting Started: Devcontainer Setup: ensure database is prepared, add helpful post-install messages and improve documentation 

### DIFF
--- a/.devcontainer/default/compose.yaml
+++ b/.devcontainer/default/compose.yaml
@@ -10,14 +10,15 @@ services:
       DATABASE_URL: postgres://zammad:zammad@postgresql:5432
       REDIS_URL: redis://redis:6379
       # Performance / DX / tests tuning
-      CI_SKIP_ASSETS_PRECOMPILE: 'true'
-      CI_SKIP_DB_RESET: 'true'
-      RAILS_SERVE_STATIC_FILES: 'true'
-      TZ: 'Europe/London'
+      CI_SKIP_ASSETS_PRECOMPILE: "true"
+      # Prepare and seed DB for development
+      CI_SKIP_DB_RESET: "false"
+      RAILS_SERVE_STATIC_FILES: "true"
+      TZ: "Europe/London"
       Z_LOCALES: en-us:en-gb:de-de
       ES_URL: http://elasticsearch:9200
       ES_INDEX: estest.local_zammad
-      VITE_RUBY_HOST: '127.0.0.1'
+      VITE_RUBY_HOST: "127.0.0.1"
 
     depends_on:
       - memcached

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -12,3 +12,11 @@ bundle exec bootsnap precompile --gemfile app/ lib/
 bundle exec rails r "Setting.set('es_url', 'http://elasticsearch:9200')"
 
 bundle exec rails zammad:setup:auto_wizard
+
+echo "== LAUNCHING ZAMMAD =="
+echo "1. Close this terminal by hitting \`Enter\`"
+echo "2. Open a new terminal via \`VS Code\` to attach to devcontainer shell"
+echo "3. Run to start develoment services inside devcontainer:"
+echo "\`\`\`"
+echo "bin/dev"
+echo "\`\`\`"

--- a/doc/developer_manual/development_environment/development-workflow.md
+++ b/doc/developer_manual/development_environment/development-workflow.md
@@ -71,7 +71,7 @@ For further details see:
 
 Linting ensures consistent code style and readability. They are optional but recommended:
 
-- [CoffeeLint](http://www.coffeelint.org/)
+- [CoffeeLint](https://github.com/coffeelint/coffeelint)
 - [Stylelint](https://stylelint.io/)
 - [ESLint](https://eslint.org/)
 - [Markdownlint](https://github.com/DavidAnson/markdownlint)

--- a/doc/developer_manual/development_environment/getting-started.md
+++ b/doc/developer_manual/development_environment/getting-started.md
@@ -48,7 +48,9 @@ bin/dev
 
 ### 5. Login
 
-Once the application is running, open it in your browser at `http://localhost:3000` and use the default development credentials:
+Once the application is running, open it in your browser at either `http://localhost:3000/desktop` (new stack) or `http://localhost:3000` (old stack).
+
+Then use the default development credentials to login:
 
 ```text
 Username / Email: admin@example.com

--- a/doc/developer_manual/development_environment/getting-started.md
+++ b/doc/developer_manual/development_environment/getting-started.md
@@ -34,17 +34,15 @@ For more information, see [devcontainer setup guide](devcontainer-setup.md)
 
 ### 4. Launching Zammad
 
-You can start Zammad development services with:
-
 #### Devcontainer setup
 
-```sh
-dev
-```
+Open a new terminal in `VS Code`. You should now run a `bash` shell attached to your devcontainer.
 
-#### Manual setup
+#### Start development services
 
-```sh
+You can start Zammad all development services with a single command for either devcontainer or manual setup:
+
+```bash
 bin/dev
 ```
 


### PR DESCRIPTION
Hi,

I just tested the new `devcontainer` setup and ran into a few issues. This should fix them. 

I also added helpful post-install messages to devcontainer `post_create.sh` and fixed some issues with "Getting Started" documentation (old link, unify `bin/dev` command for both setups, mention routes for old and new dashboard tech stacks)
