### PR TITLE
Skip redis and database connections during asset precompilation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,13 @@ module Zammad
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.0
 
+    # Check if the current process is running assets:precompile only
+    def self.assets_precompile?
+      defined?(Rake) &&
+        Rake.respond_to?(:application) &&
+        Rake.application.top_level_tasks.any? { |t| t.include?('assets:precompile') }
+    end
+
     Rails.autoloaders.each do |autoloader|
       autoloader.ignore            "#{config.root}/app/frontend"
       autoloader.do_not_eager_load "#{config.root}/lib/core_ext"

--- a/config/initializers/db_preflight_check.rb
+++ b/config/initializers/db_preflight_check.rb
@@ -1,5 +1,8 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
+# Skip database preflight check during asset precompilation (no DB needed)
+return if Zammad::Application.assets_precompile?
+
 # Rails' constant auto-loading resolves to 'rails/initializable' instead
 require 'zammad/application/initializer/db_preflight_check'
 

--- a/config/initializers/models_preload.rb
+++ b/config/initializers/models_preload.rb
@@ -3,6 +3,9 @@
 # Ensure all models are preloaded, as Zammad uses reflections
 #   which rely on all model classes being present.
 Rails.application.reloader.to_prepare do
+  # Skip models preload during asset precompilation (no DB needed)
+  next if Zammad::Application.assets_precompile?
+
   begin
     Models.all
   rescue ActiveRecord::StatementInvalid

--- a/config/initializers/zzz_action_cable_preferences.rb
+++ b/config/initializers/zzz_action_cable_preferences.rb
@@ -1,5 +1,8 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
+# Skip ActionCable configuration during asset precompilation (no Redis needed)
+return if Zammad::Application.assets_precompile?
+
 require_relative '../../lib/zammad/service/redis'
 
 Rails.application.config.action_cable.cable = {


### PR DESCRIPTION
Asset precompilation only needs to compile CSS, JavaScript, and images. It does not require Redis (for ActionCable) or PostgreSQL/MySQL database connections. This patch modifies initializers to skip these services when running the assets:precompile rake task, allowing the build to succeed in environments where these services are not available.


I'm currently packaging zammad for openSUSE [here](https://build.opensuse.org/package/show/home:gladiac:apps/zammad). This is one of my patches trying to get it built.