### PR TITLE
Allow same-browser session tabs to coexist

### DIFF
--- a/app/assets/javascripts/app/lib/app_post/task_manager/singleton.coffee
+++ b/app/assets/javascripts/app/lib/app_post/task_manager/singleton.coffee
@@ -447,8 +447,22 @@ class App.TaskManagerSingleton extends App.Controller
     false
 
   TaskbarId: =>
-    if !@TaskbarIdInt
-      @TaskbarIdInt = Math.floor( Math.random() * 99999999 )
+    storageKey = 'taskbar_id'
+
+    try
+      storedTaskbarId = App.LocalStorage.get(storageKey)
+
+      if storedTaskbarId
+        @TaskbarIdInt = storedTaskbarId
+        return @TaskbarIdInt
+
+      if !@TaskbarIdInt
+        @TaskbarIdInt = Math.floor( Math.random() * 99999999 )
+        App.LocalStorage.set(storageKey, @TaskbarIdInt)
+    catch
+      if !@TaskbarIdInt
+        @TaskbarIdInt = Math.floor( Math.random() * 99999999 )
+
     @TaskbarIdInt
 
   taskUpdate: (task, mute = false) ->

--- a/spec/system/basic/session_takeover_spec.rb
+++ b/spec/system/basic/session_takeover_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Session takeover check', type: :system do
-  context 'when use logout action' do
+  context 'when opening multiple browser tabs' do
     let(:agent)    { create(:agent) }
 
-    it 'check that all tabs have been logged out', authenticated_as: :agent do
+    it 'keeps the existing tab active', authenticated_as: :agent do
       visit '/'
 
       # open new tab
@@ -17,7 +17,9 @@ RSpec.describe 'Session takeover check', type: :system do
       # Go back and check for session takeover message
       switch_to_window_index(1)
 
-      expect(page).to have_text('A new session was created with your account. This session will be stopped to prevent a conflict.')
+      expect(page).to have_no_text(
+        'A new session was created with your account. This session will be stopped to prevent a conflict.',
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

This change allows multiple browser tabs in the same browser profile to stay active for the same user.

Previously, opening a second tab could trigger the legacy `session_takeover` blocker in the first tab because `App.TaskManager.TaskbarId()` generated a random in-memory value per tab. This made tabs from the same browser look like competing sessions.

The taskbar id is now persisted in `localStorage`, so same-browser tabs share the same id. If `localStorage` is unavailable, the existing in-memory fallback is still used.

## Changes

- Persist the legacy task manager tab/session id in `localStorage`.
- Re-read the stored id before comparing takeover messages, so tabs opened close together converge on the same browser id.
- Update the system spec to assert that opening another browser tab does not stop the existing tab.

## Verification

Ran the targeted system spec locally:

```sh
RAILS_ENV=test VITE_TEST_MODE=1 CI_SKIP_ASSETS_PRECOMPILE=1 \
DATABASE_URL=postgresql://test@127.0.0.1:5432/zammad_test \
REDIS_URL=redis://127.0.0.1:6379 \
SELENIUM_BROWSER=chrome SELENIUM_BROWSER_HEADLESS=true \
bundle _2.6.9_ exec rspec spec/system/basic/session_takeover_spec.rb
