### PR TITLE
Maintenance: Improved wording on login screen.

### DIFF
--- a/app/assets/javascripts/app/views/login.jst.eco
+++ b/app/assets/javascripts/app/views/login.jst.eco
@@ -95,7 +95,7 @@
         <p>
           <%- @T("You're already registered with your email address if you've been in touch with our Support team.") %><br>
           <% if @C('user_lost_password'): %>
-            <%- @T('You can request your password') %> <a href="#password_reset"><%- @T('here') %></a>.
+            <a href="#password_reset"><%- @T('You can request your password here.') %></a>
           <% end %>
         </p>
       <% end %>


### PR DESCRIPTION
The login screen contains a sentence consist of two strings. Because of the fix order of sentence parts, it is not possible to translate into a language which uses different word order in the sentence. This pull request removes the concatenation, and put the whole sentence into the `<a>...</a>` element as link text.

Other occurrences already use the same solution, like same lines below in the changed file:

```
<a class="text-muted" href="#admin_password_auth"><%- @T('Request the password login here.') %></a>
```

Or in `app/frontend/apps/desktop/pages/authentication/views/Signup.vue:163`

```
<CommonLink v-if="$c.user_lost_password" link="/reset-password" size="medium">
    {{ $t('You can request your password here.') }}
</CommonLink>
```

You can also see how many language translations are affected  by the concatenation if you execute

```
grep -A 1 'You can request your password' i18n/zammad.*.po
```

For example in German language file:

```
i18n/zammad.de-de.po:msgid "You can request your password"
i18n/zammad.de-de.po-msgstr "Beantragen eines neuen Passworts"
--
i18n/zammad.de-de.po:msgid "You can request your password here."
i18n/zammad.de-de.po-msgstr "Sie können Ihr Passwort hier anfordern."
```