### PR TITLE
Maintenance: Upgrade Sprockets to v4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,11 +79,11 @@ group :assets do
   # We cannot use sassc-rails, as it can lead to crashes on modern platforms like CentOS 9.
   # See https://jcmaciel.com/apple-silicon-ruby-on-rails-crash-segfault-sassc/
   #     https://github.com/sass/sassc-ruby/issues/197
-  # Pin to v5 which does not use sassc internally.
-  gem 'sass-rails', '~> 5', require: false
+  # dartsass-sprockets uses the Dart Sass binary (no sassc) and supports Sprockets 4.
+  gem 'dartsass-sprockets', require: false
 
   # asset handling - pipeline
-  gem 'sprockets', '~> 3.7.2', require: false
+  gem 'sprockets', '~> 4.2', require: false
   gem 'terser', require: false
 
   gem 'autoprefixer-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,12 @@ GEM
     daemons (1.4.1)
     dalli (5.0.2)
       logger
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.1)
     debug_inspector (1.2.0)
     deprecation_toolkit (2.3.0)
@@ -704,17 +710,10 @@ GEM
     rubyzip (2.4.1)
     safety_net_attestation (0.5.0)
       jwt (>= 2.0, < 4.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-embedded (1.97.3-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sassc-embedded (1.80.8)
+      sass-embedded (~> 1.80)
     securerandom (0.4.1)
     selenium-webdriver (4.41.0)
       base64 (~> 0.2)
@@ -737,8 +736,7 @@ GEM
     snaky_hash (2.0.3)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
-    sprockets (3.7.5)
-      base64
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.5.2)
@@ -880,6 +878,7 @@ DEPENDENCIES
   csv
   daemons
   dalli
+  dartsass-sprockets
   delayed_job!
   delayed_job_active_record!
   deprecation_toolkit
@@ -961,12 +960,11 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   ruby-keycloak-admin
-  sass-rails (~> 5)
   selenium-webdriver
   shoulda-matchers
   simpleidn
   slack-ruby-client
-  sprockets (~> 3.7.2)
+  sprockets (~> 4.2)
   sprockets-rails
   tcr
   telegram-bot-ruby

--- a/app/assets/javascripts/app/index.coffee
+++ b/app/assets/javascripts/app/index.coffee
@@ -3,7 +3,7 @@
 #= require_self
 #= require_tree ./lib/app_init
 #= require_tree ./lib/mixins
-#= require ./config.coffee
+#= require app/config
 #= require_tree ./models
 #= require_tree ./controllers/_application_controller
 #= require_tree ./controllers

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,46 +5,46 @@
 // the compiled file.
 //
 
-//= require ./app/lib/core/jquery-3.6.0.js
-//= require ./app/lib/core/jquery-ui-1.11.4.js
-//= require ./app/lib/core/underscore-1.8.3.js
+//= require app/lib/core/jquery-3.6.0
+//= require app/lib/core/jquery-ui-1.11.4
+//= require app/lib/core/underscore-1.8.3
 
-//= require ./app/lib/animations/velocity.min.js
-//= require ./app/lib/animations/velocity.ui.js
+//= require app/lib/animations/velocity.min
+//= require app/lib/animations/velocity.ui
 
 //not_used= require_tree ./app/lib/spine
-//= require ./app/lib/spine/spine.coffee
-//= require ./app/lib/spine/ajax.coffee
-//= require ./app/lib/spine/local.coffee
-//= require ./app/lib/spine/route.coffee
+//= require app/lib/spine/spine
+//= require app/lib/spine/ajax
+//= require app/lib/spine/local
+//= require app/lib/spine/route
 
-//= require ./app/lib/flot/jquery.flot.js
-//= require ./app/lib/flot/jquery.flot.selection.js
+//= require app/lib/flot/jquery.flot
+//= require app/lib/flot/jquery.flot.selection
 
 //not_used= require_tree ./app/lib/bootstrap
-//= require ./app/lib/bootstrap/dropdown.js
-//= require ./app/lib/bootstrap/tooltip.js
-//= require ./app/lib/bootstrap/popover.js
-//= require ./app/lib/bootstrap/popover-enhance.js
+//= require app/lib/bootstrap/dropdown
+//= require app/lib/bootstrap/tooltip
+//= require app/lib/bootstrap/popover
+//= require app/lib/bootstrap/popover-enhance
 
 // modified by Felix Jan-2014
-//= require ./app/lib/bootstrap/modal.js
+//= require app/lib/bootstrap/modal
 
-//= require ./app/lib/bootstrap/tab.js
-//= require ./app/lib/bootstrap/transition.js
-//= require ./app/lib/bootstrap/button.js
-//= require ./app/lib/bootstrap/collapse.js
-//= require ./app/lib/bootstrap/bootstrap-timepicker.js
-//= require ./app/lib/bootstrap/bootstrap-datepicker.js
+//= require app/lib/bootstrap/tab
+//= require app/lib/bootstrap/transition
+//= require app/lib/bootstrap/button
+//= require app/lib/bootstrap/collapse
+//= require app/lib/bootstrap/bootstrap-timepicker
+//= require app/lib/bootstrap/bootstrap-datepicker
 
-//= require ./app/lib/rangy/rangy-core.js
-//= require ./app/lib/rangy/rangy-classapplier.js
-//= require ./app/lib/rangy/rangy-textrange.js
-//= require ./app/lib/rangy/rangy-highlighter.js
+//= require app/lib/rangy/rangy-core
+//= require app/lib/rangy/rangy-classapplier
+//= require app/lib/rangy/rangy-textrange
+//= require app/lib/rangy/rangy-highlighter
 
 //= require_tree ./app/lib/base
 
-//= require ./app/index.coffee
+//= require app/index
 
 // IE8 workaround for missing console.log
 if (!window.console) {

--- a/app/assets/stylesheets/application-print.css
+++ b/app/assets/stylesheets/application-print.css
@@ -1,4 +1,4 @@
 /*
  *= require_self
- *= require ./print.scss
+ *= require print
 */

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,7 +12,7 @@
  *= require ./svg-dimensions.css
  *= require ./highlighter-github.css
  *= require ./jquery.enableObjectResizingShim.css
- *= require ./zammad.scss
+ *= require zammad
  *
  *= require_tree ./addons/
  *= require_tree ./custom/

--- a/lib/core_ext/rack/utils.rb
+++ b/lib/core_ext/rack/utils.rb
@@ -7,16 +7,23 @@ module Rack
 
     module_function
 
-    singleton_class.alias_method :original_add_cookie_to_header, :add_cookie_to_header
+    if Rack::Utils.respond_to?(:add_cookie_to_header)
+      # Rack 2.x
+      singleton_class.alias_method :original_add_cookie_to_header, :add_cookie_to_header
 
-    # https://github.com/rack/rack/blob/2.2.3/lib/rack/session/utils.rb#L223-L262
-    def add_cookie_to_header(header, key, value)
-
-      if value.is_a?(Hash)
-        value[:secure] = ::Session.secure_flag?
+      # https://github.com/rack/rack/blob/2.2.3/lib/rack/session/utils.rb#L223-L262
+      def add_cookie_to_header(header, key, value)
+        value[:secure] = ::Session.secure_flag? if value.is_a?(Hash)
+        original_add_cookie_to_header(header, key, value)
       end
+    else
+      # Rack 3.1+ — add_cookie_to_header was removed; set_cookie_header! is now used
+      singleton_class.alias_method :original_set_cookie_header!, :set_cookie_header!
 
-      original_add_cookie_to_header(header, key, value)
+      def set_cookie_header!(headers, key, value)
+        value[:secure] = ::Session.secure_flag? if value.is_a?(Hash)
+        original_set_cookie_header!(headers, key, value)
+      end
     end
   end
 end

--- a/lib/zammad/application/initializer/session_store.rb
+++ b/lib/zammad/application/initializer/session_store.rb
@@ -18,7 +18,7 @@ module Zammad
           # instead of accessing the `:secure` key (default Rack/Rails behavior).
           # See: lib/core_ext/action_dispatch/middleware/cookies.rb
           # See: lib/core_ext/rack/session/abstract/id.rb
-          # See: lib/core_ext/rack/session/utils.rb
+          # See: lib/core_ext/rack/utils.rb
           Rails.application.config.session_store STORE_TYPE,
                                                  key: SESSION_KEY
 


### PR DESCRIPTION
This upgrades Sprockets to v4.2. Couldn't find an issue yet. Note I have this patch on 6.5.2 running. I just forward ported it. I'm not sure the Gemfile changes are 100% correct. Help welcome.