### PR TITLE
Fix #1023 - ignored emails creating users

### DIFF
--- a/app/models/channel/email_parser.rb
+++ b/app/models/channel/email_parser.rb
@@ -168,18 +168,29 @@ returns
     original_interface_handle = ApplicationHandleInfo.current
     transaction_params = { interface_handle: "#{original_interface_handle}.postmaster", disable: [] }
 
-    filters = postmaster_prefilters
+    filters = {}
+    Setting.where(area: 'Postmaster::PreFilter').reorder(:name).each do |setting|
+      filters[setting.name] = Setting.get(setting.name).constantize
+    end
 
-    run_prefilters(prefilters_before_ignore(filters), channel, mail, transaction_params)
+    filters_before_ignore = filters.reject do |_key, backend|
+      prefilters_after_ignore_backend?(backend)
+    end
 
-    # check ignore header as early as possible after decision filters
+    filters_after_ignore = filters.select do |_key, backend|
+      prefilters_after_ignore_backend?(backend)
+    end
+
+    run_prefilters(filters_before_ignore, channel, mail, transaction_params)
+
+    # check ignore header
     if ['true', true].include?(mail[:'x-zammad-ignore'])
       Rails.logger.info "ignored email with msgid '#{mail[:message_id]}' from '#{mail[:from]}' because of x-zammad-ignore header"
 
       return [{}, nil, nil, mail]
     end
 
-    run_prefilters(prefilters_after_ignore(filters), channel, mail, transaction_params)
+    run_prefilters(filters_after_ignore, channel, mail, transaction_params)
 
     ticket       = nil
     article      = nil
@@ -529,24 +540,6 @@ returns
   end
 
   private
-
-  def postmaster_prefilters
-    Setting.where(area: 'Postmaster::PreFilter').reorder(:name).to_h do |setting|
-      [setting.name, Setting.get(setting.name).constantize]
-    end
-  end
-
-  def prefilters_before_ignore(filters)
-    filters.select do |_key, backend|
-      !prefilters_after_ignore_backend?(backend)
-    end
-  end
-
-  def prefilters_after_ignore(filters)
-    filters.select do |_key, backend|
-      prefilters_after_ignore_backend?(backend)
-    end
-  end
 
   def prefilters_after_ignore_backend?(backend)
     [

--- a/app/models/channel/email_parser.rb
+++ b/app/models/channel/email_parser.rb
@@ -168,27 +168,18 @@ returns
     original_interface_handle = ApplicationHandleInfo.current
     transaction_params = { interface_handle: "#{original_interface_handle}.postmaster", disable: [] }
 
-    filters = {}
-    Setting.where(area: 'Postmaster::PreFilter').reorder(:name).each do |setting|
-      filters[setting.name] = Setting.get(setting.name).constantize
-    end
-    filters.each do |key, backend|
-      Rails.logger.debug { "run postmaster pre filter #{key}: #{backend}" }
-      begin
-        backend.run(channel, mail, transaction_params)
-      rescue => e
-        Rails.logger.error "can't run postmaster pre filter #{key}: #{backend}"
-        Rails.logger.error e.inspect
-        raise e
-      end
-    end
+    filters = postmaster_prefilters
 
-    # check ignore header
+    run_prefilters(prefilters_before_ignore(filters), channel, mail, transaction_params)
+
+    # check ignore header as early as possible after decision filters
     if ['true', true].include?(mail[:'x-zammad-ignore'])
       Rails.logger.info "ignored email with msgid '#{mail[:message_id]}' from '#{mail[:from]}' because of x-zammad-ignore header"
 
       return [{}, nil, nil, mail]
     end
+
+    run_prefilters(prefilters_after_ignore(filters), channel, mail, transaction_params)
 
     ticket       = nil
     article      = nil
@@ -538,6 +529,44 @@ returns
   end
 
   private
+
+  def postmaster_prefilters
+    Setting.where(area: 'Postmaster::PreFilter').reorder(:name).to_h do |setting|
+      [setting.name, Setting.get(setting.name).constantize]
+    end
+  end
+
+  def prefilters_before_ignore(filters)
+    filters.select do |_key, backend|
+      !prefilters_after_ignore_backend?(backend)
+    end
+  end
+
+  def prefilters_after_ignore(filters)
+    filters.select do |_key, backend|
+      prefilters_after_ignore_backend?(backend)
+    end
+  end
+
+  def prefilters_after_ignore_backend?(backend)
+    [
+      Channel::Filter::IdentifySessionUser,
+      Channel::Filter::IdentifySender,
+    ].include?(backend)
+  end
+
+  def run_prefilters(filters, channel, mail, transaction_params)
+    filters.each do |key, backend|
+      Rails.logger.debug { "run postmaster pre filter #{key}: #{backend}" }
+      begin
+        backend.run(channel, mail, transaction_params)
+      rescue => e
+        Rails.logger.error "can't run postmaster pre filter #{key}: #{backend}"
+        Rails.logger.error e.inspect
+        raise e
+      end
+    end
+  end
 
   # generate Message ID on the fly if it was missing
   # yes, Mail gem generates one in some cases

--- a/app/models/channel/email_parser.rb
+++ b/app/models/channel/email_parser.rb
@@ -173,12 +173,8 @@ returns
       filters[setting.name] = Setting.get(setting.name).constantize
     end
 
-    filters_before_ignore = filters.reject do |_key, backend|
-      prefilters_after_ignore_backend?(backend)
-    end
-
-    filters_after_ignore = filters.select do |_key, backend|
-      prefilters_after_ignore_backend?(backend)
+    filters_before_ignore, filters_after_ignore = filters.partition do |_key, backend|
+      !prefilters_after_ignore_backend?(backend)
     end
 
     run_prefilters(filters_before_ignore, channel, mail, transaction_params)

--- a/app/models/channel/filter/identify_sender.rb
+++ b/app/models/channel/filter/identify_sender.rb
@@ -2,6 +2,7 @@
 
 class Channel::Filter::IdentifySender < Channel::Filter::BaseIdentifyUser
   def self.run(_channel, mail, _transaction_params)
+    return true if ['true', true].include?(mail[:'x-zammad-ignore'])
 
     customer_user_id = mail[ :'x-zammad-ticket-customer_id' ]
     customer_user = nil

--- a/app/models/channel/filter/identify_session_user.rb
+++ b/app/models/channel/filter/identify_session_user.rb
@@ -2,6 +2,7 @@
 
 class Channel::Filter::IdentifySessionUser < Channel::Filter::BaseIdentifyUser
   def self.run(_channel, mail, _transaction_params)
+    return true if ['true', true].include?(mail[:'x-zammad-ignore'])
     user = fetch_session_user(mail) || create_session_user(mail)
 
     mail[ :'x-zammad-session-user-id' ] = user.id

--- a/app/models/channel/filter/identify_session_user.rb
+++ b/app/models/channel/filter/identify_session_user.rb
@@ -3,6 +3,7 @@
 class Channel::Filter::IdentifySessionUser < Channel::Filter::BaseIdentifyUser
   def self.run(_channel, mail, _transaction_params)
     return true if ['true', true].include?(mail[:'x-zammad-ignore'])
+
     user = fetch_session_user(mail) || create_session_user(mail)
 
     mail[ :'x-zammad-session-user-id' ] = user.id

--- a/spec/models/channel/email_parser_spec.rb
+++ b/spec/models/channel/email_parser_spec.rb
@@ -212,6 +212,37 @@ RSpec.describe Channel::EmailParser, type: :model do
         end
       end
 
+      context 'with one unrecognized email address and matching ignore postmaster filter' do
+        let!(:postmaster_filter) do
+          create(
+            :postmaster_filter,
+            match:   { 'subject' => { 'operator' => 'contains', 'value' => 'Test' } },
+            perform: { 'x-zammad-ignore' => { 'value' => true } }
+          )
+        end
+
+        it 'does not create a new user' do
+          expect { described_class.new.process({}, <<~RAW) }.not_to change(User, :count)
+            From: #{Faker::Internet.unique.email}
+            Subject: Test
+
+            Lorem ipsum dolor
+          RAW
+        end
+
+        it 'does not create a ticket or article', :aggregate_failures do
+          expect { described_class.new.process({}, <<~RAW) }
+            .not_to change(Ticket, :count)
+            .and not_change(Ticket::Article, :count)
+            .and not_change(User, :count)
+            From: #{Faker::Internet.unique.email}
+            Subject: Test
+
+            Lorem ipsum dolor
+          RAW
+        end
+      end
+
       context 'with a large number of unrecognized recipient addresses' do
         it 'never creates more than 40 users' do
           expect { described_class.new.process({}, <<~RAW) }.to change(User, :count).by(40)

--- a/spec/models/channel/email_parser_spec.rb
+++ b/spec/models/channel/email_parser_spec.rb
@@ -221,25 +221,17 @@ RSpec.describe Channel::EmailParser, type: :model do
           )
         end
 
-        it 'does not create a new user' do
-          expect { described_class.new.process({}, <<~RAW) }.not_to change(User, :count)
-            From: #{Faker::Internet.unique.email}
-            Subject: Test
+        it 'does not create a ticket, article or user', :aggregate_failures do
+          expect do
+            described_class.new.process({}, <<~RAW)
+              From: #{Faker::Internet.unique.email}
+              Subject: Test
 
-            Lorem ipsum dolor
-          RAW
-        end
-
-        it 'does not create a ticket or article', :aggregate_failures do
-          expect { described_class.new.process({}, <<~RAW) }
-            .not_to change(Ticket, :count)
+              Lorem ipsum dolor
+            RAW
+          end.to not_change(Ticket, :count)
             .and not_change(Ticket::Article, :count)
             .and not_change(User, :count)
-            From: #{Faker::Internet.unique.email}
-            Subject: Test
-
-            Lorem ipsum dolor
-          RAW
         end
       end
 


### PR DESCRIPTION
Fixes #1023

## Summary

Postmaster filters with `ignore message = yes` currently stop ticket creation, but they can still create users before processing is aborted.

This happens because user-identification filters run before `x-zammad-ignore` from database-backed Postmaster rules is evaluated.

This change moves the ignore decision earlier and delays user-creating identification filters until after that check.

## Problem

`Channel::EmailParser#_process` executes all pre-filters first and checks `x-zammad-ignore` only afterwards.

As a result, a matching Postmaster rule can mark an email as ignored, but by that time filters like `Channel::Filter::IdentifySessionUser` have already called `user_create(...)`.

So ignored emails may still create sender users.

## Changes

- split pre-filter execution in `Channel::EmailParser` into two phases
- run Postmaster filters before user-identification filters
- check `x-zammad-ignore` immediately after the first phase
- only run these filters if the mail is not ignored:
  - `Channel::Filter::IdentifySessionUser`
  - `Channel::Filter::IdentifySender`
- add defensive early returns in both filters when `x-zammad-ignore` is already set
- add a regression spec to ensure ignored emails do not create users

## Result

Ignored emails no longer create users, while normal email processing stays unchanged.