### PR TITLE
fix(gitlab): Accept work_items URLs in addition to issues URLs

### DIFF
--- a/lib/gitlab/linked_issue.rb
+++ b/lib/gitlab/linked_issue.rb
@@ -118,7 +118,7 @@ class GitLab
     end
 
     def variables(url)
-      if url !~ %r{^https?://([^/]+)/(.*)/-/issues/(\d+)$}
+      if url !~ %r{^https?://([^/]+)/(.*)/-/(?:issues|work_items)/(\d+)$}
         raise Exceptions::UnprocessableEntity, __('Invalid GitLab issue link format')
       end
 

--- a/spec/integration/gitlab_spec.rb
+++ b/spec/integration/gitlab_spec.rb
@@ -101,5 +101,14 @@ RSpec.describe GitLab, integration: true, required_envs: %w[GITLAB_ENDPOINT GITL
         expect(linked_issue.send(:variables, issue_url)[:fullpath]).to eq('group/project')
       end
     end
+
+    describe 'work_items URL format' do
+      let(:linked_issue) { GitLab::LinkedIssue.new(instance.client) }
+      let(:work_item_url) { "https://#{URI.parse(ENV['GITLAB_ISSUE_LINK']).host}/group/project/-/work_items/42" }
+
+      it 'accepts work_items URLs in addition to issues URLs' do
+        expect(linked_issue.send(:variables, work_item_url)).to include(fullpath: 'group/project', issue_id: '42')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

GitLab is migrating issues to a new work items architecture, which changes the URL path from `/-/issues/<id>` to `/-/work_items/<id>`. The URL validation regex in `GitLab::LinkedIssue#variables` only accepted the `issues` path segment, causing valid `work_items` links to be rejected with an _"Invalid GitLab issue link format"_ error.

## Solution

Extend the regex to accept both `issues` and `work_items` path segments:

```ruby
# before
%r{^https?://([^/]+)/(.*)/-/issues/(\d+)$}

# after
%r{^https?://([^/]+)/(.*)/-/(?:issues|work_items)/(\d+)$}
```

## Changes

- `lib/gitlab/linked_issue.rb` — updated URL validation regex
- `spec/integration/gitlab_spec.rb` — added integration test for `work_items` URL format