### PR TITLE
Show accounted time in each article

### DIFF
--- a/app/assets/javascripts/app/controllers/article_view/item.coffee
+++ b/app/assets/javascripts/app/controllers/article_view/item.coffee
@@ -1,4 +1,6 @@
 class App.ArticleViewItem extends App.ControllerObserver
+  @include App.TimeAccountingUnitMixin
+
   model: 'TicketArticle'
   observe:
     from: true
@@ -133,6 +135,7 @@ class App.ArticleViewItem extends App.ControllerObserver
         article:     article
         attachments: attachments
         links:       links
+        displayUnit: @timeAccountingDisplayUnit()
       )
       return
     if article.sender.name is 'System' && article.type.name isnt 'note'
@@ -142,6 +145,7 @@ class App.ArticleViewItem extends App.ControllerObserver
         article:     article
         attachments: attachments
         links:       links
+        displayUnit: @timeAccountingDisplayUnit()
       )
       return
 
@@ -166,6 +170,7 @@ class App.ArticleViewItem extends App.ControllerObserver
       article:     article
       attachments: App.view('generic/attachments')(attachments: attachments, has_body: !!article.html)
       links:       links
+      displayUnit: @timeAccountingDisplayUnit()
     )
 
     new App.WidgetAvatar(

--- a/app/assets/javascripts/app/controllers/article_view/item.coffee
+++ b/app/assets/javascripts/app/controllers/article_view/item.coffee
@@ -34,6 +34,7 @@ class App.ArticleViewItem extends App.ControllerObserver
   constructor: ->
     super
     @seeMoreOpen = false
+    @time_accountings = @ui?.parent?.time_accountings
 
     # set expand of text area only once
     @controllerBind('ui::ticket::shown', (data) =>
@@ -54,6 +55,14 @@ class App.ArticleViewItem extends App.ControllerObserver
       if @highlighter
         @highlighter.loadHighlights(@object_id)
     @delay(d, 200)
+
+  # Calculate time_unit for this article
+  getArticleTimeUnit: (article) =>
+    return null if !@time_accountings || !article?.id
+    timeAccounting = _.find(@time_accountings, (item) =>
+      item.ticket_article_id is article.id
+    )
+    return timeAccounting?.time_unit || null
 
   render: (article) =>
 
@@ -135,7 +144,6 @@ class App.ArticleViewItem extends App.ControllerObserver
         article:     article
         attachments: attachments
         links:       links
-        displayUnit: @timeAccountingDisplayUnit()
       )
       return
     if article.sender.name is 'System' && article.type.name isnt 'note'
@@ -145,7 +153,6 @@ class App.ArticleViewItem extends App.ControllerObserver
         article:     article
         attachments: attachments
         links:       links
-        displayUnit: @timeAccountingDisplayUnit()
       )
       return
 
@@ -171,6 +178,7 @@ class App.ArticleViewItem extends App.ControllerObserver
       attachments: App.view('generic/attachments')(attachments: attachments, has_body: !!article.html)
       links:       links
       displayUnit: @timeAccountingDisplayUnit()
+      time_unit:   @getArticleTimeUnit(article)
     )
 
     new App.WidgetAvatar(

--- a/app/assets/javascripts/app/controllers/ticket_zoom.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom.coffee
@@ -621,6 +621,7 @@ class App.TicketZoom extends App.Controller
         ui:                 @
         highlighter:        @highlighter
         ticket_article_ids: @ticket_article_ids
+        time_accountings:   @time_accountings
         form_id:            @form_id
       )
 

--- a/app/assets/javascripts/app/controllers/ticket_zoom.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom.coffee
@@ -660,6 +660,7 @@ class App.TicketZoom extends App.Controller
     else
       @articleView.execute(
         ticket_article_ids: @ticket_article_ids
+        time_accountings:   @time_accountings
       )
 
     if @sidebarWidget

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
@@ -1,6 +1,7 @@
 class App.TicketZoomArticleView extends App.Controller
-  constructor: ->
+  constructor: (params) ->
     super
+    @time_accountings = params.time_accountings
     @articleController = {}
     @run()
 
@@ -20,6 +21,7 @@ class App.TicketZoomArticleView extends App.Controller
           el:         el
           ui:         @ui
           highlighter: @highlighter
+          time_accountings: @time_accountings
           form_id:    @form_id
         )
         if !@ticketArticleInsertByIndex(index, el)

--- a/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/article_view.coffee
@@ -1,12 +1,12 @@
 class App.TicketZoomArticleView extends App.Controller
-  constructor: (params) ->
+  constructor: ->
     super
-    @time_accountings = params.time_accountings
     @articleController = {}
     @run()
 
   execute: (params) =>
     @ticket_article_ids = params.ticket_article_ids
+    @time_accountings   = params.time_accountings
     @run()
 
   run: =>

--- a/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
+++ b/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
@@ -177,6 +177,18 @@
           </div>
         </div>
       </div>
+    <% if @article.time_unit > 0: %>
+      <div class="horizontal article-meta-row">
+        <div class="article-meta-key"><%- @T('Accounted Time') %></div>
+        <div class="article-meta-value">
+          <%- @Icon('clock', 'article-meta-icon') %>
+          <%= @timeUnit(@article.time_unit) %>
+          <% if @displayUnit: %>
+            <%- @T(@displayUnit) %>
+          <% end %>
+      </div>
+      </div>
+    <% end %>
     </div>
   </div>
 </div>

--- a/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
+++ b/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
@@ -186,7 +186,7 @@
           <% if @displayUnit: %>
             <%- @T(@displayUnit) %>
           <% end %>
-      </div>
+        </div>
       </div>
     <% end %>
     </div>

--- a/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
+++ b/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
@@ -177,12 +177,12 @@
           </div>
         </div>
       </div>
-    <% if @article.time_unit != 0: %>
+    <% if @time_unit: %>
       <div class="horizontal article-meta-row">
         <div class="article-meta-key"><%- @T('Accounted Time') %></div>
         <div class="article-meta-value">
           <%- @Icon('clock', 'article-meta-icon') %>
-          <%= @timeUnit(@article.time_unit) %>
+          <%= @timeUnit(@time_unit) %>
           <% if @displayUnit: %>
             <%- @T(@displayUnit) %>
           <% end %>

--- a/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
+++ b/app/assets/javascripts/app/views/ticket_zoom/article_view.jst.eco
@@ -177,7 +177,7 @@
           </div>
         </div>
       </div>
-    <% if @article.time_unit > 0: %>
+    <% if @article.time_unit != 0: %>
       <div class="horizontal article-meta-row">
         <div class="article-meta-key"><%- @T('Accounted Time') %></div>
         <div class="article-meta-value">

--- a/app/models/ticket/article.rb
+++ b/app/models/ticket/article.rb
@@ -327,6 +327,7 @@ returns
   def attributes_with_association_ids
     attributes = super
     add_attachments_to_attributes(attributes)
+    add_time_unit_to_attributes(attributes)
     if attributes['body'] && attributes['content_type'] =~ %r{text/html}i
       attributes['body'] = Rails.cache.fetch("#{self.class}/#{cache_key_with_version}/body/dynamic_image_size") do
         HtmlSanitizer.dynamic_image_size(attributes['body'])

--- a/app/models/ticket/article.rb
+++ b/app/models/ticket/article.rb
@@ -327,7 +327,6 @@ returns
   def attributes_with_association_ids
     attributes = super
     add_attachments_to_attributes(attributes)
-    add_time_unit_to_attributes(attributes)
     if attributes['body'] && attributes['content_type'] =~ %r{text/html}i
       attributes['body'] = Rails.cache.fetch("#{self.class}/#{cache_key_with_version}/body/dynamic_image_size") do
         HtmlSanitizer.dynamic_image_size(attributes['body'])


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->

This pull request adds accounted time to each `article_view` in `ticket_zoom`.

Currently accounted time per article can be found only in ticket history and user has to find which history entry point to the ticket article entry. If there are many articles, it is difficult to do so.

Some times, it is useful to see, where most time is reported or what time is reported in each article.

This PR is to solve this Feature Request:
https://community.zammad.org/t/show-accounted-time-in-each-article-or-article-detail/19933