### PR TITLE
Fixes #5955 - Inline images from quoted emails cause invalid base64 GraphQL error.

### DIFF
--- a/app/frontend/shared/components/Form/fields/FieldEditor/features/image-handler/ImageHandler.vue
+++ b/app/frontend/shared/components/Form/fields/FieldEditor/features/image-handler/ImageHandler.vue
@@ -27,7 +27,7 @@ const isResizing = ref(false)
 const imageLoaded = ref(false)
 const failedDueToCors = ref(false)
 const isDraggable = computed(() => props.node.attrs.isDraggable)
-const uploadCacheExists = computed(() => props.node.attrs.src.startsWith('/api/v1/attachments/'))
+const uploadCacheExists = computed(() => props.node.attrs.src.startsWith('/api/v1/'))
 const uploadInsideOtherEditor = computed(
   () => props.node.attrs.src.startsWith('blob:') && !props.node.attrs.content,
 )
@@ -42,7 +42,7 @@ const getNodeStyle = () =>
   }, {})
 
 const handleUpload = () => {
-  if (props.node.attrs.src.startsWith('/api/v1/attachments/')) return
+  if (props.node.attrs.src.startsWith('/api/v1/')) return
   if (props.node.attrs.src.startsWith('blob:') && !props.node.attrs.content) return
 
   if (props.node.attrs.src.startsWith('file:')) {


### PR DESCRIPTION
## Summary

- Fixes a transient red error flash (`Variable $files of type [UploadFileInput!]! was provided invalid value for 0.content (invalid base64)`) when replying to or forwarding an email with inline images (embedded screenshots, company logos, etc.)
- Single file change, 2 lines modified

## Root Cause

When an email with inline images is quoted in a reply/forward, the backend replaces `cid:` references with `/api/v1/ticket_attachment/:ticket_id/:article_id/:id?view=inline` URLs. The `ImageHandler.vue` component's `handleUpload()` guard and `uploadCacheExists` computed only matched `/api/v1/attachments/`, so `ticket_attachment` URLs fell through to the else branch which sent the raw URL path as base64 `content` to the GraphQL mutation. `BinaryStringType` then failed on `Base64.strict_decode64`.

## Fix

Broaden the guard from `/api/v1/attachments/` to `/api/v1/` — any image served by the Zammad API is already persisted server-side and doesn't need client-side re-uploading.

## Testing

Built a clean Docker image from upstream develop with only this patch applied, deployed to a full stack (PostgreSQL 16.1, Elasticsearch 8.17.0, Redis 7, Memcached 1.6, Rails, Nginx) and verified:

- [x] Fix compiled into production Vite bundle (FieldEditorInput chunk) — confirmed `/api/v1/` guard in minified JS
- [x] Reply to email ticket with inline images — no error flash
- [x] Forward email ticket with inline images — no error flash  
- [x] New image uploads via editor toolbar — still works normally
- [x] `uploadCacheExists` computed correctly identifies server-persisted images (no dimming)
- [x] No regression in desktop-view or mobile app asset serving
- [x] Audited all `/api/v1/` routes — none serve user-uploadable content that would need re-uploading