### PR TITLE
Fix Facebook integration for Facebook Login for Business

### DIFF
--- a/lib/external_credential/facebook.rb
+++ b/lib/external_credential/facebook.rb
@@ -32,9 +32,7 @@ class ExternalCredential::Facebook
     state = SecureRandom.uuid
     {
       request_token: state,
-      # authorize_url: oauth.url_for_oauth_code(permissions: 'publish_pages, manage_pages, user_posts', state: state),
-      # authorize_url: oauth.url_for_oauth_code(permissions: 'publish_pages, manage_pages', state: state),
-      authorize_url: oauth.url_for_oauth_code(permissions: 'pages_manage_posts, pages_manage_engagement, pages_manage_metadata, pages_read_engagement, pages_read_user_content', state: state),
+      authorize_url: oauth.url_for_oauth_code(permissions: 'pages_manage_metadata, pages_messaging, pages_show_list, pages_read_engagement', state: state),
     }
   end
 
@@ -52,13 +50,35 @@ class ExternalCredential::Facebook
     access_token = oauth.get_access_token(params[:code])
     client = Koala::Facebook::API.new(access_token)
     user = client.get_object('me')
-    # p client.get_connections('me', 'accounts').inspect
     pages = client.get_connections('me', 'accounts').map do |page|
       {
         id:           page['id'],
         name:         page['name'],
         access_token: page['access_token']
       }
+    end
+
+    # Fallback for Facebook Login for Business with granular permissions:
+    # /me/accounts may return empty even when pages are authorized, because
+    # "Facebook Login for Business" grants page access via granular_scopes
+    # rather than the traditional /me/accounts endpoint.
+    # In this case, extract page IDs from the token's granular_scopes and
+    # query each page individually.
+    if pages.empty?
+      app_token = external_credential.credentials['application_id'] + '|' + external_credential.credentials['application_secret']
+      app_client = Koala::Facebook::API.new(app_token)
+      token_info = app_client.debug_token(access_token)
+      granular = token_info.dig('data', 'granular_scopes') || []
+      page_ids = granular.select { |s| s['scope'] == 'pages_show_list' }
+                         .flat_map { |s| s['target_ids'] || [] }
+                         .uniq
+      pages = page_ids.filter_map do |pid|
+        page_data = client.get_object(pid, fields: 'id,name,access_token')
+        { id: page_data['id'], name: page_data['name'], access_token: page_data['access_token'] }
+      rescue => e
+        Rails.logger.warn "Facebook: failed to fetch page #{pid} via granular_scopes fallback: #{e.message}"
+        nil
+      end
     end
 
     # check if account already exists


### PR DESCRIPTION
## Summary

Two issues prevent the Facebook channel from working with newly created Meta developer apps:

1. **Deprecated OAuth scopes** — The currently requested scopes (`pages_manage_posts`, `pages_manage_engagement`, `pages_read_user_content`) are no longer valid in Meta's current Graph API, causing an "Invalid Scopes" error during OAuth authorization. This PR replaces them with the current equivalents: `pages_manage_metadata`, `pages_messaging`, `pages_show_list`, `pages_read_engagement`.

2. **Empty pages with Facebook Login for Business** — Meta now creates apps with "Facebook Login for Business" by default (rather than the legacy "Facebook Login"). This uses [granular permissions](https://developers.facebook.com/docs/permissions/overview/), where page access is granted per-page during the OAuth flow. With granular permissions, the `/me/accounts` endpoint returns an empty array even when the user has authorized specific pages. The fix adds a fallback that inspects the token's `granular_scopes` via the [debug_token](https://developers.facebook.com/docs/graph-api/reference/v21.0/debug_token) endpoint to discover authorized page IDs, then queries each page individually for its name and access token.

## The problem

Without this fix, it is not possible to set up a new Facebook channel in Zammad using a newly created Meta developer app. Users encounter:
- "Invalid Scopes: pages_manage_posts, pages_manage_engagement, pages_read_engagement, pages_read_user_content" during OAuth
- After fixing scopes manually, no Facebook Pages appear in the channel configuration despite the user selecting pages during the OAuth flow

## Changes

- Updated OAuth scopes in `request_account_to_link` to use current Meta Graph API permissions
- Added granular_scopes fallback in `link_account` that activates only when `/me/accounts` returns empty
- Removed stale commented-out scope lines

## Test plan

- [ ] Create a new Meta developer app (type: Business) with "Facebook Login for Business"
- [ ] Add permissions: `pages_manage_metadata`, `pages_messaging`, `pages_show_list`, `pages_read_engagement`
- [ ] Configure Facebook channel in Zammad — OAuth should complete without scope errors
- [ ] Authorized Facebook Pages should appear in the channel configuration
- [ ] Verify backward compatibility: apps using legacy "Facebook Login" (where `/me/accounts` works) should continue to work without hitting the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)