### PR TITLE
Maintenance: Fix typos

### DIFF
--- a/app/assets/javascripts/app/controllers/_integration/ldap.coffee
+++ b/app/assets/javascripts/app/controllers/_integration/ldap.coffee
@@ -2,7 +2,7 @@ class Ldap extends App.ControllerIntegrationBase
   featureIntegration: 'ldap_integration'
   featureName: __('LDAP')
   description: [
-    [__('Use this switch to start synchronization of your ldap sources.')]
+    [__('Use this switch to start synchronization of your LDAP sources.')]
     [__('If a user is found in two (or more) configured LDAP sources, the last synchronisation will win.')]
     [__('In order to be able to influence the desired behavior in this regard, you can influence the order of the LDAP sources via drag & drop.')]
   ]

--- a/app/assets/javascripts/app/controllers/_plugin/navigation.coffee
+++ b/app/assets/javascripts/app/controllers/_plugin/navigation.coffee
@@ -182,7 +182,7 @@ class Navigation extends App.Controller
 
         new App.ControllerConfirm(
           head: __('Help')
-          message: __('You can switch between the old and the New BETA UI at any moment in the Profile > New BETA UI section.')
+          message: __('You can switch between the old and the New BETA UI at any moment in the Profile settings > New BETA UI section.')
           buttonClass: 'btn--success'
           buttonCancel: false
           buttonSubmit: __('Got it')

--- a/app/assets/javascripts/app/views/channel/chat.jst.eco
+++ b/app/assets/javascripts/app/views/channel/chat.jst.eco
@@ -215,7 +215,7 @@ $(function() {
       <li><%- @T('The chat is turned off.') %>
       <li><%- @T('There are too many people in the chat queue.') %>
     </ol>
-    <%- @T('When you turn on debugging by setting the option §debug§ to §true§ the reason gets printed to the javascript console.') %>
+    <%- @T('When you turn on debugging by setting the option §debug§ to §true§ the reason gets printed to the JavaScript console.') %>
   </p>
 
   <hr>

--- a/app/assets/javascripts/app/views/channel/form.jst.eco
+++ b/app/assets/javascripts/app/views/channel/form.jst.eco
@@ -148,7 +148,7 @@
   <p><%- @T("Zammad Forms requires jQuery. If you don't already use it on your website, you can add it like this:") %></p>
   <pre><code class="language-html js-code">&lt;script src="https://code.jquery.com/jquery-3.6.0.min.js"&gt;&lt;/script&gt;</code></pre>
 
-  <p><%- @T('You need to add the following Javascript code snippet to your web page:') %></p>
+  <p><%- @T('You need to add the following JavaScript code snippet to your web page:') %></p>
 
   <pre class="js-modal"><code class="language-html js-code js-paramsBlock">&lt;button id="zammad-feedback-form"&gt;Feedback&lt;/button&gt;
 

--- a/app/frontend/apps/desktop/components/BetaUi/composables/useBetaUi.ts
+++ b/app/frontend/apps/desktop/components/BetaUi/composables/useBetaUi.ts
@@ -79,7 +79,7 @@ export const useBetaUi = () => {
 
     waitForConfirmation(
       __(
-        'You can switch between the old and the New BETA UI at any moment in the Profile Settings > New BETA UI section.',
+        'You can switch between the old and the New BETA UI at any moment in the Profile settings > New BETA UI section.',
       ),
       {
         headerIcon: 'question-circle',

--- a/app/frontend/apps/desktop/composables/dragAndDrop/useKeyboardKeysForDragAndDrop.ts
+++ b/app/frontend/apps/desktop/composables/dragAndDrop/useKeyboardKeysForDragAndDrop.ts
@@ -143,7 +143,7 @@ export function useKeyboardKeysForDragAndDrop<T extends object | string>({
     }
     announce(
       __(
-        'Sortable list focused. Use up and down arrows to navigate items. Press Space to select and item and again on another item to swap them.',
+        'Sortable list focused. Use up and down arrows to navigate items. Press Space to select an item and again on another item to swap them.',
       ),
     )
   }

--- a/app/frontend/apps/desktop/pages/personal-setting/views/PersonalSettingCalendar.vue
+++ b/app/frontend/apps/desktop/pages/personal-setting/views/PersonalSettingCalendar.vue
@@ -249,7 +249,7 @@ const submitForm = async (data: FormValues) => {
     notify({
       id: 'calendar-subscription-update-success',
       type: NotificationTypes.Success,
-      message: __('You calendar subscription settings were updated.'),
+      message: __('Your calendar subscription settings were updated.'),
     })
   })
 }

--- a/app/frontend/apps/desktop/pages/personal-setting/views/PersonalSettingNewBetaUi.vue
+++ b/app/frontend/apps/desktop/pages/personal-setting/views/PersonalSettingNewBetaUi.vue
@@ -101,7 +101,7 @@ const leaveFeedbackProgram = () => {
           </CommonButton>
           <template v-else>
             <CommonLabel tag="p">
-              {{ $t('Would you like to give us feedback on the BETA UI? ') }}
+              {{ $t('Would you like to give us feedback on the BETA UI?') }}
             </CommonLabel>
             <CommonButton @click="showFeedbackConsent">{{
               $t('Join feedback program')

--- a/app/services/service/system/import/apply_otrs_configuration.rb
+++ b/app/services/service/system/import/apply_otrs_configuration.rb
@@ -75,7 +75,7 @@ class Service::System::Import::ApplyOtrsConfiguration < Service::System::Import:
     Setting.set('import_otrs_endpoint', nil)
     Setting.set('import_otrs_endpoint_key', nil)
 
-    raise InaccessibleError, __('The OTRS migrator plugin is not accessable. Please verify the API key.') if !accessible
+    raise InaccessibleError, __('The OTRS migrator plugin is not accessible. Please verify the API key.') if !accessible
   end
 
   def raise_unreachable_error(message = nil)

--- a/db/seeds/schedulers.rb
+++ b/db/seeds/schedulers.rb
@@ -256,7 +256,7 @@ Scheduler.create_if_not_exists(
   created_by_id: 1,
 )
 Scheduler.create_if_not_exists(
-  name:          __('Update exchange oauth 2 token.'),
+  name:          __('Update exchange OAuth2 token.'),
   method:        'ExternalCredential::Exchange.refresh_token',
   period:        10.minutes,
   prio:          1,

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -307,18 +307,18 @@ Setting.create_if_not_exists(
   frontend:    true
 )
 Setting.create_if_not_exists(
-  title:       __('Websocket backend'),
+  title:       __('WebSocket backend'),
   name:        'websocket_backend',
   area:        'System::WebSocket',
-  description: __('Defines how to reach websocket server. "websocket" is default on production, "websocketPort" is for CI'),
+  description: __('Defines how to reach WebSocket server. "websocket" is default on production, "websocketPort" is for CI.'),
   state:       Rails.env.production? ? 'websocket' : 'websocketPort',
   frontend:    true
 )
 Setting.create_if_not_exists(
-  title:       __('Websocket port'),
+  title:       __('WebSocket port'),
   name:        'websocket_port',
   area:        'System::WebSocket',
-  description: __('Defines the port of the websocket server.'),
+  description: __('Defines the port of the WebSocket server.'),
   options:     {
     form: [
       {
@@ -601,7 +601,7 @@ Setting.create_if_not_exists(
   title:       __('Core Workflow Ajax Mode'),
   name:        'core_workflow_ajax_mode',
   area:        'System::UI',
-  description: __('Defines if the core workflow communication should run over ajax instead of websockets.'),
+  description: __('Defines if the core workflow communication should run over AJAX instead of WebSocket.'),
   options:     {
     form: [
       {
@@ -4347,7 +4347,7 @@ Setting.create_if_not_exists(
   title:       __('Defines postmaster filter.'),
   name:        '0900_postmaster_filter_bounce_follow_up_check',
   area:        'Postmaster::PreFilter',
-  description: __('Defines postmaster filter to identify postmaster bounces; and handles them as follow-up of the original tickets'),
+  description: __('Defines postmaster filter to identify postmaster bounces; and handles them as follow-up of the original tickets.'),
   options:     {},
   state:       'Channel::Filter::BounceFollowUpCheck',
   frontend:    false
@@ -5587,7 +5587,7 @@ Setting.create_if_not_exists(
   title:       __('Defines the timeframe during which a self-created note can be deleted.'),
   name:        'ui_ticket_zoom_article_delete_timeframe',
   area:        'UI::TicketZoomArticle',
-  description: __("Set timeframe in seconds. If it's set to 0 you can delete notes without time limits"),
+  description: __("Set timeframe in seconds. If it's set to 0 you can delete notes without time limits."),
   options:     {},
   state:       600,
   preferences: {
@@ -6017,7 +6017,7 @@ Setting.create_if_not_exists(
 )
 
 Setting.create_if_not_exists(
-  title:       __('UI Desktop Beta Switch'),
+  title:       __('UI Desktop BETA Switch'),
   name:        'ui_desktop_beta_switch',
   area:        'UI::Desktop',
   description: __('Allow users to switch automatically to the new desktop UI.'),
@@ -6038,7 +6038,7 @@ Setting.create_if_not_exists(
   title:       __('UI Desktop BETA Switch Roles'),
   name:        'ui_desktop_beta_switch_role_ids',
   area:        'UI::Desktop',
-  description: __('Defines which roles are allowed to access the desktop UI beta switch.'),
+  description: __('Defines which roles are allowed to access the desktop BETA UI switch.'),
   state:       [],
   frontend:    true,
 )


### PR DESCRIPTION
This PR fixes some typos and standardizes wording.

Please check, if the strings in `display` key should be translatable or not. The strings `ticket.agent` and `ticket.customer` looks different in translator point of view.

See in  `db/seeds/settings.rb`:

```
  description: __('Defines the session timeout for inactivity of users. Based on the assigned permissions the highest timeout value will be used, otherwise the default.'),
  options:     {
    form: [
      {
        display:   __('Default'),
        null:      false,
        name:      'default',
        tag:       'select',
        options:   options,
        translate: true,
      },
      {
        display:   __('admin'),
        null:      false,
        name:      'admin',
        tag:       'select',
        options:   options,
        translate: true,
      },
      {
        display:   __('ticket.agent'),
        null:      false,
        name:      'ticket.agent',
        tag:       'select',
        options:   options,
        translate: true,
      },
      {
        display:   __('ticket.customer'),
        null:      false,
        name:      'ticket.customer',
        tag:       'select',
        options:   options,
        translate: true,
      },
    ],
  },
```
