### PR TITLE
Fix #5903 disable name guessing for structured user sources

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -852,6 +852,7 @@ curl http://localhost/api/v1/users/avatar -v -u #{login}:#{password} -H "Content
 
     user = User.new(clean_user_params)
     user.associations_from_param(params)
+    user.disable_name_guessing = true
 
     user.save!
 

--- a/app/models/concerns/can_csv_import.rb
+++ b/app/models/concerns/can_csv_import.rb
@@ -143,6 +143,7 @@ returns
 
                 record = new(param_cleanup(clean_params).reverse_merge(created_by_id: 1, updated_by_id: 1))
                 record.associations_from_param(attributes)
+                record.disable_name_guessing = true if record.is_a?(User)
                 record.save!
               rescue => e
                 errors.push "Line #{i.next}: Unable to create record - #{e.message}"
@@ -158,6 +159,7 @@ returns
                 record.with_lock do
                   record.associations_from_param(attributes)
                   record.assign_attributes(clean_params)
+                  record.disable_name_guessing = true if record.is_a?(User)
                   record.save! if record.changed?
                 end
               rescue => e

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -696,7 +696,7 @@ try to find correct name
     preferences.fetch(:locale) { Locale.default }
   end
 
-  attr_accessor :skip_ensure_uniq_email, :name_from_channel_import
+  attr_accessor :skip_ensure_uniq_email, :name_from_channel_import, :disable_name_guessing
 
   def shared_organizations?
     all_organizations.exists? shared: true
@@ -774,7 +774,7 @@ try to find correct name
     self.firstname = sanitize_name(firstname)
     self.lastname  = sanitize_name(lastname)
 
-    return if firstname.present? && lastname.present?
+    return if disable_name_guessing && (firstname.present? || lastname.present?)
 
     if (firstname.blank? && lastname.present?) || (firstname.present? && lastname.blank?)
       used_name = firstname.presence || lastname

--- a/app/services/service/user/signup.rb
+++ b/app/services/service/user/signup.rb
@@ -90,6 +90,7 @@ class Service::User::Signup < Service::Base
     user.role_ids = Role.signup_role_ids
     user.source = 'signup'
     user.skip_ensure_uniq_email = true
+    user.disable_name_guessing = true
     user.validate!
 
     UserInfo.ensure_current_user_id do

--- a/lib/sequencer/unit/import/common/model/save.rb
+++ b/lib/sequencer/unit/import/common/model/save.rb
@@ -18,6 +18,7 @@ class Sequencer::Unit::Import::Common::Model::Save < Sequencer::Unit::Base
 
   def save!
     BulkImportInfo.enable
+    instance.disable_name_guessing = true if instance.is_a?(User)
     instance.save!
   rescue => e
     handle_failure(e)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -431,6 +431,41 @@ RSpec.describe User, type: :model do
 
           it_behaves_like 'preserving name', 'John', 'TESTUSER'
         end
+
+        context 'when name guessing is disabled' do
+          context 'when only firstname is present' do
+            let(:user) do
+              build(:user, firstname: 'perkūnas ąžuolas', lastname: '', email: Faker::Internet.unique.email).tap do |record|
+                record.disable_name_guessing = true
+                record.save!
+              end
+            end
+
+            it_behaves_like 'preserving name', 'perkūnas ąžuolas', ''
+          end
+
+          context 'when only lastname is present' do
+            let(:user) do
+              build(:user, firstname: '', lastname: 'Zammad Foundation', email: Faker::Internet.unique.email).tap do |record|
+                record.disable_name_guessing = true
+                record.save!
+              end
+            end
+
+            it_behaves_like 'preserving name', '', 'Zammad Foundation'
+          end
+
+          context 'when firstname is nil and only lastname is present' do
+            let(:user) do
+              build(:user, firstname: nil, lastname: 'Zammad Foundation', email: Faker::Internet.unique.email).tap do |record|
+                record.disable_name_guessing = true
+                record.save!
+              end
+            end
+
+            it_behaves_like 'preserving name', nil, 'Zammad Foundation'
+          end
+        end
       end
 
       context 'with postmaster context' do


### PR DESCRIPTION
Fixes #5903

## Summary

`User#check_name` currently guesses and splits names too aggressively when only one of `firstname` or `lastname` is present.

This causes the LDAP issue described in #5903, where repeated updates can happen if `givenName` / `firstname` is empty. It also affects other structured user creation flows where separate `firstname` / `lastname` fields already exist and explicitly provided values should be preserved.

For example, when `firstname` is left blank and `lastname` contains a structured value such as `Zimmermann GmbH`, the value may be split unexpectedly.

## Relation to recent changes / #4139

A recent change already addressed #4139 via `name_from_channel_import` handling for channel-import related name processing.

This PR does not try to replace that logic. Instead, it complements it by covering additional structured user creation flows outside the channel-import context.

In other words: the existing `name_from_channel_import` handling remains responsible for its specific channel-import use case, while this change introduces an explicit `disable_name_guessing` opt-out for structured sources that already provide separate `firstname` / `lastname` fields.

## Changes

- add a transient `disable_name_guessing` accessor to `User`
- update `User#check_name` to skip guessing when that flag is set and either name part is already present
- set `disable_name_guessing = true` for structured imports in the sequencer save path
- set `disable_name_guessing = true` in CSV import
- set `disable_name_guessing = true` in manual user creation via `UsersController`
- set `disable_name_guessing = true` in self signup via `Service::User::Signup`
- add specs covering the disabled-guessing behavior

## Why this approach

A global change of the existing `check_name` behavior would be too broad and would risk changing behavior in flows where guessing is still useful.

Sources like email, web forms with unstructured names, SMS, Facebook, Telegram, or WhatsApp may provide unstructured name data, so the existing guessing behavior should remain intact there.

This change therefore takes an explicit opt-out approach for structured user creation flows that already provide separate `firstname` / `lastname` fields.

## Result

This fixes the repeated LDAP update problem from #5903 and also prevents unintended splitting or rewriting of explicitly provided name values in structured user creation flows such as LDAP/sequencer imports, CSV import, manual user creation, and self signup.

It may also overlap with the underlying symptom described in #4139 for those structured flows, but without changing the existing channel-import specific handling.