### PR TITLE
Sort expert header list alphabetically and add Exchange auto-reply headers

### DIFF
--- a/app/assets/javascripts/app/controllers/_ui_element/postmaster_match.coffee
+++ b/app/assets/javascripts/app/controllers/_ui_element/postmaster_match.coffee
@@ -77,12 +77,10 @@ class App.UiElement.postmaster_match
             value:    'x-priority'
             name:     'X-Priority'
           },
-
           {
             value:    'organization'
             name:     'Organization'
           },
-
           {
             value:    'x-original-to'
             name:     'X-Original-To'
@@ -155,7 +153,18 @@ class App.UiElement.postmaster_match
             value:    'Resent-To'
             name:     'Resent-To'
           },
+          {
+            value:    'x-auto-response-suppress'
+            name:     'X-Auto-Response-Suppress'
+          },
+          {
+            value:    'x-ms-exchange-inbox-rules-loop'
+            name:     'X-MS-Exchange-Inbox-Rules-Loop'
+          },
         ]
+
+    groups.expert.options = groups.expert.options.sort (a, b) ->
+      a.name.toLowerCase().localeCompare(b.name.toLowerCase())
 
     groups
 


### PR DESCRIPTION
…aders

The list of expert headers used in postmaster filters is currently defined as a static array and displayed in the same order in which it appears in the source code. As the list grows, locating a specific header becomes increasingly difficult.

This change introduces an alphabetical sorting of the expert header options before they are returned from @defaults. Sorting is performed by the visible header name to improve usability in the UI.

In addition, two Microsoft Exchange specific headers have been added:

X-Auto-Response-Suppress

X-MS-Exchange-Inbox-Rules-Loop

These headers are commonly used by Microsoft Exchange / Microsoft 365 to mark automatically generated responses such as out-of-office replies or inbox rule loops. Having them available in the expert header list allows administrators to create more reliable postmaster filters to detect and handle automated replies.

The changes include:

Alphabetical sorting of groups.expert.options

Addition of the headers:
* X-Auto-Response-Suppress
* X-MS-Exchange-Inbox-Rules-Loop

This improves both usability of the expert header selector and the ability to detect automatic email responses in Exchange environments.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
