### PR TITLE
ApplySSLCertificates: remove V_FLAG_CRL_CHECK_ALL (OpenSSL fix)

### DIFF
--- a/lib/certificate/apply_ssl_certificates.rb
+++ b/lib/certificate/apply_ssl_certificates.rb
@@ -22,7 +22,6 @@ class Certificate::ApplySSLCertificates
         # Build a new default store.
         store = OpenSSL::X509::Store.new
         store.set_default_paths
-        store.flags = OpenSSL::X509::V_FLAG_CRL_CHECK_ALL
         all_certificates.each { |cert| store.add_cert(cert.certificate_parsed) }
         Kernel.silence_warnings do
           OpenSSL::SSL::SSLContext.const_set(:DEFAULT_CERT_STORE, store)


### PR DESCRIPTION
After upgrading my server to NixOS 25.11 (which was released two weeks ago), I noticed that Zammad was no longer able to send outgoing email via SMTP:

    SSL_connect returned=1 errno=0 peeraddr=[2a00:d70:0:10::1]:465 state=error:
    certificate verify failed (unable to get certificate CRL)
    (OpenSSL::SSL::SSLError)

What broke? OpenSSL 3.6.0 changed the behavior of X509_V_FLAG_CRL_CHECK_ALL so that it no longer requires X509_V_FLAG_CRL_CHECK to also be set. This causes certificate verification to fail ("unable to get certificate CRL") because CRLs are not pre-loaded into the certificate store. 

This behavioral change was accidental and was reverted upstream by now: https://github.com/openssl/openssl/commit/996d50da8fac4938fd910af96389c1e67ff1cb11

By now, Ruby has also removed this flag in the ssl gem: https://github.com/ruby/openssl/commit/e8481cd687840f6d8247ca70967c1de47093ecb8

I assume Zammad copied the certificate store initialization from the ssl gem, so let’s remove this faulty line here, too. In the worst case, it’s a cleanup to align with the ssl gem. In the best case, it saves other users from errors.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
