### PR TITLE
Fixes #5968 - Increase OTRS import HTTP timeouts

### DIFF
--- a/lib/import/otrs/requester.rb
+++ b/lib/import/otrs/requester.rb
@@ -119,8 +119,8 @@ module Import
           params,
           {
             open_timeout:  10,
-            read_timeout:  120,
-            total_timeout: 360,
+            read_timeout:  600,
+            total_timeout: 1200,
             user:          Setting.get('import_otrs_user'),
             password:      Setting.get('import_otrs_password'),
           },


### PR DESCRIPTION
## Summary

- Increases `read_timeout` from 120s to 600s in `lib/import/otrs/requester.rb`
- Increases `total_timeout` from 360s to 1200s
- Fixes OTRS migration failures on slower hardware or with larger datasets

Closes #5968

## Test plan

- [x] Verify OTRS import completes successfully on slower systems
- [x] Verify no regression for fast systems (timeouts are upper bounds, not delays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)