### PR TITLE
Fix #6033 - backup script issue 

### DIFF
--- a/contrib/backup/functions
+++ b/contrib/backup/functions
@@ -60,7 +60,7 @@ function delete_old_backups () {
   # Use -mmin to clean up files as -mtime (days) is too unprecise.
   #   However, add +60 minutes to allow for the backup script run time, so that
   #   backups created a few minutes more than a day ago are not already purged.
-  FILES_TO_DELETE=$(test -d "${BACKUP_DIR}" && find "${BACKUP_DIR}" -type f -name '*_zammad_*.gz' -mmin "+$((60*24*HOLD_DAYS+60))")
+  FILES_TO_DELETE=$(test -d "${BACKUP_DIR}" && find "${BACKUP_DIR}" -maxdepth 1 -type f -name '*_zammad_*.gz' -mmin "+$((60*24*HOLD_DAYS+60))")
 
   if [[ -n ${FILES_TO_DELETE} ]]; then
     if [ "${DEBUG}" == "yes" ]; then

--- a/contrib/backup/functions
+++ b/contrib/backup/functions
@@ -60,7 +60,7 @@ function delete_old_backups () {
   # Use -mmin to clean up files as -mtime (days) is too unprecise.
   #   However, add +60 minutes to allow for the backup script run time, so that
   #   backups created a few minutes more than a day ago are not already purged.
-  FILES_TO_DELETE=$(test -d ${BACKUP_DIR} && find ${BACKUP_DIR}/*_zammad_*.gz -type f -mmin +$(((60*24)*${HOLD_DAYS}+60)))
+  FILES_TO_DELETE=$(test -d "${BACKUP_DIR}" && find "${BACKUP_DIR}" -type f -name '*_zammad_*.gz' -mmin "+$((60*24*HOLD_DAYS+60))")
 
   if [[ -n ${FILES_TO_DELETE} ]]; then
     if [ "${DEBUG}" == "yes" ]; then

--- a/contrib/docker/backup.sh
+++ b/contrib/docker/backup.sh
@@ -29,7 +29,7 @@ function zammad_backup {
 
   # delete old backups
   if [ -d "${BACKUP_DIR}" ] && [ -n "$(ls "${BACKUP_DIR}")" ]; then
-    find "${BACKUP_DIR}"/*_zammad_*.gz -type f -mtime +"${HOLD_DAYS}" -delete
+    find "${BACKUP_DIR}" -type f -name "*_zammad_*.gz" -mtime +"${HOLD_DAYS}" -delete
   fi
 
   if [ "${NO_FILE_BACKUP}" != "yes" ]; then

--- a/contrib/docker/backup.sh
+++ b/contrib/docker/backup.sh
@@ -29,7 +29,7 @@ function zammad_backup {
 
   # delete old backups
   if [ -d "${BACKUP_DIR}" ] && [ -n "$(ls "${BACKUP_DIR}")" ]; then
-    find "${BACKUP_DIR}" -type f -name "*_zammad_*.gz" -mtime +"${HOLD_DAYS}" -delete
+    find "${BACKUP_DIR}" -maxdepth 1 -type f -name "*_zammad_*.gz" -mtime +"${HOLD_DAYS}" -delete
   fi
 
   if [ "${NO_FILE_BACKUP}" != "yes" ]; then


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

### Summary

This PR fixes an issue in the backup cleanup logic (see #6033) where `find` fails if no files match the glob pattern `*_zammad_*.gz`.

### Problem

The current implementation uses shell globbing:

`find "${BACKUP_DIR}"/*_zammad_*.gz ...`

If no files match, the shell passes the pattern literally to `find`, resulting in:

`find: ‘.../*_zammad_*.gz’: No such file or directory`. 

With `set -e`, this causes the script to exit prematurely. As a result no (initial/new) backups are created.

### Solution

Replace shell globbing with `find -name` so that pattern matching is handled by `find` itself:

`find "${BACKUP_DIR}" -type f -name '*_zammad_*.gz' ...`