### PR TITLE
Maintenance: Disable Yarn installation for Node in devcontainer

### DIFF
--- a/.devcontainer/features/zammad-deps/devcontainer-feature.json
+++ b/.devcontainer/features/zammad-deps/devcontainer-feature.json
@@ -8,7 +8,9 @@
       "moby": false
     },
     "ghcr.io/devcontainers-extra/features/shellcheck:1": {},
-    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/node:1": {
+      "installYarnUsingApt": false
+    },
     "ghcr.io/joshuanianji/devcontainer-features/mount-pnpm-store:1": {},
     // Can't use bundler cache, it breaks overcommit:
     //   https://github.com/rails/devcontainer/issues/55


### PR DESCRIPTION
The devcontainer setup currently fails since this weekend (at least it strucks me since then), because the upstream node dependencies are now installed on Debian trixie.

Installing yarn fails with

``` 
######################################################################## 100.0%
2.917 Computing checksum with sha256sum
2.937 Checksums matched!
5.039 Now using node v24.13.0 (npm v11.6.2)
5.141 Creating default alias: default -> lts/* (-> v24.13.0 *)
5.192 => Node.js version lts/* has been successfully installed
5.193 => Close and reopen your terminal to start using nvm or run the following to use it now:
5.193 
5.193 export NVM_DIR="/usr/local/share/nvm"
5.193 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
5.331 default -> lts/* (-> v24.13.0 *)
5.332 Updating /etc/bash.bashrc and /etc/zsh/zshrc...
5.510 Get:1 https://dl.yarnpkg.com/debian stable InRelease
5.524 Get:2 https://download.docker.com/linux/debian trixie InRelease [32.5 kB]
5.525 Err:1 https://dl.yarnpkg.com/debian stable InRelease
5.525   Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on 72ECF46A56B4AD39C907BBB71646B01B86E50310 is bad:            The subkey is not live   because: Expired on 2023-01-24T19:06:41Z
5.527 Get:3 http://deb.debian.org/debian trixie InRelease [140 kB]
5.533 Get:4 https://download.docker.com/linux/debian trixie/stable arm64 Packages [24.7 kB]
5.567 Get:5 http://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
5.584 Get:6 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
5.601 Get:7 http://deb.debian.org/debian trixie/main arm64 Packages [9607 kB]
5.735 Get:8 http://deb.debian.org/debian trixie-updates/main arm64 Packages [5404 B]
5.753 Get:9 http://deb.debian.org/debian-security trixie-security/main arm64 Packages [98.2 kB]
6.565 Reading package lists...
6.924 W: OpenPGP signature verification failed: https://dl.yarnpkg.com/debian stable InRelease: Sub-process /usr/bin/sqv returned an error code (1), error message is: Signing key on 72ECF46A56B4AD39C907BBB71646B01B86E50310 is bad:            The subkey is not live   because: Expired on 2023-01-24T19:06:41Z
6.924 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
6.924 ERROR: Feature "Node.js (via nvm), yarn and pnpm" (ghcr.io/devcontainers/features/node) failed to install! Look at the documentation at https://github.com/devcontainers/features/tree/main/src/node for help troubleshooting this error.
```

I couldn't find any references or reasons why yarn should still be used. As far as I can tell, it's no longer relevant to Zammads stack and thus can safely be omitted. This change works on my machine and solves the rebuild problems.