### PR TITLE
Follow up #5886 - migrate user preferences to new Catalan locale code

### DIFF
--- a/db/migrate/20260209120000_migrate_catalan_user_preference.rb
+++ b/db/migrate/20260209120000_migrate_catalan_user_preference.rb
@@ -1,0 +1,14 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class MigrateCatalanUserPreference < ActiveRecord::Migration[8.0]
+  def change
+    # return if it's a new setup
+    return if !Setting.exists?(name: 'system_init_done')
+
+    # Migrate user preferences from es-ca to ca
+    User.where('preferences LIKE ?', "%\nlocale: es-ca\n%").find_each(batch_size: 1000) do |user|
+      user.preferences[:locale] = 'ca'
+      user.save
+    end
+  end
+end


### PR DESCRIPTION
I know it was decided against it, but it bugged me so much, that I did a little research.
[Back in 2022](https://github.com/zammad/zammad/blob/18206b495c3e97f21456d3701c7c248a95c875fd/db/migrate/20220308072741_rename_tw_locale.rb#L4), this kind of migration has happened.

This PR will touch affected user preferences only and should not have a negative impact on the knowledge base (at least I personally don't see one, but I might miss a vector).

I believe that this will improve the users experience and takes off burdens from administrators of an instance.