### PR TITLE
Fix PreparedStatementInvalid when multi_tree_select / multiselect condition values contain '?'

### DIFF
--- a/lib/sql_helper.rb
+++ b/lib/sql_helper.rb
@@ -10,6 +10,26 @@ class SqlHelper
     ApplicationModel.sanitize_sql_like(...)
   end
 
+  # Quote a value for inclusion as a literal element inside an ARRAY[...]
+  # SQL expression.
+  #
+  # The resulting fragment is later concatenated into a larger SQL string
+  # and passed to ActiveRecord as `relation.where(query_sql, *bind_params)`.
+  # ActiveRecord scans the query string for `?` bind placeholders across
+  # the entire string — it does not exclude occurrences inside quoted
+  # literals. Any `?` inside a value would therefore be mistaken for an
+  # unfilled bind placeholder and trigger
+  # `ActiveRecord::PreparedStatementInvalid: wrong number of bind
+  # variables`. To avoid this, split the value on `?` and concatenate the
+  # segments with `chr(63)` so the resulting SQL no longer contains a
+  # literal `?` character.
+  def self.quote_array_literal(value)
+    quoted = quote_string(value.to_s)
+    return "'#{quoted}'" unless quoted.include?('?')
+
+    quoted.split('?', -1).map { |segment| "'#{segment}'" }.join(' || chr(63) || ')
+  end
+
   def initialize(object:, table_name: nil)
     @object     = object
     @table_name = table_name
@@ -198,7 +218,7 @@ sql = 'tickets.created_at ASC, tickets.updated_at DESC'
   def array_contains_all(attribute, value, negated: false)
     value = [''] if value.blank?
     value = Array(value)
-    result = "(#{db_column(attribute)} @> ARRAY[#{value.map { |v| "'#{self.class.quote_string(v)}'" }.join(',')}]::varchar[])"
+    result = "(#{db_column(attribute)} @> ARRAY[#{value.map { |v| self.class.quote_array_literal(v) }.join(',')}]::varchar[])"
 
     negated ? "NOT(#{result})" : "(#{result})"
   end
@@ -206,7 +226,7 @@ sql = 'tickets.created_at ASC, tickets.updated_at DESC'
   def array_contains_one(attribute, value, negated: false)
     value = [''] if value.blank?
     value = Array(value)
-    result = "(#{db_column(attribute)} && ARRAY[#{value.map { |v| "'#{self.class.quote_string(v)}'" }.join(',')}]::varchar[])"
+    result = "(#{db_column(attribute)} && ARRAY[#{value.map { |v| self.class.quote_array_literal(v) }.join(',')}]::varchar[])"
 
     negated ? "NOT(#{result})" : "(#{result})"
   end

--- a/spec/lib/sql_helper_spec.rb
+++ b/spec/lib/sql_helper_spec.rb
@@ -1,0 +1,97 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe SqlHelper do
+  describe '.quote_array_literal' do
+    it 'wraps a simple value in single quotes' do
+      expect(described_class.quote_array_literal('foo')).to eq("'foo'")
+    end
+
+    it 'doubles embedded single quotes' do
+      expect(described_class.quote_array_literal("foo's")).to eq("'foo''s'")
+    end
+
+    it 'splits on ? so the fragment does not contain a raw ? placeholder (#6089)' do
+      # A literal ? inside the quoted value would otherwise be counted as an
+      # unfilled bind placeholder by ActiveRecord#build_bound_sql_literal and
+      # raise ActiveRecord::PreparedStatementInvalid.
+      result = described_class.quote_array_literal('trip?')
+      expect(result).not_to include('?')
+      expect(result).to eq("'trip' || chr(63) || ''")
+    end
+
+    it 'handles multiple ? in the same value' do
+      result = described_class.quote_array_literal('a?b?c')
+      expect(result).not_to include('?')
+      expect(result).to eq("'a' || chr(63) || 'b' || chr(63) || 'c'")
+    end
+  end
+
+  describe '#array_contains_one' do
+    subject(:helper) { described_class.new(object: Ticket) }
+
+    it 'inlines values that contain ? without leaking a raw ? into the SQL (#6089)' do
+      sql = helper.array_contains_one('title', ['Why was I charged?'])
+      expect(sql).not_to include('?')
+      expect(sql).to include("'Why was I charged' || chr(63) || ''")
+    end
+  end
+
+  describe '#array_contains_all' do
+    subject(:helper) { described_class.new(object: Ticket) }
+
+    it 'inlines values that contain ? without leaking a raw ? into the SQL (#6089)' do
+      sql = helper.array_contains_all('title', ['trip?'])
+      expect(sql).not_to include('?')
+      expect(sql).to include("'trip' || chr(63) || ''")
+    end
+  end
+
+  context 'when used through Ticket.selectors with a multi_tree_select value containing ?' do
+    let(:attribute) do
+      create(:object_manager_attribute_tree_select,
+             object_name: 'Ticket',
+             data_option: {
+               options:             [
+                 { name: 'Why was I charged?', value: 'Why was I charged?',
+                   children: [{ name: 'Explained', value: 'Why was I charged?::Explained' }] },
+               ],
+               historical_options:  {
+                 'Why was I charged?'            => 'Why was I charged?',
+                 'Why was I charged?::Explained' => 'Explained',
+               },
+               default:             '',
+               null:                true,
+               translate:           false,
+               relation:            '',
+               multiple:            true,
+               type:                'tree_select',
+               nulloption:          true,
+               options_raw:         '',
+               rejectNonExistentValues: false,
+             },
+             screens: {
+               'create_middle' => { 'ticket.agent' => { shown: true } },
+               'edit'          => { 'ticket.agent' => { shown: true } },
+             })
+    end
+
+    before do
+      attribute
+      ObjectManager::Attribute.migration_execute
+    end
+
+    it 'does not raise PreparedStatementInvalid (regression for #6089)' do
+      condition = {
+        operator:   'AND',
+        conditions: [
+          { name: "ticket.#{attribute.name}", operator: 'contains one',
+            value: ['Why was I charged?::Explained'] },
+        ],
+      }
+
+      expect { Ticket.selectors(condition, current_user: User.find(1), access: 'ignore') }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #6091. Saving a Trigger / Overview / Scheduler / Core Workflow with a `contains one` / `contains all` condition on a `multiselect` or `multi_tree_select` attribute currently fails with HTTP 422 `Invalid object selector conditions` whenever any selected value contains a literal `?` character. Under the hood this surfaces as `ActiveRecord::PreparedStatementInvalid: wrong number of bind variables (N for M)` — `Selector::Sql#valid?`'s bare `rescue` swallows it and returns `false`, which admins then see as the opaque 422.

## Root cause

`lib/sql_helper.rb#array_contains_one` and `array_contains_all` build SQL by inlining values directly into the `ARRAY[…]::varchar[]` literal. The resulting fragment is later passed to `relation.where(query_sql, *bind_params)`. AR 8's `build_bound_sql_literal` scans the entire query string for `?` — including occurrences inside quoted string literals — and treats each as a bind placeholder. Because the helper emits no bind for those, the placeholder count mismatches → `PreparedStatementInvalid`.

This matters in practice because natural-language operational vocabularies commonly use `?` (FAQs, contact-reason trees, satisfaction flags — e.g. "Why was I charged?", "Has my Extra Hold been released?", "Customer OK with outcome?").

## Fix

Add `SqlHelper.quote_array_literal(value)` that splits the value on `?` and joins the segments with `|| chr(63) ||` so the emitted SQL no longer contains a raw `?`. Route both `array_contains_one` and `array_contains_all` through it.

- `chr(63)` is ASCII `?` in PostgreSQL; the concatenation evaluates at query time to the exact original string, so no semantic change for any existing value. Only values that actually contain `?` get the rewrite.
- API is unchanged; this is a purely internal escape strategy.

## Test plan

- [x] Added `spec/lib/sql_helper_spec.rb` covering:
  - `quote_array_literal` for simple values, values with single quotes, single `?`, multiple `?`.
  - `array_contains_one` / `array_contains_all` emit no raw `?` and preserve semantics.
  - Integration: `Ticket.selectors` with a `multi_tree_select` condition whose value contains `?` does not raise `PreparedStatementInvalid`.
- [x] Manual repro on Zammad 7.0.1 / PostgreSQL 17 / Rails 8.0.5: without patch — 422 `Invalid object selector conditions` + `PreparedStatementInvalid (1 for 2)` in Rails console. With patch — trigger save 200 OK, SQL fragment contains `|| chr(63) ||` instead of raw `?`, returned row count is correct.

## Related

- Issue: #6091

