### PR TITLE
Fix Rack compatibility for newer Rack versions

### DIFF
--- a/lib/core_ext/rack/utils.rb
+++ b/lib/core_ext/rack/utils.rb
@@ -7,16 +7,23 @@ module Rack
 
     module_function
 
-    singleton_class.alias_method :original_add_cookie_to_header, :add_cookie_to_header
+    if Rack::Utils.respond_to?(:add_cookie_to_header)
+      # Rack 2.x
+      singleton_class.alias_method :original_add_cookie_to_header, :add_cookie_to_header
 
-    # https://github.com/rack/rack/blob/2.2.3/lib/rack/session/utils.rb#L223-L262
-    def add_cookie_to_header(header, key, value)
-
-      if value.is_a?(Hash)
-        value[:secure] = ::Session.secure_flag?
+      # https://github.com/rack/rack/blob/2.2.3/lib/rack/session/utils.rb#L223-L262
+      def add_cookie_to_header(header, key, value)
+        value[:secure] = ::Session.secure_flag? if value.is_a?(Hash)
+        original_add_cookie_to_header(header, key, value)
       end
+    else
+      # Rack 3.1+ — add_cookie_to_header was removed; set_cookie_header! is now used
+      singleton_class.alias_method :original_set_cookie_header!, :set_cookie_header!
 
-      original_add_cookie_to_header(header, key, value)
+      def set_cookie_header!(headers, key, value)
+        value[:secure] = ::Session.secure_flag? if value.is_a?(Hash)
+        original_set_cookie_header!(headers, key, value)
+      end
     end
   end
 end

--- a/lib/zammad/application/initializer/session_store.rb
+++ b/lib/zammad/application/initializer/session_store.rb
@@ -18,7 +18,7 @@ module Zammad
           # instead of accessing the `:secure` key (default Rack/Rails behavior).
           # See: lib/core_ext/action_dispatch/middleware/cookies.rb
           # See: lib/core_ext/rack/session/abstract/id.rb
-          # See: lib/core_ext/rack/session/utils.rb
+          # See: lib/core_ext/rack/utils.rb
           Rails.application.config.session_store STORE_TYPE,
                                                  key: SESSION_KEY
 


### PR DESCRIPTION
Rack::Utils.add_cookie_to_header has been deprecated and removed in version 3.10.

This patch makes the monkey-patch conditional - it only applies if the method exists, allowing compatibility with both Rack 2.x and 3.x+.