### PR TITLE
Make aws-sdk-s3 and S3 storage provider optional

### DIFF
--- a/app/models/store/provider/s3.rb
+++ b/app/models/store/provider/s3.rb
@@ -1,6 +1,10 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
-require 'aws-sdk-s3'
+begin
+  require 'aws-sdk-s3'
+rescue LoadError
+  # Gem not installed, S3 storage provider will not be available
+end
 
 module Store::Provider::S3
 


### PR DESCRIPTION
Guard require 'aws-sdk-s3' so S3 provider file loads cleanly when the gem is not installed. It is marked as optional in the Gemfile.