### PR TITLE
Add Microsoft365 Graph Notification-Channel

### DIFF
--- a/app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee
@@ -130,6 +130,9 @@ class App.ChannelAccountOverview extends App.ControllerSubContent
       rollback_button_first: @rollbackButtonFirst
     )
 
+    if !App.Config.get('system_online_service')
+      new App.ChannelEmailNotification(el: @$('.js-notificationSection'))
+
     # On a channel creation, auto-open the edit dialog so the user can
     # adjust the inbound configuration. Skip for migrated channels — their
     # configuration is assumed to be correct.

--- a/app/assets/javascripts/app/controllers/_channel/_email_notification.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/_email_notification.coffee
@@ -1,0 +1,245 @@
+# Shared Email Notification tab controller.
+# Can be included as a tab in any channel page (Email, Microsoft Graph, etc.)
+# Loads the notification channel data from the email index endpoint and renders
+# the notification section with an Edit button that opens the notification wizard.
+
+class App.ChannelEmailNotification extends App.Controller
+  events:
+    'click .js-editNotificationOutbound': 'editNotificationOutbound'
+
+  constructor: ->
+    super
+    @load()
+
+  load: =>
+    @startLoading()
+    @ajax(
+      id:   'email_notification_tab'
+      type: 'GET'
+      url:  "#{@apiPath}/channels_email"
+      processData: true
+      success: (data, status, xhr) =>
+        @stopLoading()
+        App.Collection.loadAssets(data.assets)
+        @channelDriver = data.channel_driver
+        @config = data.config
+        @render(data)
+    )
+
+  render: (data = {}) =>
+    notification_channels = []
+    if data.notification_channel_ids
+      for channel_id in data.notification_channel_ids
+        notification_channels.push App.Channel.find(channel_id)
+
+    @html App.view('channel/email_notification_overview')(
+      notification_channels: notification_channels
+      config: @config
+    )
+
+  editNotificationOutbound: (e) =>
+    e.preventDefault()
+    id      = $(e.target).closest('.action').data('id')
+    channel = App.Channel.find(id)
+    # ChannelEmailNotificationWizard is file-local in email.coffee, so we
+    # trigger the edit via a synthetic click on the email channel page.
+    # Instead, we re-implement the wizard opening inline.
+    @openNotificationWizard(channel)
+
+  openNotificationWizard: (channel) =>
+    # Load the notification wizard dynamically. Since ChannelEmailNotificationWizard
+    # is not globally accessible, we navigate to the email channel page to trigger
+    # the edit there. This is a pragmatic workaround.
+    # However, we can also replicate the wizard-opening behavior:
+    new App.ChannelEmailNotificationWizardProxy(
+      container:     @el.closest('.content')
+      channel:       channel
+      callback:      @load
+      channelDriver: @channelDriver
+    )
+
+
+# Proxy class that opens the notification wizard by temporarily navigating to
+# the email channel, or by creating the wizard modal inline.
+# Since the actual ChannelEmailNotificationWizard is file-local, we build the
+# wizard modal here using the same template and behavior.
+class App.ChannelEmailNotificationWizardProxy extends App.ControllerWizardModal
+  elements:
+    '.modal-body': 'body'
+  events:
+    'change [name="options::ssl_verify"]': 'toggleSslVerifyAlert'
+    'change [name="options::port"]':       'toggleSslVerifyVisibility'
+    'change .js-outbound [name=adapter]':  'toggleOutboundAdapter'
+    'submit .js-outbound':                 'probleOutbound'
+    'click  .js-close':                    'hide'
+
+  constructor: ->
+    super
+
+    @account =
+      inbound:
+        adapter: undefined
+        options: undefined
+      outbound:
+        adapter: undefined
+        options: undefined
+      meta: {}
+
+    if @channel
+      @account =
+        inbound: clone(@channel.options.inbound)
+        outbound: clone(@channel.options.outbound)
+
+    @render()
+    @toggleSslVerifyAlert(target: @el.find('[name="options::ssl_verify"]'))
+
+    @el.modal(
+      keyboard:  true
+      show:      true
+      backdrop:  true
+      container: @container
+    ).on(
+      'show.bs.modal':   @onShow
+      'shown.bs.modal': =>
+        @el.addClass('modal--ready')
+        @onShown() if @onShown
+      'hidden.bs.modal': =>
+        if @callback
+          @callback()
+        @el.remove()
+    )
+    if @slide
+      @showSlide(@slide)
+
+  render: =>
+    super
+
+    @html App.view('channel/email_notification_wizard')()
+    @showSlide('js-outbound')
+
+    configureAttributesOutbound = [
+      { name: 'adapter', display: __('Send Mails via'), tag: 'select', multiple: false, null: false, options: @channelDriver.email.outbound, translate: true },
+    ]
+    new App.ControllerForm(
+      el:    @$('.base-outbound-type')
+      model:
+        configure_attributes: configureAttributesOutbound
+        className: ''
+      params:
+        adapter: @account.outbound.adapter || 'sendmail'
+    )
+    @toggleOutboundAdapter()
+
+  toggleOutboundAdapter: =>
+    @el.find('.base-outbound-settings').html('')
+    adapter = @$('.js-outbound [name=adapter]').val()
+    if adapter is 'smtp'
+      configureAttributesOutbound = [
+        { name: 'options::host',       display: __('Host'),     tag: 'input', type: 'text',     limit: 120, null: false, autocapitalize: false, autofocus: true },
+        { name: 'options::user',       display: __('User'),     tag: 'input', type: 'text',     limit: 120, null: true, autocapitalize: false, autocomplete: 'off' },
+        { name: 'options::password',   display: __('Password'), tag: 'input', type: 'password', limit: 120, null: true, autocapitalize: false, autocomplete: 'new-password', single: true },
+        { name: 'options::port',       display: __('Port'),     tag: 'input', type: 'text',     limit: 6,   null: true, autocapitalize: false, item_class: 'formGroup--halfSize' },
+        { name: 'options::ssl_verify', display: __('SSL verification'), tag: 'boolean', default: true, null: true, translate: true, item_class: 'formGroup--halfSize' },
+      ]
+      @form = new App.ControllerForm(
+        el:    @$('.base-outbound-settings')
+        model:
+          configure_attributes: configureAttributesOutbound
+          className: ''
+        params: @account.outbound
+      )
+      @$('.js-outbound .btn--primary').text(App.i18n.translateContent('Continue'))
+    else if adapter is 'microsoft_graph_outbound'
+      @el.find('.js-sslVerifyAlert').addClass('hide')
+
+      currentMailboxType = 'user'
+      currentSharedMailbox = ''
+      if @account?.outbound?.adapter is 'microsoft_graph_outbound'
+        if @account.outbound.options?.shared_mailbox
+          currentMailboxType = 'shared'
+          currentSharedMailbox = @account.outbound.options.shared_mailbox
+
+      configureAttributesOutbound = [
+        { name: 'mailbox_type',   display: __('Mailbox type'),   tag: 'select', options: { user: __('User mailbox'), shared: __('Shared mailbox') }, translate: true, null: false, value: currentMailboxType },
+        { name: 'shared_mailbox', display: __('Shared mailbox'), tag: 'input', type: 'email', limit: 120, null: true, placeholder: __('user@your-organization.tld'), value: currentSharedMailbox, hide: currentMailboxType isnt 'shared' },
+      ]
+      @form = new App.ControllerForm(
+        el:    @$('.base-outbound-settings')
+        model:
+          configure_attributes: configureAttributesOutbound
+          className: ''
+        handlers: [
+          App.FormHandlerChannelAccountMailboxType.run
+        ]
+      )
+      @$('.js-outbound .btn--primary').text(App.i18n.translateContent('Authenticate'))
+    else
+      # sendmail — no extra fields
+      @$('.js-outbound .btn--primary').text(App.i18n.translateContent('Continue'))
+
+  toggleSslVerifyVisibility: (e) ->
+    elem      = $(e.target)
+    isEnabled = elem.val() is '' or elem.val() is '465' or elem.val() is '587'
+    sslVerifyField = elem.closest('form').find('[name="options::ssl_verify"]')
+    if isEnabled
+      sslVerifyField.removeAttr('disabled')
+    else
+      sslVerifyField.attr('disabled', 'disabled')
+    @toggleSslVerifyAlert(target: sslVerifyField, !isEnabled)
+
+  toggleSslVerifyAlert: (e, forceInvisible) ->
+    elem           = $(e.target)
+    isAlertVisible = if forceInvisible then false else elem.val() != 'true'
+    elem.closest('.modal-content')
+      .find('.js-sslVerifyAlert')
+      .toggleClass('hide', !isAlertVisible)
+
+  probleOutbound: (e) =>
+    e.preventDefault()
+
+    params = @formParam(e.target)
+    params.channel_id = @channel.id
+
+    adapter = @$('.js-outbound [name=adapter]').val()
+
+    if adapter is 'microsoft_graph_outbound'
+      if params.mailbox_type is 'shared' && !params.shared_mailbox
+        @showAlert('js-outbound', __('Please enter a shared mailbox address.'))
+        return
+      # Move mailbox fields into options for the server
+      params.options ||= {}
+      params.options.shared_mailbox = params.shared_mailbox if params.mailbox_type is 'shared'
+      delete params.mailbox_type
+      delete params.shared_mailbox
+
+    sslVerifyField = $(e.target).closest('form').find('[name="options::ssl_verify"]')
+    if sslVerifyField[0]?.disabled
+      params.options ||= {}
+      params.options.ssl_verify = false
+
+    @disable(e)
+    @showSlide('js-test')
+
+    @ajax(
+      id:   'email_outbound'
+      type: 'POST'
+      url:  "#{@apiPath}/channels_email_notification"
+      data: JSON.stringify(params)
+      processData: true
+      success: (data, status, xhr) =>
+        if data.result is 'redirect' && data.url
+          window.location.href = data.url
+          return
+        if data.result is 'ok'
+          @el.modal('hide')
+        else
+          @showSlide('js-outbound')
+          @showAlert('js-outbound', data.message_human || data.message)
+          @showInvalidField('js-outbound', data.invalid_field)
+        @enable(e)
+      error: (xhr) =>
+        data = JSON.parse(xhr.responseText)
+        @showSlide('js-outbound')
+        @showAlert('js-outbound', data.message_human || data.message || data.error)
+        @showInvalidField('js-outbound', data.invalid_field)
+    )

--- a/app/assets/javascripts/app/controllers/_channel/_email_notification.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/_email_notification.coffee
@@ -9,7 +9,12 @@ class App.ChannelEmailNotification extends App.Controller
 
   constructor: ->
     super
-    @load()
+    if @data
+      @channelDriver = @data.channel_driver
+      @config        = @data.config
+      @render(@data)
+    else
+      @load()
 
   load: =>
     @startLoading()
@@ -242,4 +247,5 @@ class App.ChannelEmailNotificationWizardProxy extends App.ControllerWizardModal
         @showSlide('js-outbound')
         @showAlert('js-outbound', data.message_human || data.message || data.error)
         @showInvalidField('js-outbound', data.invalid_field)
+        @enable(e)
     )

--- a/app/assets/javascripts/app/controllers/_channel/_email_notification.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/_email_notification.coffee
@@ -138,6 +138,7 @@ class App.ChannelEmailNotificationWizardProxy extends App.ControllerWizardModal
   toggleOutboundAdapter: =>
     @el.find('.base-outbound-settings').html('')
     adapter = @$('.js-outbound [name=adapter]').val()
+    @el.find('.js-msgraphNotificationWarning').toggleClass('hide', adapter isnt 'microsoft_graph_outbound')
     if adapter is 'smtp'
       configureAttributesOutbound = [
         { name: 'options::host',       display: __('Host'),     tag: 'input', type: 'text',     limit: 120, null: false, autocapitalize: false, autofocus: true },

--- a/app/assets/javascripts/app/controllers/_channel/email.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/email.coffee
@@ -44,7 +44,6 @@ class ChannelEmailAccountOverview extends App.Controller
     'click .js-emailAddressNew': 'emailAddressNew'
     'click .js-emailAddressEdit': 'emailAddressEdit'
     'click .js-emailAddressDelete': 'emailAddressDelete',
-    'click .js-editNotificationOutbound': 'editNotificationOutbound'
     'click .js-migrateGoogleMail': 'migrateGoogleMail'
     'click .js-migrateMicrosoft365Mail': 'migrateMicrosoft365Mail'
 
@@ -91,18 +90,15 @@ class ChannelEmailAccountOverview extends App.Controller
     for email_address_id in data.not_used_email_address_ids
       not_used_email_addresses.push App.EmailAddress.find(email_address_id)
 
-    # get channels
-    notification_channels = []
-    for channel_id in data.notification_channel_ids
-      notification_channels.push App.Channel.find(channel_id)
-
     @html App.view('channel/email_account_overview')(
       account_channels:         account_channels
       not_used_email_addresses: not_used_email_addresses
-      notification_channels:    notification_channels
       accounts_fixed:           data.accounts_fixed
       config:                   data.config
     )
+
+    # Render the notification section via the shared controller
+    new App.ChannelEmailNotification(el: @$('.js-notificationSection'))
 
   wizard: (e) =>
     e.preventDefault()
@@ -226,18 +222,6 @@ class ChannelEmailAccountOverview extends App.Controller
       item: item
       container: @el.closest('.content')
       callback: @load
-    )
-
-  editNotificationOutbound: (e) =>
-    e.preventDefault()
-    id      = $(e.target).closest('.action').data('id')
-    channel = App.Channel.find(id)
-    slide   = 'js-outbound'
-    new ChannelEmailNotificationWizard(
-      container:     @el.closest('.content')
-      channel:       channel
-      callback:      @load
-      channelDriver: @channelDriver
     )
 
   migrateGoogleMail: (e) =>

--- a/app/assets/javascripts/app/controllers/_channel/email.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/email.coffee
@@ -98,7 +98,8 @@ class ChannelEmailAccountOverview extends App.Controller
     )
 
     # Render the notification section via the shared controller, passing preloaded data to avoid a second request
-    new App.ChannelEmailNotification(el: @$('.js-notificationSection'), data: data)
+    if !App.Config.get('system_online_service')
+      new App.ChannelEmailNotification(el: @$('.js-notificationSection'), data: data)
 
   wizard: (e) =>
     e.preventDefault()

--- a/app/assets/javascripts/app/controllers/_channel/email.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/email.coffee
@@ -97,8 +97,8 @@ class ChannelEmailAccountOverview extends App.Controller
       config:                   data.config
     )
 
-    # Render the notification section via the shared controller
-    new App.ChannelEmailNotification(el: @$('.js-notificationSection'))
+    # Render the notification section via the shared controller, passing preloaded data to avoid a second request
+    new App.ChannelEmailNotification(el: @$('.js-notificationSection'), data: data)
 
   wizard: (e) =>
     e.preventDefault()

--- a/app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee
@@ -1,44 +1,12 @@
-# Injects the Email Notification section into the Microsoft 365 Graph Email
-# Accounts tab (below the channel list) and handles the OAuth redirect response
-# for the microsoft_graph_outbound adapter.
+# Handles the OAuth redirect response for the microsoft_graph_outbound adapter
+# and injects the correct form fields when that adapter is selected in the
+# Email Notification wizard.
 
 class App.MicrosoftGraphNotification extends App.Controller
   constructor: ->
     super
-    @bindGraphPageNotificationInjector()
     @bindAdapterChangeHandler()
     @bindAjaxRedirectHandler()
-
-  bindGraphPageNotificationInjector: ->
-    # After the MS Graph channel index loads and renders, append the notification
-    # section below the channel list — same position as the Email channel page.
-    $(document).ajaxComplete (event, xhr, settings) =>
-      return if !settings.url || settings.url.indexOf('channels/admin/microsoft_graph') is -1
-      # Only act on GET (index), not POST (notification/group/etc.)
-      return if settings.type isnt 'GET'
-
-      # Small delay to let render() finish painting the DOM
-      @delay(
-        ->
-          # Find the Accounts tab content on the MS Graph page
-          pageContent = $('#c-account .page-content')
-          return if !pageContent.length
-
-          # Don't inject if app is not connected (intro page shown)
-          return if !pageContent.length or pageContent.closest('.content').find('.js-new').length is 0
-
-          # Remove previous injection to avoid duplicates (re-render)
-          pageContent.closest('#c-account').find('.js-notification-section').remove()
-
-          # Create container and append after page-content
-          container = $('<div class="js-notification-section"></div>')
-          pageContent.after(container)
-
-          # Instantiate the shared notification controller
-          new App.ChannelEmailNotification(el: container)
-        200
-        'ms-graph-notification-inject'
-      )
 
   bindAdapterChangeHandler: ->
     # Inject mailbox type fields into the Email Notification wizard

--- a/app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee
@@ -1,0 +1,91 @@
+# Injects the Email Notification section into the Microsoft 365 Graph Email
+# Accounts tab (below the channel list) and handles the OAuth redirect response
+# for the microsoft_graph_outbound adapter.
+
+class App.MicrosoftGraphNotification extends App.Controller
+  constructor: ->
+    super
+    @bindGraphPageNotificationInjector()
+    @bindAdapterChangeHandler()
+    @bindAjaxRedirectHandler()
+
+  bindGraphPageNotificationInjector: ->
+    # After the MS Graph channel index loads and renders, append the notification
+    # section below the channel list — same position as the Email channel page.
+    $(document).ajaxComplete (event, xhr, settings) =>
+      return if !settings.url || settings.url.indexOf('channels/admin/microsoft_graph') is -1
+      # Only act on GET (index), not POST (notification/group/etc.)
+      return if settings.type isnt 'GET'
+
+      # Small delay to let render() finish painting the DOM
+      @delay(
+        =>
+          # Find the Accounts tab content on the MS Graph page
+          pageContent = $('#c-account .page-content')
+          return if !pageContent.length
+
+          # Don't inject if app is not connected (intro page shown)
+          return if !pageContent.length or pageContent.closest('.content').find('.js-new').length is 0
+
+          # Remove previous injection to avoid duplicates (re-render)
+          pageContent.closest('#c-account').find('.js-notification-section').remove()
+
+          # Create container and append after page-content
+          container = $('<div class="js-notification-section"></div>')
+          pageContent.after(container)
+
+          # Instantiate the shared notification controller
+          new App.ChannelEmailNotification(el: container)
+        200
+        'ms-graph-notification-inject'
+      )
+
+  bindAdapterChangeHandler: ->
+    # Inject mailbox type fields into the Email Notification wizard
+    # (either the original one on the Email page or our proxy on the MS Graph page)
+    # when microsoft_graph_outbound is selected in the dropdown.
+    $(document).on 'change', '.js-outbound [name=adapter]', (e) ->
+      adapter = $(e.target).val()
+      modal   = $(e.target).closest('.modal-content')
+
+      # Only act on the Email Notification wizard
+      return if !modal.find('.modal-title').text().match(/Email Notification/i)
+
+      settingsContainer = modal.find('.base-outbound-settings')
+      sslAlert          = modal.find('.js-sslVerifyAlert')
+      submitBtn         = modal.find('.btn--primary')
+
+      if adapter is 'microsoft_graph_outbound'
+        sslAlert.addClass('hide')
+        settingsContainer.empty()
+
+        form = new App.ControllerForm(
+          el: settingsContainer
+          model:
+            configure_attributes: [
+              { name: 'mailbox_type',   display: __('Mailbox type'),   tag: 'select', options: { user: __('User mailbox'), shared: __('Shared mailbox') }, translate: true, null: false, value: 'user' },
+              { name: 'shared_mailbox', display: __('Shared mailbox'), tag: 'input', type: 'email', limit: 120, null: true, placeholder: __('user@your-organization.tld'), hide: true },
+            ]
+            className: ''
+          handlers: [
+            App.FormHandlerChannelAccountMailboxType.run
+          ]
+        )
+
+        submitBtn.text(App.i18n.translateContent('Authenticate'))
+      else
+        submitBtn.text(App.i18n.translateContent('Continue'))
+
+  bindAjaxRedirectHandler: ->
+    # The server returns { result: 'redirect', url: '...' } for microsoft_graph_outbound.
+    # Intercept globally so both the original email wizard and our proxy wizard handle it.
+    $(document).ajaxComplete (event, xhr, settings) ->
+      return if !settings.url || settings.url.indexOf('channels_email_notification') is -1
+      try
+        data = JSON.parse(xhr.responseText)
+      catch
+        return
+      if data.result is 'redirect' && data.url
+        window.location.href = data.url
+
+App.Config.set('microsoft_graph_notification', App.MicrosoftGraphNotification, 'Plugins')

--- a/app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee
+++ b/app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee
@@ -19,7 +19,7 @@ class App.MicrosoftGraphNotification extends App.Controller
 
       # Small delay to let render() finish painting the DOM
       @delay(
-        =>
+        ->
           # Find the Accounts tab content on the MS Graph page
           pageContent = $('#c-account .page-content')
           return if !pageContent.length

--- a/app/assets/javascripts/app/views/channel/email_account_overview.jst.eco
+++ b/app/assets/javascripts/app/views/channel/email_account_overview.jst.eco
@@ -158,45 +158,4 @@
 
 <a class="btn btn--success js-channelNew"><%- @T('New') %></a>
 
-<% if !_.isEmpty(@notification_channels) && !App.Config.get('system_online_service'): %>
-  <h2><%- @T('Email Notification') %></h2>
-  <% for channel in @notification_channels: %>
-    <div class="action" data-id="<%- channel.id %>">
-      <div class="action-flow action-flow--row">
-        <div class="action-block action-block--flex">
-          <div class="horizontal">
-            <h3><%- @Icon('status', channel.status_out + " inline") %> <%- @T('Outbound') %></h3>
-            <div class="btn btn--text js-editNotificationOutbound space-left"><%- @T('Edit') %></div>
-          </div>
-
-          <table class="key-value">
-          <% if channel.options.outbound && channel.options.outbound.options: %>
-            <tr>
-              <td><%- @T('User') %>
-              <td><%= channel.options.outbound.options.user %>
-            <tr>
-              <td><%- @T('Host') %>
-              <td><%= channel.options.outbound.options.host %>
-          <% end %>
-            <tr>
-              <td><%- @T('Protocol') %>
-              <td><%= channel.options.outbound.adapter %>
-          </table>
-
-          <% if channel.status_in is 'error': %>
-            <div class="alert alert--danger"><%= channel.last_log_in %></div>
-          <% end %>
-          <% if channel.status_out is 'error': %>
-            <div class="alert alert--danger"><%= channel.last_log_out %></div>
-          <% end %>
-        </div>
-        <div class="action-block action-block--flex">
-          <h3><%- @T('Email Address') %></h3>
-          <ul class="list">
-            <li class="list-item"><%= @config.notification_sender %>
-          </ul>
-        </div>
-      </div>
-    </div>
-  <% end %>
-<% end %>
+<div class="js-notificationSection"></div>

--- a/app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco
+++ b/app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco
@@ -1,0 +1,54 @@
+<% if !_.isEmpty(@notification_channels) && !App.Config.get('system_online_service'): %>
+  <h2><%- @T('Email Notification') %></h2>
+  <% for channel in @notification_channels: %>
+    <div class="action" data-id="<%- channel.id %>">
+      <div class="action-flow action-flow--row">
+        <div class="action-block action-block--flex">
+          <div class="horizontal">
+            <h3><%- @Icon('status', channel.status_out + " inline") %> <%- @T('Outbound') %></h3>
+            <div class="btn btn--text js-editNotificationOutbound space-left"><%- @T('Edit') %></div>
+          </div>
+
+          <table class="key-value">
+          <% if channel.options.outbound && channel.options.outbound.options: %>
+            <% if channel.options.outbound.options.host: %>
+            <tr>
+              <td><%- @T('User') %>
+              <td><%= channel.options.outbound.options.user %>
+            <tr>
+              <td><%- @T('Host') %>
+              <td><%= channel.options.outbound.options.host %>
+            <% end %>
+            <% if channel.options.outbound.adapter is 'microsoft_graph_outbound': %>
+            <tr>
+              <td><%- @T('User') %>
+              <td><%= channel.options.outbound.options.user %>
+            <% if channel.options.outbound.options.shared_mailbox: %>
+            <tr>
+              <td><%- @T('Shared Mailbox') %>
+              <td><%= channel.options.outbound.options.shared_mailbox %>
+            <% end %>
+            <% end %>
+          <% end %>
+            <tr>
+              <td><%- @T('Protocol') %>
+              <td><%= channel.options.outbound.adapter %>
+          </table>
+
+          <% if channel.status_out is 'error': %>
+            <div class="alert alert--danger"><%= channel.last_log_out %></div>
+          <% end %>
+        </div>
+        <div class="action-block action-block--flex">
+          <h3><%- @T('Email Address') %></h3>
+          <ul class="list">
+            <li class="list-item"><%= @config?.notification_sender || '-' %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+<% if _.isEmpty(@notification_channels) && !App.Config.get('system_online_service'): %>
+  <p><%- @T('No notification channel configured yet.') %></p>
+<% end %>

--- a/app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco
+++ b/app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco
@@ -1,54 +1,59 @@
-<% if !_.isEmpty(@notification_channels) && !App.Config.get('system_online_service'): %>
+<% if !App.Config.get('system_online_service'): %>
   <h2><%- @T('Email Notification') %></h2>
-  <% for channel in @notification_channels: %>
-    <div class="action" data-id="<%- channel.id %>">
-      <div class="action-flow action-flow--row">
-        <div class="action-block action-block--flex">
-          <div class="horizontal">
-            <h3><%- @Icon('status', channel.status_out + " inline") %> <%- @T('Outbound') %></h3>
-            <div class="btn btn--text js-editNotificationOutbound space-left"><%- @T('Edit') %></div>
+  <% if !_.isEmpty(@notification_channels): %>
+    <% for channel in @notification_channels: %>
+      <div class="action" data-id="<%- channel.id %>">
+        <div class="action-flow action-flow--row">
+          <div class="action-block action-block--flex">
+            <div class="horizontal">
+              <h3><%- @Icon('status', channel.status_out + " inline") %> <%- @T('Outbound') %></h3>
+              <div class="btn btn--text js-editNotificationOutbound space-left"><%- @T('Edit') %></div>
+            </div>
+
+            <table class="key-value">
+            <% if channel.options.outbound && channel.options.outbound.options: %>
+              <% if channel.options.outbound.adapter is 'microsoft_graph_outbound': %>
+              <tr>
+                <td><%- @T('User') %>
+                <td><%= channel.options.outbound.options.user %>
+              <% if channel.options.outbound.options.shared_mailbox: %>
+              <tr>
+                <td><%- @T('Shared Mailbox') %>
+                <td><%= channel.options.outbound.options.shared_mailbox %>
+              <% end %>
+              <% else: %>
+              <% if channel.options.outbound.options.user: %>
+              <tr>
+                <td><%- @T('User') %>
+                <td><%= channel.options.outbound.options.user %>
+              <% end %>
+              <% if channel.options.outbound.options.host: %>
+              <tr>
+                <td><%- @T('Host') %>
+                <td><%= channel.options.outbound.options.host %>
+              <% end %>
+              <% end %>
+            <% end %>
+              <tr>
+                <td><%- @T('Protocol') %>
+                <td><% if channel.options.outbound.adapter is 'microsoft_graph_outbound': %><%- @T('Microsoft Graph API') %><% else: %><%= channel.options.outbound.adapter %><% end %>
+            </table>
+
+            <% if channel.status_in is 'error': %>
+              <div class="alert alert--danger"><%= channel.last_log_in %></div>
+            <% end %>
+            <% if channel.status_out is 'error': %>
+              <div class="alert alert--danger"><%= channel.last_log_out %></div>
+            <% end %>
           </div>
-
-          <table class="key-value">
-          <% if channel.options.outbound && channel.options.outbound.options: %>
-            <% if channel.options.outbound.options.host: %>
-            <tr>
-              <td><%- @T('User') %>
-              <td><%= channel.options.outbound.options.user %>
-            <tr>
-              <td><%- @T('Host') %>
-              <td><%= channel.options.outbound.options.host %>
-            <% end %>
-            <% if channel.options.outbound.adapter is 'microsoft_graph_outbound': %>
-            <tr>
-              <td><%- @T('User') %>
-              <td><%= channel.options.outbound.options.user %>
-            <% if channel.options.outbound.options.shared_mailbox: %>
-            <tr>
-              <td><%- @T('Shared Mailbox') %>
-              <td><%= channel.options.outbound.options.shared_mailbox %>
-            <% end %>
-            <% end %>
-          <% end %>
-            <tr>
-              <td><%- @T('Protocol') %>
-              <td><%= channel.options.outbound.adapter %>
-          </table>
-
-          <% if channel.status_out is 'error': %>
-            <div class="alert alert--danger"><%= channel.last_log_out %></div>
-          <% end %>
-        </div>
-        <div class="action-block action-block--flex">
-          <h3><%- @T('Email Address') %></h3>
-          <ul class="list">
-            <li class="list-item"><%= @config?.notification_sender || '-' %>
-          </ul>
+          <div class="action-block action-block--flex">
+            <h3><%- @T('Email Address') %></h3>
+            <ul class="list">
+              <li class="list-item"><%= @config?.notification_sender || '-' %>
+            </ul>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
-<% end %>
-<% if _.isEmpty(@notification_channels) && !App.Config.get('system_online_service'): %>
-  <p><%- @T('No notification channel configured yet.') %></p>
 <% end %>

--- a/app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco
+++ b/app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco
@@ -47,6 +47,9 @@
         <div class="alert alert--warning js-sslVerifyAlert hide" role="alert">
           <%- @T('Turning off SSL verification is a security risk and should be used only temporary. Use this option at your own risk!') %>
         </div>
+        <div class="alert alert--warning js-msgraphNotificationWarning hide" role="alert">
+          <%- @T('Microsoft recommends using High Volume Email (HVE) or Azure Communication Services (ACS) for system notifications. Using Microsoft Graph API for this purpose may be subject to rate limiting.') %>
+        </div>
         <div class="base-outbound-type"></div>
         <div class="base-outbound-settings"></div>
       </div>

--- a/app/assets/javascripts/app/views/channel_account/list.jst.eco
+++ b/app/assets/javascripts/app/views/channel_account/list.jst.eco
@@ -130,3 +130,5 @@
 <% end %>
   <a class="btn btn--success js-new"><%- @T('Add Account') %></a>
 </div>
+
+<div class="js-notificationSection"></div>

--- a/app/controllers/channels_email_controller.rb
+++ b/app/controllers/channels_email_controller.rb
@@ -210,6 +210,18 @@ class ChannelsEmailController < ApplicationController
 
     adapter = params[:adapter].downcase
 
+    # Microsoft Graph uses OAuth — return a redirect URL instead of probing SMTP.
+    if adapter == 'microsoft_graph_outbound'
+      query = { notification: true }
+      shared_mailbox = params.dig(:options, :shared_mailbox).presence || params[:shared_mailbox].presence
+      query[:shared_mailbox] = shared_mailbox if shared_mailbox.present?
+
+      oauth_url = "#{Setting.get('http_type')}://#{Setting.get('fqdn')}#{Rails.configuration.api_path}/external_credentials/microsoft_graph/link_account?#{query.to_query}"
+
+      render json: { result: 'redirect', url: oauth_url }
+      return
+    end
+
     email = Setting.get('notification_sender')
 
     channel = Channel

--- a/app/controllers/external_credentials_controller.rb
+++ b/app/controllers/external_credentials_controller.rb
@@ -108,7 +108,11 @@ class ExternalCredentialsController < ApplicationController
         microsoft_graph_auth: auth_data,
       ).execute
 
-    redirect_to "#{Setting.get('http_type')}://#{Setting.get('fqdn')}/#channels/email", allow_other_host: true
+    redirect_to channels_email_url, allow_other_host: true
+  end
+
+  def channels_email_url
+    "#{Setting.get('http_type')}://#{Setting.get('fqdn')}/#channels/email"
   end
 
   def link_params

--- a/app/controllers/external_credentials_controller.rb
+++ b/app/controllers/external_credentials_controller.rb
@@ -39,11 +39,17 @@ class ExternalCredentialsController < ApplicationController
     session[:code_verifier] = attributes[:code_verifier]
     session[:channel_id] = params[:channel_id]
     session[:shared_mailbox] = params[:shared_mailbox]
+    session[:notification] = params[:notification] == 'true' || params[:notification] == true
     redirect_to attributes[:authorize_url], allow_other_host: true
   end
 
   def callback
     provider = params[:provider].downcase
+
+    if session[:notification] && provider == 'microsoft_graph'
+      return handle_notification_callback
+    end
+
     channel = ExternalCredential.link_account(provider, session[:request_token], link_params)
     return redirect_to(channel), allow_other_host: true if channel.instance_of?(String)
 
@@ -53,9 +59,57 @@ class ExternalCredentialsController < ApplicationController
     session[:code_verifier]  = nil
     session[:channel_id]     = nil
     session[:shared_mailbox] = nil
+    session[:notification]   = nil
   end
 
   private
+
+  def handle_notification_callback
+    request_token  = session[:request_token]
+    shared_mailbox = session[:shared_mailbox]
+
+    # Clear session
+    session[:request_token]  = nil
+    session[:channel_id]     = nil
+    session[:shared_mailbox] = nil
+    session[:notification]   = nil
+
+    # Validate state
+    raise Exceptions::UnprocessableEntity, __('Invalid OAuth state parameter.') if params[:state] != request_token
+
+    external_credential = ExternalCredential.find_by(name: 'microsoft_graph')
+    raise Exceptions::UnprocessableEntity, __('No Microsoft Graph app configured!') if !external_credential
+    raise Exceptions::UnprocessableEntity, __("The required parameter 'code' is missing.") if params[:code].blank?
+
+    # Exchange code for tokens
+    response = ExternalCredential::MicrosoftGraph.authorize_tokens(external_credential.credentials, params[:code])
+    %w[refresh_token access_token expires_in scope token_type id_token].each do |key|
+      raise Exceptions::UnprocessableEntity, "No #{key} for authorization request found!" if response[key.to_sym].blank?
+    end
+
+    user_data = ExternalCredential::MicrosoftGraph.user_info(response[:id_token])
+    raise Exceptions::UnprocessableEntity, __("The user's 'preferred_username' could not be extracted from 'id_token'.") if user_data[:preferred_username].blank?
+
+    auth_data = response.merge(
+      provider:      'microsoft_graph',
+      type:          'XOAUTH2',
+      client_id:     external_credential.credentials[:client_id],
+      client_secret: external_credential.credentials[:client_secret],
+      client_tenant: external_credential.credentials[:client_tenant],
+    )
+
+    Service::System::SetEmailNotificationConfiguration
+      .new(
+        adapter:              'microsoft_graph_outbound',
+        new_configuration:    {
+          user:           user_data[:preferred_username],
+          shared_mailbox: shared_mailbox.presence,
+        },
+        microsoft_graph_auth: auth_data,
+      ).execute
+
+    redirect_to "#{Setting.get('http_type')}://#{Setting.get('fqdn')}/#channels/email", allow_other_host: true
+  end
 
   def link_params
     params.permit!.to_h.merge(channel_id: session[:channel_id], shared_mailbox: session[:shared_mailbox], code_verifier: session[:code_verifier])

--- a/app/controllers/external_credentials_controller.rb
+++ b/app/controllers/external_credentials_controller.rb
@@ -39,7 +39,7 @@ class ExternalCredentialsController < ApplicationController
     session[:code_verifier] = attributes[:code_verifier]
     session[:channel_id] = params[:channel_id]
     session[:shared_mailbox] = params[:shared_mailbox]
-    session[:notification] = params[:notification] == 'true' || params[:notification] == true
+    session[:notification] = [true, 'true'].include?(params[:notification])
     redirect_to attributes[:authorize_url], allow_other_host: true
   end
 
@@ -67,48 +67,53 @@ class ExternalCredentialsController < ApplicationController
   def handle_notification_callback
     request_token  = session[:request_token]
     shared_mailbox = session[:shared_mailbox]
+    clear_notification_session
 
-    # Clear session
-    session[:request_token]  = nil
-    session[:channel_id]     = nil
-    session[:shared_mailbox] = nil
-    session[:notification]   = nil
-
-    # Validate state
     raise Exceptions::UnprocessableEntity, __('Invalid OAuth state parameter.') if params[:state] != request_token
 
     external_credential = ExternalCredential.find_by(name: 'microsoft_graph')
     raise Exceptions::UnprocessableEntity, __('No Microsoft Graph app configured!') if !external_credential
     raise Exceptions::UnprocessableEntity, __("The required parameter 'code' is missing.") if params[:code].blank?
 
-    # Exchange code for tokens
+    auth_data          = fetch_graph_auth_data(external_credential)
+    preferred_username = extract_preferred_username(auth_data[:id_token])
+
+    Service::System::SetEmailNotificationConfiguration.execute(
+      adapter:              'microsoft_graph_outbound',
+      new_configuration:    { user: preferred_username, shared_mailbox: shared_mailbox.presence },
+      microsoft_graph_auth: auth_data,
+    )
+
+    redirect_to channels_email_url, allow_other_host: true
+  end
+
+  def clear_notification_session
+    session[:request_token]  = nil
+    session[:channel_id]     = nil
+    session[:shared_mailbox] = nil
+    session[:notification]   = nil
+  end
+
+  def fetch_graph_auth_data(external_credential)
     response = ExternalCredential::MicrosoftGraph.authorize_tokens(external_credential.credentials, params[:code])
     %w[refresh_token access_token expires_in scope token_type id_token].each do |key|
       raise Exceptions::UnprocessableEntity, "No #{key} for authorization request found!" if response[key.to_sym].blank?
     end
 
-    user_data = ExternalCredential::MicrosoftGraph.user_info(response[:id_token])
-    raise Exceptions::UnprocessableEntity, __("The user's 'preferred_username' could not be extracted from 'id_token'.") if user_data[:preferred_username].blank?
-
-    auth_data = response.merge(
+    response.merge(
       provider:      'microsoft_graph',
       type:          'XOAUTH2',
       client_id:     external_credential.credentials[:client_id],
       client_secret: external_credential.credentials[:client_secret],
       client_tenant: external_credential.credentials[:client_tenant],
     )
+  end
 
-    Service::System::SetEmailNotificationConfiguration
-      .new(
-        adapter:              'microsoft_graph_outbound',
-        new_configuration:    {
-          user:           user_data[:preferred_username],
-          shared_mailbox: shared_mailbox.presence,
-        },
-        microsoft_graph_auth: auth_data,
-      ).execute
+  def extract_preferred_username(id_token)
+    user_data = ExternalCredential::MicrosoftGraph.user_info(id_token)
+    raise Exceptions::UnprocessableEntity, __("The user's 'preferred_username' could not be extracted from 'id_token'.") if user_data[:preferred_username].blank?
 
-    redirect_to channels_email_url, allow_other_host: true
+    user_data[:preferred_username]
   end
 
   def channels_email_url

--- a/app/controllers/external_credentials_controller.rb
+++ b/app/controllers/external_credentials_controller.rb
@@ -67,7 +67,6 @@ class ExternalCredentialsController < ApplicationController
   def handle_notification_callback
     request_token  = session[:request_token]
     shared_mailbox = session[:shared_mailbox]
-    clear_notification_session
 
     raise Exceptions::UnprocessableEntity, __('Invalid OAuth state parameter.') if params[:state] != request_token
 
@@ -85,13 +84,6 @@ class ExternalCredentialsController < ApplicationController
     )
 
     redirect_to channels_email_url, allow_other_host: true
-  end
-
-  def clear_notification_session
-    session[:request_token]  = nil
-    session[:channel_id]     = nil
-    session[:shared_mailbox] = nil
-    session[:notification]   = nil
   end
 
   def fetch_graph_auth_data(external_credential)

--- a/app/controllers/external_credentials_controller.rb
+++ b/app/controllers/external_credentials_controller.rb
@@ -68,11 +68,11 @@ class ExternalCredentialsController < ApplicationController
     request_token  = session[:request_token]
     shared_mailbox = session[:shared_mailbox]
 
-    raise Exceptions::UnprocessableEntity, __('Invalid OAuth state parameter.') if params[:state] != request_token
+    raise Exceptions::UnprocessableContent, __('Invalid OAuth state parameter.') if params[:state] != request_token
 
     external_credential = ExternalCredential.find_by(name: 'microsoft_graph')
-    raise Exceptions::UnprocessableEntity, __('No Microsoft Graph app configured!') if !external_credential
-    raise Exceptions::UnprocessableEntity, __("The required parameter 'code' is missing.") if params[:code].blank?
+    raise Exceptions::UnprocessableContent, __('No Microsoft Graph app configured!') if !external_credential
+    raise Exceptions::UnprocessableContent, __("The required parameter 'code' is missing.") if params[:code].blank?
 
     auth_data          = fetch_graph_auth_data(external_credential)
     preferred_username = extract_preferred_username(auth_data[:id_token])
@@ -89,7 +89,7 @@ class ExternalCredentialsController < ApplicationController
   def fetch_graph_auth_data(external_credential)
     response = ExternalCredential::MicrosoftGraph.authorize_tokens(external_credential.credentials, params[:code])
     %w[refresh_token access_token expires_in scope token_type id_token].each do |key|
-      raise Exceptions::UnprocessableEntity, "No #{key} for authorization request found!" if response[key.to_sym].blank?
+      raise Exceptions::UnprocessableContent, "No #{key} for authorization request found!" if response[key.to_sym].blank?
     end
 
     response.merge(
@@ -103,7 +103,7 @@ class ExternalCredentialsController < ApplicationController
 
   def extract_preferred_username(id_token)
     user_data = ExternalCredential::MicrosoftGraph.user_info(id_token)
-    raise Exceptions::UnprocessableEntity, __("The user's 'preferred_username' could not be extracted from 'id_token'.") if user_data[:preferred_username].blank?
+    raise Exceptions::UnprocessableContent, __("The user's 'preferred_username' could not be extracted from 'id_token'.") if user_data[:preferred_username].blank?
 
     user_data[:preferred_username]
   end

--- a/app/controllers/external_credentials_controller.rb
+++ b/app/controllers/external_credentials_controller.rb
@@ -40,6 +40,7 @@ class ExternalCredentialsController < ApplicationController
     session[:channel_id] = params[:channel_id]
     session[:shared_mailbox] = params[:shared_mailbox]
     session[:notification] = [true, 'true'].include?(params[:notification])
+    request.session_options.delete(:skip)
     redirect_to attributes[:authorize_url], allow_other_host: true
   end
 

--- a/app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue
+++ b/app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue
@@ -2,10 +2,11 @@
 
 <script setup lang="ts">
 import { cloneDeep } from 'lodash-es'
-import { toRef } from 'vue'
+import { computed, toRef } from 'vue'
 
 import useValue from '#shared/components/Form/composables/useValue.ts'
 import type { FormFieldContext } from '#shared/components/Form/types/field.ts'
+import { useApplicationStore } from '#shared/stores/application.ts'
 
 import CommonSimpleTable from '#desktop/components/CommonTable/CommonSimpleTable.vue'
 import type { TableSimpleHeader } from '#desktop/components/CommonTable/types.ts'
@@ -24,7 +25,9 @@ const context = toRef(props, 'context')
 
 const { localValue } = useValue(context)
 
-const tableHeaders: TableSimpleHeader[] = [
+const { config } = useApplicationStore()
+
+const allTableHeaders: TableSimpleHeader[] = [
   {
     key: 'name',
     label: __('Name'),
@@ -66,6 +69,15 @@ const tableHeaders: TableSimpleHeader[] = [
     headerClass: 'w-20',
   },
 ]
+
+const tableHeaders = computed(() => {
+  if (config.system_online_service) {
+    return allTableHeaders.filter(
+      (h) => h.key !== NotificationMatrixColumnKey.AlsoNotifyViaEmail,
+    )
+  }
+  return allTableHeaders
+})
 
 const tableItems = [
   {

--- a/app/frontend/apps/desktop/entities/channel-email/types/email-inbound-outbound.ts
+++ b/app/frontend/apps/desktop/entities/channel-email/types/email-inbound-outbound.ts
@@ -28,7 +28,14 @@ export interface EmailOutboundSmtpFormData extends Required<EmailBaseOutboundDat
   adapter: EnumChannelEmailOutboundAdapter.Smtp
 }
 
-export type EmailOutboundData = EmailOutboundSendmailFormData | EmailOutboundSmtpFormData
+export interface EmailOutboundMicrosoftGraphFormData extends EmailBaseOutboundData {
+  adapter: EnumChannelEmailOutboundAdapter.MicrosoftGraphOutbound
+}
+
+export type EmailOutboundData =
+  | EmailOutboundSendmailFormData
+  | EmailOutboundSmtpFormData
+  | EmailOutboundMicrosoftGraphFormData
 
 export interface EmailInboundMessagesData {
   archive?: boolean

--- a/app/frontend/shared/graphql/schema-types.ts
+++ b/app/frontend/shared/graphql/schema-types.ts
@@ -869,6 +869,7 @@ export enum EnumChannelEmailInboundAdapter {
 
 /** Outbound email protocols/adapters */
 export enum EnumChannelEmailOutboundAdapter {
+  MicrosoftGraphOutbound = 'microsoft_graph_outbound',
   Sendmail = 'sendmail',
   Smtp = 'smtp'
 }

--- a/app/graphql/gql/mutations/channel/email/set_notification_configuration.rb
+++ b/app/graphql/gql/mutations/channel/email/set_notification_configuration.rb
@@ -2,7 +2,7 @@
 
 module Gql::Mutations
   class Channel::Email::SetNotificationConfiguration < Channel::Email::BaseConfiguration
-    description 'Set confioguration for sending system notification emails'
+    description 'Set configuration for sending system notification emails'
 
     argument :outbound_configuration, Gql::Types::Input::Channel::Email::OutboundConfigurationInputType, description: 'Configuration to validate'
 

--- a/app/graphql/gql/types/enum/channel/email/outbound_adapter_type.rb
+++ b/app/graphql/gql/types/enum/channel/email/outbound_adapter_type.rb
@@ -6,5 +6,6 @@ module Gql::Types::Enum
 
     value 'smtp'
     value 'sendmail'
+    value 'microsoft_graph_outbound'
   end
 end

--- a/app/graphql/graphql_introspection.json
+++ b/app/graphql/graphql_introspection.json
@@ -5291,6 +5291,12 @@
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "microsoft_graph_outbound",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "possibleTypes": null
@@ -10201,7 +10207,7 @@
             },
             {
               "name": "channelEmailSetNotificationConfiguration",
-              "description": "Set confioguration for sending system notification emails",
+              "description": "Set configuration for sending system notification emails",
               "args": [
                 {
                   "name": "outboundConfiguration",
@@ -10214,6 +10220,16 @@
                       "name": "ChannelEmailOutboundConfigurationInput",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "microsoftGraphChannelId",
+                  "description": "ID of a MicrosoftGraph::Account channel (required when adapter is microsoft_graph_outbound)",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }

--- a/app/graphql/graphql_introspection.json
+++ b/app/graphql/graphql_introspection.json
@@ -10222,16 +10222,6 @@
                     }
                   },
                   "defaultValue": null
-                },
-                {
-                  "name": "microsoftGraphChannelId",
-                  "description": "ID of a MicrosoftGraph::Account channel (required when adapter is microsoft_graph_outbound)",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  },
-                  "defaultValue": null
                 }
               ],
               "type": {

--- a/app/services/service/system/set_email_notification_configuration.rb
+++ b/app/services/service/system/set_email_notification_configuration.rb
@@ -40,16 +40,16 @@ class Service::System::SetEmailNotificationConfiguration < Service::Base
     channel.active = is_matching_adapter
 
     if is_matching_adapter
-      if @adapter == 'microsoft_graph_outbound'
-        channel.options = build_microsoft_graph_options
-      else
-        channel.options = {
-          outbound: {
-            adapter: @adapter,
-            options: @new_configuration,
-          },
-        }
-      end
+      channel.options = if @adapter == 'microsoft_graph_outbound'
+                          build_microsoft_graph_options
+                        else
+                          {
+                            outbound: {
+                              adapter: @adapter,
+                              options: @new_configuration,
+                            },
+                          }
+                        end
 
       channel.status_out   = 'ok'
       channel.last_log_out = nil

--- a/app/services/service/system/set_email_notification_configuration.rb
+++ b/app/services/service/system/set_email_notification_configuration.rb
@@ -3,7 +3,7 @@
 class Service::System::SetEmailNotificationConfiguration < Service::Base
   # Setup Email Notification channel configuration
   #
-  # @param [String] adapter sendmail or smtp
+  # @param [String] adapter sendmail, smtp, or microsoft_graph_outbound
   # @param [Hash] new_configuration email server configuration, empty unless adapter is smtp
   # @option new_configuration [String] :host SMTP server address
   # @option new_configuration [String] :port SMTP server port
@@ -11,7 +11,8 @@ class Service::System::SetEmailNotificationConfiguration < Service::Base
   # @option new_configuration [String] :user login of SMTP server
   # @option new_configuration [String] :password of SMTP server
   # @option new_configuration [Boolean] :ssl_verify Wether SSL verification is performed
-  def initialize(adapter:, new_configuration:)
+  # @param [Hash] microsoft_graph_auth OAuth auth data (required when adapter is microsoft_graph_outbound)
+  def initialize(adapter:, new_configuration:, microsoft_graph_auth: nil)
     @adapter = adapter
     @new_configuration = new_configuration
     @microsoft_graph_auth = microsoft_graph_auth
@@ -55,7 +56,8 @@ class Service::System::SetEmailNotificationConfiguration < Service::Base
 
   def build_microsoft_graph_options
     outbound_options = {
-      user: @new_configuration[:user] || @new_configuration['user'],
+      user:     @new_configuration[:user] || @new_configuration['user'],
+      password: @microsoft_graph_auth&.dig(:access_token) || @microsoft_graph_auth&.dig('access_token'),
     }
 
     shared_mailbox = @new_configuration[:shared_mailbox].presence || @new_configuration['shared_mailbox'].presence

--- a/app/services/service/system/set_email_notification_configuration.rb
+++ b/app/services/service/system/set_email_notification_configuration.rb
@@ -14,14 +14,10 @@ class Service::System::SetEmailNotificationConfiguration < Service::Base
   def initialize(adapter:, new_configuration:)
     @adapter = adapter
     @new_configuration = new_configuration
+    @microsoft_graph_auth = microsoft_graph_auth
   end
 
   def execute
-    # There're two instances of Email::Notification for historical easons
-    # One for SMTP and one for Sendmail.
-    # However, this feature is not used anywhere.
-    # At some point it may be good to clean this up to simply use a single instance
-    # and set adapter as needed.
     ActiveRecord::Base.transaction do
       Channel
         .where(area: 'Email::Notification')
@@ -39,17 +35,38 @@ class Service::System::SetEmailNotificationConfiguration < Service::Base
     channel.active = is_matching_adapter
 
     if is_matching_adapter
-      channel.options = {
-        outbound: {
-          adapter: @adapter,
-          options: @new_configuration,
-        },
-      }
+      if @adapter == 'microsoft_graph_outbound'
+        channel.options = build_microsoft_graph_options
+      else
+        channel.options = {
+          outbound: {
+            adapter: @adapter,
+            options: @new_configuration,
+          },
+        }
+      end
 
       channel.status_out   = 'ok'
       channel.last_log_out = nil
     end
 
     channel.save!
+  end
+
+  def build_microsoft_graph_options
+    outbound_options = {
+      user: @new_configuration[:user] || @new_configuration['user'],
+    }
+
+    shared_mailbox = @new_configuration[:shared_mailbox].presence || @new_configuration['shared_mailbox'].presence
+    outbound_options[:shared_mailbox] = shared_mailbox if shared_mailbox
+
+    {
+      outbound: {
+        adapter: 'microsoft_graph_outbound',
+        options: outbound_options.compact_blank,
+      },
+      auth:     @microsoft_graph_auth,
+    }
   end
 end

--- a/app/services/service/system/set_email_notification_configuration.rb
+++ b/app/services/service/system/set_email_notification_configuration.rb
@@ -19,6 +19,10 @@ class Service::System::SetEmailNotificationConfiguration < Service::Base
   end
 
   def execute
+    if @adapter == 'microsoft_graph_outbound' && @microsoft_graph_auth.blank?
+      raise ArgumentError, __('Microsoft Graph auth data is required for the microsoft_graph_outbound adapter.')
+    end
+
     ActiveRecord::Base.transaction do
       Channel
         .where(area: 'Email::Notification')

--- a/db/migrate/20260428000001_add_microsoft_graph_notification_channel.rb
+++ b/db/migrate/20260428000001_add_microsoft_graph_notification_channel.rb
@@ -1,0 +1,29 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class AddMicrosoftGraphNotificationChannel < ActiveRecord::Migration[8.0]
+  def up
+    # return if it's a new setup
+    return if !Setting.exists?(name: 'system_init_done')
+
+    # Don't create if it already exists (e.g. from seeds on a fresh install).
+    already_exists = Channel.where(area: 'Email::Notification').any? do |channel|
+      adapter = channel.options.dig(:outbound, :adapter) || channel.options.dig('outbound', 'adapter')
+      adapter == 'microsoft_graph_outbound'
+    end
+    return if already_exists
+
+    Channel.create!(
+      area:          'Email::Notification',
+      options:       {
+        outbound: {
+          adapter: 'microsoft_graph_outbound',
+          options: {},
+        },
+      },
+      preferences:   { online_service_disable: true },
+      active:        false,
+      created_by_id: 1,
+      updated_by_id: 1,
+    )
+  end
+end

--- a/db/seeds/channels.rb
+++ b/db/seeds/channels.rb
@@ -26,3 +26,14 @@ Channel.create_if_not_exists(
   preferences: { online_service_disable: true },
   active:      true,
 )
+Channel.create_if_not_exists(
+  area:        'Email::Notification',
+  options:     {
+    outbound: {
+      adapter: 'microsoft_graph_outbound',
+      options: {},
+    },
+  },
+  preferences: { online_service_disable: true },
+  active:      false,
+)

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -3944,7 +3944,7 @@ msgstr ""
 msgid "Context menu"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:151
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:156
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:77
 #: app/assets/javascripts/app/views/channel/email_account_wizard.jst.eco:99
 #: app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco:56
@@ -8535,8 +8535,8 @@ msgstr ""
 msgid "Honeypot spam protection"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:138
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:416
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:143
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:400
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:331
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:80
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:69
@@ -9230,7 +9230,6 @@ msgid "Invalid GitLab issue link format"
 msgstr ""
 
 #: app/controllers/external_credentials_controller.rb:73
-#: config/initializers/microsoft_graph_notification.rb:157
 #: lib/external_credential/exchange.rb:43
 #: lib/external_credential/facebook.rb:42
 #: lib/external_credential/google.rb:39
@@ -10803,6 +10802,10 @@ msgstr ""
 msgid "Microsoft Graph API"
 msgstr ""
 
+#: app/services/service/system/set_email_notification_configuration.rb:23
+msgid "Microsoft Graph auth data is required for the microsoft_graph_outbound adapter."
+msgstr ""
+
 #: app/models/webhook/pre_defined/microsoft_teams.rb:5
 msgid "Microsoft Teams Notifications"
 msgstr ""
@@ -11529,7 +11532,6 @@ msgid "No Microsoft 365 app configured!"
 msgstr ""
 
 #: app/controllers/external_credentials_controller.rb:76
-#: config/initializers/microsoft_graph_notification.rb:160
 #: lib/external_credential/microsoft_graph.rb:9
 msgid "No Microsoft Graph app configured!"
 msgstr ""
@@ -12810,7 +12812,7 @@ msgstr ""
 msgid "Parent group"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:140
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:145
 #: app/assets/javascripts/app/controllers/_channel/email.coffee:365
 #: app/assets/javascripts/app/controllers/_manage/security.coffee:10
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:82
@@ -13127,7 +13129,7 @@ msgstr ""
 msgid "Please enable execution_time feature to use it (currently only allowed for triggers and schedulers)"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:207
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:212
 msgid "Please enter a shared mailbox address."
 msgstr ""
 
@@ -13257,7 +13259,7 @@ msgstr ""
 msgid "Please wait…"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:141
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:146
 #: app/assets/javascripts/app/controllers/_channel/email.coffee:405
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:85
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:72
@@ -14485,7 +14487,7 @@ msgstr ""
 msgid "SSL Certificates"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:142
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:147
 #: app/assets/javascripts/app/controllers/_channel/email.coffee:404
 #: app/assets/javascripts/app/controllers/_ui_element/object_manager_attribute.coffee:707
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:84
@@ -15212,7 +15214,7 @@ msgstr ""
 msgid "Send Email"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:121
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:126
 #: app/assets/javascripts/app/controllers/_channel/email.coffee:381
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:65
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:50
@@ -17620,7 +17622,6 @@ msgid "The required parameter 'client_secret' is missing."
 msgstr ""
 
 #: app/controllers/external_credentials_controller.rb:77
-#: config/initializers/microsoft_graph_notification.rb:161
 #: lib/external_credential/exchange.rb:47
 #: lib/external_credential/google.rb:43
 #: lib/external_credential/microsoft_base.rb:80
@@ -17942,7 +17943,6 @@ msgid "The user token could not be generated."
 msgstr ""
 
 #: app/controllers/external_credentials_controller.rb:85
-#: config/initializers/microsoft_graph_notification.rb:169
 #: lib/external_credential/exchange.rb:55
 #: lib/external_credential/microsoft_base.rb:88
 msgid "The user's 'preferred_username' could not be extracted from 'id_token'."
@@ -20130,7 +20130,7 @@ msgstr ""
 msgid "Used when viewing a Ticket"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:139
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:144
 #: app/assets/javascripts/app/controllers/_channel/email.coffee:401
 #: app/assets/javascripts/app/controllers/_manage/ticket_duplicate_detection.coffee:37
 #: app/assets/javascripts/app/controllers/_ui_element/_application_action.coffee:173

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -231,7 +231,7 @@ msgstr ""
 msgid "%s deselected."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:695
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:679
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:260
 #: app/assets/javascripts/app/views/channel/email_archive.jst.eco:7
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:27
@@ -957,9 +957,9 @@ msgstr ""
 msgid "Account Time"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:610
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:594
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:197
-#: app/controllers/channels_email_controller.rb:238
+#: app/controllers/channels_email_controller.rb:249
 msgid "Account already exists!"
 msgstr ""
 
@@ -1922,14 +1922,14 @@ msgstr ""
 msgid "Archive Emails"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:724
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:708
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:43
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:289
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:57
 msgid "Archive cut-off time"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:723
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:707
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:42
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:288
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailChannelConfiguration.ts:65
@@ -1937,7 +1937,7 @@ msgstr ""
 msgid "Archive emails"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:725
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:709
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:44
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:290
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:66
@@ -3944,6 +3944,8 @@ msgstr ""
 msgid "Context menu"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:151
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:77
 #: app/assets/javascripts/app/views/channel/email_account_wizard.jst.eco:99
 #: app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco:56
 #: app/assets/javascripts/app/views/getting_started/agent.jst.eco:8
@@ -6255,6 +6257,7 @@ msgstr ""
 #: app/assets/javascripts/app/controllers/user_profile/action_row.coffee:77
 #: app/assets/javascripts/app/views/calendar/index.jst.eco:85
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:62
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:10
 #: app/assets/javascripts/app/views/channel/sms_account_overview.jst.eco:68
 #: app/assets/javascripts/app/views/channel_account/list.jst.eco:51
 #: app/assets/javascripts/app/views/facebook/list.jst.eco:35
@@ -6474,7 +6477,7 @@ msgstr ""
 msgid "Email Inbound"
 msgstr ""
 
-#: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:162
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:2
 #: app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco:8
 #: app/assets/javascripts/app/views/getting_started/email_notification.jst.eco:6
 msgid "Email Notification"
@@ -6528,7 +6531,7 @@ msgstr ""
 msgid "Email outbound"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:891
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:875
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:405
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailChannelConfiguration.ts:152
 msgid "Email sending and receiving could not be verified. Please check your settings."
@@ -6553,7 +6556,7 @@ msgstr ""
 msgid "Email verification"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:724
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:708
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:43
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:289
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:60
@@ -8532,12 +8535,14 @@ msgstr ""
 msgid "Honeypot spam protection"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:138
 #: app/assets/javascripts/app/controllers/_channel/email.coffee:416
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:331
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:80
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:69
 #: app/assets/javascripts/app/controllers/knowledge_base/video_servers_manager.coffee:80
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:73
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:20
 #: app/assets/javascripts/app/views/integration/ldap_wizard.jst.eco:29
 #: app/assets/javascripts/app/views/knowledge_base_video_servers/index.jst.eco:11
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:107
@@ -9224,6 +9229,8 @@ msgstr ""
 msgid "Invalid GitLab issue link format"
 msgstr ""
 
+#: app/controllers/external_credentials_controller.rb:73
+#: config/initializers/microsoft_graph_notification.rb:157
 #: lib/external_credential/exchange.rb:43
 #: lib/external_credential/facebook.rb:42
 #: lib/external_credential/google.rb:39
@@ -10774,6 +10781,7 @@ msgstr ""
 
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:4
 #: db/seeds/permissions.rb:161
+#: lib/email_helper.rb:27
 msgid "Microsoft 365 Graph Email"
 msgstr ""
 
@@ -11516,6 +11524,8 @@ msgstr ""
 msgid "No Microsoft 365 app configured!"
 msgstr ""
 
+#: app/controllers/external_credentials_controller.rb:76
+#: config/initializers/microsoft_graph_notification.rb:160
 #: lib/external_credential/microsoft_graph.rb:9
 msgid "No Microsoft Graph app configured!"
 msgstr ""
@@ -11524,7 +11534,7 @@ msgstr ""
 msgid "No Proxy"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:419
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:204
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:43
@@ -12477,7 +12487,7 @@ msgstr ""
 msgid "Organization"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:379
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:363
 msgid "Organization & Department Name"
 msgstr ""
 
@@ -12485,7 +12495,7 @@ msgstr ""
 msgid "Organization Name"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:379
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:363
 #: app/assets/javascripts/app/views/getting_started/email.jst.eco:12
 msgid "Organization Support"
 msgstr ""
@@ -12606,6 +12616,7 @@ msgid "Out of office settings have been saved successfully"
 msgstr ""
 
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:99
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:9
 #: app/assets/javascripts/app/views/channel/sms_account_overview.jst.eco:24
 #: app/assets/javascripts/app/views/channel_account/list.jst.eco:85
 #: app/assets/javascripts/app/views/integration/cti.jst.eco:56
@@ -12795,7 +12806,8 @@ msgstr ""
 msgid "Parent group"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:381
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:140
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:365
 #: app/assets/javascripts/app/controllers/_manage/security.coffee:10
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:82
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:71
@@ -13111,6 +13123,10 @@ msgstr ""
 msgid "Please enable execution_time feature to use it (currently only allowed for triggers and schedulers)"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:207
+msgid "Please enter a shared mailbox address."
+msgstr ""
+
 #: app/assets/javascripts/app/controllers/ticket_zoom/article_new.coffee:383
 msgid "Please enter a text."
 msgstr ""
@@ -13237,7 +13253,8 @@ msgstr ""
 msgid "Please wait…"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:421
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:141
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:405
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:85
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:72
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:159
@@ -13475,6 +13492,7 @@ msgid "Proof Key for Code Exchange is currently only supporting SHA256 as code c
 msgstr ""
 
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:76
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:35
 msgid "Protocol"
 msgstr ""
 
@@ -14451,7 +14469,7 @@ msgstr ""
 msgid "SMTP - configure your own outgoing SMTP settings"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:419
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:208
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:47
@@ -14463,7 +14481,8 @@ msgstr ""
 msgid "SSL Certificates"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:420
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:142
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:404
 #: app/assets/javascripts/app/controllers/_ui_element/object_manager_attribute.coffee:707
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:84
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:73
@@ -14479,7 +14498,7 @@ msgstr ""
 msgid "SSL verification"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:419
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/assets/javascripts/app/views/integration/ldap.jst.eco:27
 #: app/assets/javascripts/app/views/integration/ldap_wizard.jst.eco:33
@@ -14497,7 +14516,7 @@ msgstr ""
 msgid "SSO request from untrusted IP address."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:419
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:206
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:54
@@ -15189,7 +15208,8 @@ msgstr ""
 msgid "Send Email"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:397
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:121
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:381
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:65
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:50
 msgid "Send Mails via"
@@ -16998,7 +17018,7 @@ msgstr ""
 msgid "The certificates for %s were not found."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:309
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:293
 #: app/assets/javascripts/app/controllers/_channel/facebook.coffee:247
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:123
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:128
@@ -17595,6 +17615,8 @@ msgstr ""
 msgid "The required parameter 'client_secret' is missing."
 msgstr ""
 
+#: app/controllers/external_credentials_controller.rb:77
+#: config/initializers/microsoft_graph_notification.rb:161
 #: lib/external_credential/exchange.rb:47
 #: lib/external_credential/google.rb:43
 #: lib/external_credential/microsoft_base.rb:80
@@ -17723,7 +17745,7 @@ msgstr ""
 msgid "The server returned a redirect response, but the current operation does not allow redirects."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:614
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:598
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:200
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailChannelConfiguration.ts:222
 msgid "The server settings could not be automatically detected. Please configure them manually."
@@ -17915,6 +17937,8 @@ msgstr ""
 msgid "The user token could not be generated."
 msgstr ""
 
+#: app/controllers/external_credentials_controller.rb:85
+#: config/initializers/microsoft_graph_notification.rb:169
 #: lib/external_credential/exchange.rb:55
 #: lib/external_credential/microsoft_base.rb:88
 msgid "The user's 'preferred_username' could not be extracted from 'id_token'."
@@ -19562,7 +19586,7 @@ msgstr ""
 msgid "Two-factor method has been configured successfully."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:415
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:399
 #: app/assets/javascripts/app/controllers/_ui_element/object_manager_attribute.coffee:240
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:79
 #: app/assets/javascripts/app/controllers/translation.coffee:288
@@ -20102,7 +20126,8 @@ msgstr ""
 msgid "Used when viewing a Ticket"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:417
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:139
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:401
 #: app/assets/javascripts/app/controllers/_manage/ticket_duplicate_detection.coffee:37
 #: app/assets/javascripts/app/controllers/_ui_element/_application_action.coffee:173
 #: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:24
@@ -20121,6 +20146,7 @@ msgstr ""
 #: app/assets/javascripts/app/models/mention.coffee:6
 #: app/assets/javascripts/app/models/user_overview_sorting.coffee:2
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:67
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:17
 #: app/assets/javascripts/app/views/integration/exchange.jst.eco:46
 #: app/assets/javascripts/app/views/integration/exchange_wizard.jst.eco:38
 #: app/assets/javascripts/app/views/integration/ldap.jst.eco:47

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -9229,7 +9229,7 @@ msgstr ""
 msgid "Invalid GitLab issue link format"
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:73
+#: app/controllers/external_credentials_controller.rb:71
 #: lib/external_credential/exchange.rb:43
 #: lib/external_credential/facebook.rb:42
 #: lib/external_credential/google.rb:39
@@ -11531,7 +11531,7 @@ msgstr ""
 msgid "No Microsoft 365 app configured!"
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:76
+#: app/controllers/external_credentials_controller.rb:74
 #: lib/external_credential/microsoft_graph.rb:9
 msgid "No Microsoft Graph app configured!"
 msgstr ""
@@ -17621,7 +17621,7 @@ msgstr ""
 msgid "The required parameter 'client_secret' is missing."
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:77
+#: app/controllers/external_credentials_controller.rb:75
 #: lib/external_credential/exchange.rb:47
 #: lib/external_credential/google.rb:43
 #: lib/external_credential/microsoft_base.rb:80
@@ -17942,7 +17942,7 @@ msgstr ""
 msgid "The user token could not be generated."
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:85
+#: app/controllers/external_credentials_controller.rb:106
 #: lib/external_credential/exchange.rb:55
 #: lib/external_credential/microsoft_base.rb:88
 msgid "The user's 'preferred_username' could not be extracted from 'id_token'."

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -231,7 +231,7 @@ msgstr ""
 msgid "%s deselected."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:679
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:680
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:260
 #: app/assets/javascripts/app/views/channel/email_archive.jst.eco:7
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:27
@@ -702,7 +702,7 @@ msgstr ""
 msgid "AI Service Name"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_ticket_summary.coffee:132
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_ticket_summary.coffee:145
 msgid "AI Summary"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgstr ""
 msgid "Account Time"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:594
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:595
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:197
 #: app/controllers/channels_email_controller.rb:249
 msgid "Account already exists!"
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Admin"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:318
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:321
 msgid "Admin Consent"
 msgstr ""
 
@@ -1617,7 +1617,7 @@ msgid "All priorities will be considered for prioritizing tickets."
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/_manage/ticket_duplicate_detection.coffee:38
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:56
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:59
 msgid "All tickets"
 msgstr ""
 
@@ -1682,7 +1682,7 @@ msgid "Allow websites (separated by ;)"
 msgstr ""
 
 #: app/assets/javascripts/app/views/generic/notification_matrix.jst.eco:9
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:64
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:67
 msgid "Also notify via email"
 msgstr ""
 
@@ -1922,14 +1922,14 @@ msgstr ""
 msgid "Archive Emails"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:708
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:709
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:43
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:289
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:57
 msgid "Archive cut-off time"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:707
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:708
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:42
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:288
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailChannelConfiguration.ts:65
@@ -1937,7 +1937,7 @@ msgstr ""
 msgid "Archive emails"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:709
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:710
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:44
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:290
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:66
@@ -1981,8 +1981,8 @@ msgid "Are you sure you want to unset \"%s\" as default?"
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/_application_controller/_modal_generic_confirm_delete.coffee:6
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:185
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:141
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:188
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:142
 #: app/assets/javascripts/app/controllers/_channel/facebook.coffee:99
 #: app/assets/javascripts/app/controllers/_channel/telegram.coffee:67
 #: app/assets/javascripts/app/controllers/_channel/whatsapp.coffee:68
@@ -2282,9 +2282,9 @@ msgstr ""
 msgid "August"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:180
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:181
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:172
-#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:75
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:43
 msgid "Authenticate"
 msgstr ""
 
@@ -2945,7 +2945,7 @@ msgstr ""
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarChecklist/TicketSidebarChecklistContent/ChecklistItems.vue:201
 #: app/frontend/apps/mobile/components/CommonDialogObjectForm/CommonDialogObjectForm.vue:109
 #: app/frontend/apps/mobile/components/CommonSectionPopup/CommonSectionPopup.vue:30
-#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:244
+#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:236
 #: app/frontend/apps/mobile/pages/account/views/PersonalSettingAvatar.vue:265
 #: app/frontend/apps/mobile/pages/search/views/SearchOverview.vue:217
 #: app/frontend/apps/mobile/pages/ticket/components/TicketDetailView/ArticleReplyDialog.vue:127
@@ -3177,7 +3177,7 @@ msgstr ""
 msgid "Changes were made that require a database update."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:243
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:244
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:55
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:60
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:68
@@ -3533,7 +3533,7 @@ msgstr ""
 
 #: app/assets/javascripts/app/controllers/_application_controller/_modal_generic_description.coffee:4
 #: app/assets/javascripts/app/controllers/_application_controller/_modal_generic_error_modal.coffee:4
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:317
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:320
 #: app/assets/javascripts/app/controllers/_plugin/maintenance.coffee:32
 #: app/assets/javascripts/app/controllers/_settings/area_proxy.coffee:55
 #: app/assets/javascripts/app/controllers/translation.coffee:184
@@ -3946,10 +3946,10 @@ msgstr ""
 msgid "Context menu"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:156
-#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:77
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:157
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:45
 #: app/assets/javascripts/app/views/channel/email_account_wizard.jst.eco:99
-#: app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco:56
+#: app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco:59
 #: app/assets/javascripts/app/views/getting_started/agent.jst.eco:8
 #: app/assets/javascripts/app/views/getting_started/email.jst.eco:77
 #: app/assets/javascripts/app/views/getting_started/email_notification.jst.eco:18
@@ -5810,7 +5810,7 @@ msgstr ""
 msgid "Desktop BETA UI Switch Roles"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:247
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:248
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:59
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:64
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:72
@@ -5831,7 +5831,7 @@ msgstr ""
 msgid "Destination caller ID or queue"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:248
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:249
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:60
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:65
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:73
@@ -6099,7 +6099,7 @@ msgid "Don't synchronize"
 msgstr ""
 
 #: app/frontend/apps/mobile/components/CommonDialog/CommonDialog.vue:145
-#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:269
+#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:261
 #: app/frontend/apps/mobile/pages/account/views/PersonalSettingAvatar.vue:169
 #: app/frontend/apps/mobile/pages/ticket/components/TicketDetailView/ArticleReplyDialog.vue:139
 msgid "Done"
@@ -6236,7 +6236,7 @@ msgstr ""
 msgid "Duplicate Detection"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:352
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:355
 msgid "Duplicate Email Address"
 msgstr ""
 
@@ -6467,8 +6467,8 @@ msgstr ""
 msgid "Email Accounts"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:282
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:197
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:285
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:198
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:126
 #: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:50
 #: app/assets/javascripts/app/views/channel_account/list.jst.eco:96
@@ -6534,7 +6534,7 @@ msgstr ""
 msgid "Email outbound"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:875
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:876
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:405
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailChannelConfiguration.ts:152
 msgid "Email sending and receiving could not be verified. Please check your settings."
@@ -6559,7 +6559,7 @@ msgstr ""
 msgid "Email verification"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:708
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:709
 #: app/assets/javascripts/app/controllers/_channel/email_archive.coffee:43
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:289
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundMessagesForm.ts:60
@@ -7358,7 +7358,7 @@ msgstr ""
 msgid "Failed to load content."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:264
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:267
 msgid "Failed to roll back the migration of the channel!"
 msgstr ""
 
@@ -7586,7 +7586,7 @@ msgstr ""
 msgid "Focus on %s"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:406
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:407
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:61
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:66
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:273
@@ -8538,8 +8538,8 @@ msgstr ""
 msgid "Honeypot spam protection"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:143
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:400
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:144
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:401
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:331
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:80
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:69
@@ -9504,7 +9504,7 @@ msgstr ""
 msgid "Kayako"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:407
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:408
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:62
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:67
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:274
@@ -10173,9 +10173,9 @@ msgstr ""
 msgid "Macros make it easy to automate common, multi-step tasks within Zammad.\n\nYou can use macros in Zammad to automate recurring sequences, saving time (and nerves). This allows a combined sequence of actions on the ticket to be executed with just one click."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:168
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:169
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:177
-#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:66
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:34
 msgid "Mailbox type"
 msgstr ""
 
@@ -10815,6 +10815,10 @@ msgstr ""
 msgid "Microsoft Teams Notifications"
 msgstr ""
 
+#: app/assets/javascripts/app/views/channel/email_notification_wizard.jst.eco:51
+msgid "Microsoft recommends using High Volume Email (HVE) or Azure Communication Services (ACS) for system notifications. Using Microsoft Graph API for this purpose may be subject to rate limiting."
+msgstr ""
+
 #: app/assets/javascripts/app/views/import/freshdesk.jst.eco:56
 #: app/assets/javascripts/app/views/import/kayako.jst.eco:60
 #: app/assets/javascripts/app/views/import/otrs.jst.eco:41
@@ -11038,7 +11042,7 @@ msgstr ""
 msgid "My handling time: %s minutes"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:35
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:38
 #: app/frontend/apps/desktop/pages/personal-setting/views/PersonalSettingCalendar.vue:61
 msgid "My tickets"
 msgstr ""
@@ -11116,7 +11120,7 @@ msgstr ""
 #: app/assets/javascripts/app/views/widget/organization.jst.eco:9
 #: app/assets/javascripts/app/views/widget/user.jst.eco:5
 #: app/controllers/time_accountings_controller.rb:89
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:30
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:33
 #: app/frontend/apps/desktop/components/TwoFactor/TwoFactorConfiguration/TwoFactorConfigurationSecurityKeys.vue:111
 #: app/frontend/apps/desktop/pages/personal-setting/components/PersonalSettingNewAccessTokenFlyout.vue:28
 #: app/frontend/apps/desktop/pages/personal-setting/views/PersonalSettingDevices.vue:95
@@ -11408,7 +11412,7 @@ msgstr ""
 msgid "New text module"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:74
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:86
 #: app/frontend/apps/desktop/components/layout/LayoutSidebar/LeftSidebar/MenuContainer/AddMenu/plugins/ticket-create.ts:12
 #: app/frontend/apps/desktop/entities/ticket/composables/useTicketCreateTitle.ts:21
 #: app/frontend/apps/desktop/pages/ticket/components/TicketCreate/TicketCreateContent.vue:89
@@ -11545,7 +11549,7 @@ msgstr ""
 msgid "No Proxy"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:404
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:204
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:43
@@ -11736,7 +11740,7 @@ msgstr ""
 #: app/frontend/apps/desktop/components/Form/fields/FieldTreeSelect/FieldTreeSelectInputDropdown.vue:491
 #: app/frontend/apps/desktop/components/NavigationMenu/NavigationMenu.vue:90
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarIdoit/IdoitFlyout/IdoitObjectList.vue:38
-#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:378
+#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:365
 #: app/frontend/apps/mobile/components/Form/fields/FieldEditor/FieldEditorSuggestionList.vue:57
 #: app/frontend/apps/mobile/components/Form/fields/FieldTreeSelect/FieldTreeSelectInputDialog.vue:319
 msgid "No results found"
@@ -11880,7 +11884,7 @@ msgstr ""
 msgid "Not applicable to: merging, emails, form, Facebook, Telegram, SMS"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:42
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:45
 #: app/frontend/apps/desktop/pages/personal-setting/views/PersonalSettingCalendar.vue:73
 msgid "Not assigned"
 msgstr ""
@@ -12047,7 +12051,7 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:130
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:142
 msgid "Notifications matrix"
 msgstr ""
 
@@ -12498,7 +12502,7 @@ msgstr ""
 msgid "Organization"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:363
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:364
 msgid "Organization & Department Name"
 msgstr ""
 
@@ -12506,7 +12510,7 @@ msgstr ""
 msgid "Organization Name"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:363
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:364
 #: app/assets/javascripts/app/views/getting_started/email.jst.eco:12
 msgid "Organization Support"
 msgstr ""
@@ -12817,8 +12821,8 @@ msgstr ""
 msgid "Parent group"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:145
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:365
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:146
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:366
 #: app/assets/javascripts/app/controllers/_manage/security.coffee:10
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:82
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:71
@@ -13134,7 +13138,7 @@ msgstr ""
 msgid "Please enable execution_time feature to use it (currently only allowed for triggers and schedulers)"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:212
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:213
 msgid "Please enter a shared mailbox address."
 msgstr ""
 
@@ -13264,8 +13268,8 @@ msgstr ""
 msgid "Please wait…"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:146
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:405
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:147
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:406
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:85
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:72
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:159
@@ -14361,7 +14365,7 @@ msgstr ""
 msgid "Rollback migration"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:260
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:263
 msgid "Rollback of channel migration succeeded!"
 msgstr ""
 
@@ -14480,7 +14484,7 @@ msgstr ""
 msgid "SMTP - configure your own outgoing SMTP settings"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:404
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:208
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:47
@@ -14492,8 +14496,8 @@ msgstr ""
 msgid "SSL Certificates"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:147
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:404
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:148
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:405
 #: app/assets/javascripts/app/controllers/_ui_element/object_manager_attribute.coffee:707
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:84
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:73
@@ -14509,7 +14513,7 @@ msgstr ""
 msgid "SSL verification"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:404
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/assets/javascripts/app/views/integration/ldap.jst.eco:27
 #: app/assets/javascripts/app/views/integration/ldap_wizard.jst.eco:33
@@ -14523,11 +14527,11 @@ msgstr ""
 msgid "SSO"
 msgstr ""
 
-#: app/controllers/sessions_controller.rb:264
+#: app/controllers/sessions_controller.rb:267
 msgid "SSO request from untrusted IP address."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:403
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:404
 #: app/assets/javascripts/app/controllers/_integration/ldap.coffee:206
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:83
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:54
@@ -14630,7 +14634,7 @@ msgstr ""
 #: app/assets/javascripts/app/controllers/_integration/github.coffee:63
 #: app/assets/javascripts/app/controllers/_integration/gitlab.coffee:80
 #: app/assets/javascripts/app/controllers/_integration/idoit.coffee:93
-#: app/assets/javascripts/app/controllers/ticket_zoom.coffee:1213
+#: app/assets/javascripts/app/controllers/ticket_zoom.coffee:1212
 msgid "Saving failed."
 msgstr ""
 
@@ -14843,13 +14847,11 @@ msgstr ""
 msgid "Search for…"
 msgstr ""
 
-#: app/frontend/apps/mobile/components/Form/fields/FieldRecipient/index.ts:24
 #: app/frontend/shared/components/Form/fields/FieldRecipient/features/setAutoCompleteBehavior.ts:33
 msgid "Search or enter email address…"
 msgstr ""
 
-#: app/frontend/apps/mobile/components/Form/fields/FieldRecipient/index.ts:19
-#: app/frontend/shared/components/Form/fields/FieldRecipient/features/setAutoCompleteBehavior.ts:25
+#: app/frontend/shared/components/Form/fields/FieldRecipient/features/setAutoCompleteBehavior.ts:27
 msgid "Search or enter phone number…"
 msgstr ""
 
@@ -15199,7 +15201,7 @@ msgstr ""
 #: app/frontend/apps/desktop/components/CommonSelect/CommonSelect.vue:478
 #: app/frontend/apps/desktop/components/Form/fields/FieldTreeSelect/FieldTreeSelectInputDropdown.vue:455
 #: app/frontend/apps/mobile/components/CommonSelect/CommonSelect.vue:197
-#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:287
+#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:274
 #: app/frontend/apps/mobile/components/Form/fields/FieldTags/FieldTagsDialog.vue:171
 #: app/frontend/apps/mobile/components/Form/fields/FieldTreeSelect/FieldTreeSelectInputDialog.vue:201
 msgid "Select…"
@@ -15220,7 +15222,7 @@ msgid "Send Email"
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:126
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:381
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:382
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:65
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:50
 msgid "Send Mails via"
@@ -15589,9 +15591,9 @@ msgstr ""
 msgid "Shared drafts are not activated for the selected group"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:168
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:169
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:177
-#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:66
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:34
 msgid "Shared mailbox"
 msgstr ""
 
@@ -16126,19 +16128,19 @@ msgstr ""
 msgid "Start typing to search or enter a new tag…"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:48
+#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:36
 msgid "Start typing to search or enter a phone number…"
 msgstr ""
 
 #: app/frontend/apps/desktop/components/Form/fields/FieldCustomer/FieldCustomerWrapper.vue:115
-#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:49
+#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:37
 msgid "Start typing to search or enter an email address…"
 msgstr ""
 
 #: app/frontend/apps/desktop/components/CommonSelect/CommonSelect.vue:65
 #: app/frontend/apps/desktop/components/Form/fields/FieldCustomer/FieldCustomerWrapper.vue:116
 #: app/frontend/apps/desktop/components/Form/fields/FieldTags/FieldTagsWrapper.vue:37
-#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:385
+#: app/frontend/apps/mobile/components/Form/fields/FieldAutoComplete/FieldAutoCompleteInputDialog.vue:372
 msgid "Start typing to search…"
 msgstr ""
 
@@ -16360,7 +16362,7 @@ msgstr ""
 msgid "Subscribed Tickets"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:49
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:52
 msgid "Subscribed tickets"
 msgstr ""
 
@@ -17032,7 +17034,7 @@ msgstr ""
 msgid "The certificates for %s were not found."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:293
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:294
 #: app/assets/javascripts/app/controllers/_channel/facebook.coffee:247
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:123
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:128
@@ -17062,7 +17064,7 @@ msgstr ""
 msgid "The checklist feature is not active"
 msgstr ""
 
-#: app/models/group.rb:109
+#: app/models/group.rb:107
 msgid "The chosen parent group is part of a circular reference."
 msgstr ""
 
@@ -17107,7 +17109,7 @@ msgstr ""
 msgid "The current password you provided is incorrect."
 msgstr ""
 
-#: app/services/service/ai/vectordb/create_table.rb:18
+#: app/services/service/ai/vectordb/create_table.rb:20
 msgid "The currently selected AI provider does not support embeddings."
 msgstr ""
 
@@ -17712,7 +17714,7 @@ msgstr ""
 msgid "The required value 'group_id' is missing."
 msgstr ""
 
-#: lib/ai/provider.rb:84
+#: lib/ai/provider.rb:89
 msgid "The response could not be processed."
 msgstr ""
 
@@ -17758,7 +17760,7 @@ msgstr ""
 msgid "The server returned a redirect response, but the current operation does not allow redirects."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:598
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:599
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:200
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailChannelConfiguration.ts:222
 msgid "The server settings could not be automatically detected. Please configure them manually."
@@ -17923,7 +17925,7 @@ msgstr ""
 msgid "The two-factor authentication method \"%s\" was removed for this user."
 msgstr ""
 
-#: app/controllers/sessions_controller.rb:253
+#: app/controllers/sessions_controller.rb:256
 #: app/graphql/gql/mutations/two_factor_method_initiate_authentication.rb:32
 #: app/services/service/user/two_factor/initiate_method_configuration.rb:6
 #: app/services/service/user/two_factor/verify_method_configuration.rb:15
@@ -17956,7 +17958,7 @@ msgstr ""
 msgid "The user's 'preferred_username' could not be extracted from 'id_token'."
 msgstr ""
 
-#: app/controllers/sessions_controller.rb:249
+#: app/controllers/sessions_controller.rb:252
 #: app/graphql/gql/mutations/two_factor_method_initiate_authentication.rb:27
 msgid "The username or password is incorrect."
 msgstr ""
@@ -18360,15 +18362,15 @@ msgstr ""
 msgid "This field was configured incorrectly and can't be submitted."
 msgstr ""
 
-#: app/models/group.rb:82
+#: app/models/group.rb:80
 msgid "This group cannot be moved into itself."
 msgstr ""
 
-#: app/models/group.rb:83
+#: app/models/group.rb:81
 msgid "This group cannot be moved into one of its children."
 msgstr ""
 
-#: app/models/group.rb:89
+#: app/models/group.rb:87
 msgid "This group exceeds the allowed nesting depth."
 msgstr ""
 
@@ -18378,7 +18380,7 @@ msgstr ""
 msgid "This group has no email address configured for outgoing communication."
 msgstr ""
 
-#: app/models/group.rb:95
+#: app/models/group.rb:93
 msgid "This group's children would exceed the allowed nesting depth."
 msgstr ""
 
@@ -18590,7 +18592,7 @@ msgstr ""
 msgid "This user is currently blocked because of too many failed login attempts."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:248
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:249
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:60
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:65
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:73
@@ -18831,7 +18833,7 @@ msgstr ""
 
 #: app/assets/javascripts/app/controllers/_profile/notification.coffee:71
 #: app/assets/javascripts/app/controllers/_ui_element/notification_matrix.coffee:13
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:89
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:101
 msgid "Ticket escalation"
 msgstr ""
 
@@ -18888,7 +18890,7 @@ msgstr ""
 
 #: app/assets/javascripts/app/controllers/_profile/notification.coffee:69
 #: app/assets/javascripts/app/controllers/_ui_element/notification_matrix.coffee:11
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:84
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:96
 msgid "Ticket reminder reached"
 msgstr ""
 
@@ -18937,7 +18939,7 @@ msgstr ""
 #: app/assets/javascripts/app/controllers/_profile/notification.coffee:67
 #: app/assets/javascripts/app/controllers/_ui_element/notification_matrix.coffee:9
 #: app/assets/javascripts/app/controllers/_ui_element/postmaster_set.coffee:11
-#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:79
+#: app/frontend/apps/desktop/components/Form/fields/FieldNotifications/FieldNotificationsInput.vue:91
 msgid "Ticket update"
 msgstr ""
 
@@ -19598,7 +19600,7 @@ msgstr ""
 msgid "Two-factor method has been configured successfully."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:399
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:400
 #: app/assets/javascripts/app/controllers/_ui_element/object_manager_attribute.coffee:240
 #: app/assets/javascripts/app/controllers/getting_started/channel_email.coffee:79
 #: app/assets/javascripts/app/controllers/translation.coffee:288
@@ -20138,8 +20140,8 @@ msgstr ""
 msgid "Used when viewing a Ticket"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:144
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:401
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:145
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:402
 #: app/assets/javascripts/app/controllers/_manage/ticket_duplicate_detection.coffee:37
 #: app/assets/javascripts/app/controllers/_ui_element/_application_action.coffee:173
 #: app/assets/javascripts/app/controllers/_ui_element/core_workflow_condition.coffee:24
@@ -20193,7 +20195,7 @@ msgstr ""
 msgid "User Mailbox"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:335
+#: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:338
 msgid "User Mismatch"
 msgstr ""
 
@@ -20266,7 +20268,7 @@ msgstr ""
 msgid "User is inactive"
 msgstr ""
 
-#: app/controllers/sessions_controller.rb:165
+#: app/controllers/sessions_controller.rb:168
 #: app/frontend/apps/desktop/components/Search/QuickSearch/entities/User.vue:25
 msgid "User is inactive."
 msgstr ""
@@ -20283,9 +20285,9 @@ msgstr ""
 msgid "User is out of office"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:168
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:169
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:177
-#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:66
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:34
 msgid "User mailbox"
 msgstr ""
 
@@ -21455,12 +21457,12 @@ msgstr ""
 msgid "add"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldAutoComplete/useAddUnknownValueAction.ts:27
-#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:25
+#: app/frontend/apps/desktop/components/Form/fields/FieldAutoComplete/useAddUnknownValueAction.ts:20
+#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:21
 msgid "add new email address"
 msgstr ""
 
-#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:25
+#: app/frontend/apps/desktop/components/Form/fields/FieldRecipient/FieldRecipientWrapper.vue:21
 msgid "add new phone number"
 msgstr ""
 
@@ -21590,7 +21592,7 @@ msgstr ""
 msgid "can't be used because *_id and *_ids are not allowed"
 msgstr ""
 
-#: app/models/knowledge_base/category.rb:151
+#: app/models/knowledge_base/category.rb:149
 msgid "cannot be a subcategory of the parent category"
 msgstr ""
 
@@ -22231,7 +22233,7 @@ msgstr ""
 msgid "is not included in the list"
 msgstr ""
 
-#: app/models/knowledge_base/category.rb:168
+#: app/models/knowledge_base/category.rb:167
 msgid "is part of a circular reference"
 msgstr ""
 
@@ -22985,9 +22987,9 @@ msgstr ""
 msgid "updated"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:169
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:170
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:178
-#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:67
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:35
 msgid "user@your-organization.tld"
 msgstr ""
 
@@ -23037,11 +23039,11 @@ msgstr ""
 msgid "within next (relative)"
 msgstr ""
 
-#: app/models/knowledge_base/category.rb:181
+#: app/models/knowledge_base/category.rb:180
 msgid "would exceed the allowed nesting depth"
 msgstr ""
 
-#: app/models/knowledge_base/category.rb:186
+#: app/models/knowledge_base/category.rb:185
 msgid "would push this category's children beyond the allowed nesting depth"
 msgstr ""
 

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -8542,7 +8542,7 @@ msgstr ""
 #: app/assets/javascripts/app/controllers/getting_started/email_notification.coffee:69
 #: app/assets/javascripts/app/controllers/knowledge_base/video_servers_manager.coffee:80
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:73
-#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:20
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:32
 #: app/assets/javascripts/app/views/integration/ldap_wizard.jst.eco:29
 #: app/assets/javascripts/app/views/knowledge_base_video_servers/index.jst.eco:11
 #: app/frontend/apps/desktop/entities/channel-email/composables/useEmailInboundForm.ts:107
@@ -10797,6 +10797,10 @@ msgstr ""
 #: app/assets/javascripts/app/views/widget/two_factor_configuration/authenticator_app.jst.eco:15
 #: app/frontend/apps/desktop/components/TwoFactor/TwoFactorConfiguration/TwoFactorConfigurationAuthenticatorApp.vue:153
 msgid "Microsoft Authenticator"
+msgstr ""
+
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:39
+msgid "Microsoft Graph API"
 msgstr ""
 
 #: app/models/webhook/pre_defined/microsoft_teams.rb:5
@@ -13492,7 +13496,7 @@ msgid "Proof Key for Code Exchange is currently only supporting SHA256 as code c
 msgstr ""
 
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:76
-#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:35
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:38
 msgid "Protocol"
 msgstr ""
 

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -1982,7 +1982,7 @@ msgstr ""
 
 #: app/assets/javascripts/app/controllers/_application_controller/_modal_generic_confirm_delete.coffee:6
 #: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:185
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:145
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:141
 #: app/assets/javascripts/app/controllers/_channel/facebook.coffee:99
 #: app/assets/javascripts/app/controllers/_channel/telegram.coffee:67
 #: app/assets/javascripts/app/controllers/_channel/whatsapp.coffee:68
@@ -2282,7 +2282,9 @@ msgstr ""
 msgid "August"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:180
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:172
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:75
 msgid "Authenticate"
 msgstr ""
 
@@ -3175,7 +3177,7 @@ msgstr ""
 msgid "Changes were made that require a database update."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:259
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:243
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:55
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:60
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:68
@@ -5808,7 +5810,7 @@ msgstr ""
 msgid "Desktop BETA UI Switch Roles"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:263
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:247
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:59
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:64
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:72
@@ -5829,7 +5831,7 @@ msgstr ""
 msgid "Destination caller ID or queue"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:264
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:248
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:60
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:65
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:73
@@ -6466,8 +6468,9 @@ msgid "Email Accounts"
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/_channel/_channel_account_overview.coffee:282
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:201
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:197
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:126
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:50
 #: app/assets/javascripts/app/views/channel_account/list.jst.eco:96
 msgid "Email Address"
 msgstr ""
@@ -7583,7 +7586,7 @@ msgstr ""
 msgid "Focus on %s"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:422
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:406
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:61
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:66
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:273
@@ -9229,7 +9232,7 @@ msgstr ""
 msgid "Invalid GitLab issue link format"
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:71
+#: app/controllers/external_credentials_controller.rb:72
 #: lib/external_credential/exchange.rb:43
 #: lib/external_credential/facebook.rb:42
 #: lib/external_credential/google.rb:39
@@ -9501,7 +9504,7 @@ msgstr ""
 msgid "Kayako"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:423
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:407
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:62
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:67
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:274
@@ -10170,7 +10173,9 @@ msgstr ""
 msgid "Macros make it easy to automate common, multi-step tasks within Zammad.\n\nYou can use macros in Zammad to automate recurring sequences, saving time (and nerves). This allows a combined sequence of actions on the ticket to be executed with just one click."
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:168
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:177
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:66
 msgid "Mailbox type"
 msgstr ""
 
@@ -11531,7 +11536,7 @@ msgstr ""
 msgid "No Microsoft 365 app configured!"
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:74
+#: app/controllers/external_credentials_controller.rb:75
 #: lib/external_credential/microsoft_graph.rb:9
 msgid "No Microsoft Graph app configured!"
 msgstr ""
@@ -15547,6 +15552,7 @@ msgstr ""
 msgid "Shared Drafts"
 msgstr ""
 
+#: app/assets/javascripts/app/views/channel/email_notification_overview.jst.eco:21
 #: app/assets/javascripts/app/views/channel_account/list.jst.eco:65
 msgid "Shared Mailbox"
 msgstr ""
@@ -15583,7 +15589,9 @@ msgstr ""
 msgid "Shared drafts are not activated for the selected group"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:168
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:177
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:66
 msgid "Shared mailbox"
 msgstr ""
 
@@ -17621,7 +17629,7 @@ msgstr ""
 msgid "The required parameter 'client_secret' is missing."
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:75
+#: app/controllers/external_credentials_controller.rb:76
 #: lib/external_credential/exchange.rb:47
 #: lib/external_credential/google.rb:43
 #: lib/external_credential/microsoft_base.rb:80
@@ -17942,7 +17950,7 @@ msgstr ""
 msgid "The user token could not be generated."
 msgstr ""
 
-#: app/controllers/external_credentials_controller.rb:106
+#: app/controllers/external_credentials_controller.rb:107
 #: lib/external_credential/exchange.rb:55
 #: lib/external_credential/microsoft_base.rb:88
 msgid "The user's 'preferred_username' could not be extracted from 'id_token'."
@@ -18582,7 +18590,7 @@ msgstr ""
 msgid "This user is currently blocked because of too many failed login attempts."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/_channel/email.coffee:264
+#: app/assets/javascripts/app/controllers/_channel/email.coffee:248
 #: app/assets/javascripts/app/controllers/_channel/google.coffee:60
 #: app/assets/javascripts/app/controllers/_channel/microsoft365.coffee:65
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:73
@@ -20275,7 +20283,9 @@ msgstr ""
 msgid "User is out of office"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:168
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:177
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:66
 msgid "User mailbox"
 msgstr ""
 
@@ -22975,7 +22985,9 @@ msgstr ""
 msgid "updated"
 msgstr ""
 
+#: app/assets/javascripts/app/controllers/_channel/_email_notification.coffee:169
 #: app/assets/javascripts/app/controllers/_channel/microsoft_graph.coffee:178
+#: app/assets/javascripts/app/controllers/_channel/microsoft_graph_notification.coffee:67
 msgid "user@your-organization.tld"
 msgstr ""
 

--- a/lib/email_helper.rb
+++ b/lib/email_helper.rb
@@ -41,8 +41,9 @@ returns
         pop3: __('POP3'),
       },
       outbound: {
-        smtp:     __('SMTP - configure your own outgoing SMTP settings'),
-        sendmail: __('Local MTA (Sendmail/Postfix/Exim/…) - use server setup'),
+        smtp:                      __('SMTP - configure your own outgoing SMTP settings'),
+        sendmail:                  __('Local MTA (Sendmail/Postfix/Exim/…) - use server setup'),
+        microsoft_graph_outbound:  __('Microsoft 365 Graph Email'),
       },
     }
   end

--- a/lib/email_helper.rb
+++ b/lib/email_helper.rb
@@ -41,9 +41,9 @@ returns
         pop3: __('POP3'),
       },
       outbound: {
-        smtp:                      __('SMTP - configure your own outgoing SMTP settings'),
-        sendmail:                  __('Local MTA (Sendmail/Postfix/Exim/…) - use server setup'),
-        microsoft_graph_outbound:  __('Microsoft 365 Graph Email'),
+        smtp:                     __('SMTP - configure your own outgoing SMTP settings'),
+        sendmail:                 __('Local MTA (Sendmail/Postfix/Exim/…) - use server setup'),
+        microsoft_graph_outbound: __('Microsoft 365 Graph Email'),
       },
     }
   end

--- a/spec/db/migrate/add_microsoft_graph_notification_channel_spec.rb
+++ b/spec/db/migrate/add_microsoft_graph_notification_channel_spec.rb
@@ -1,0 +1,53 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe AddMicrosoftGraphNotificationChannel, type: :db_migration do
+  context 'when microsoft_graph_outbound notification channel does not exist' do
+    before do
+      # Remove any existing microsoft_graph_outbound notification channel
+      Channel.where(area: 'Email::Notification').each do |channel|
+        adapter = channel.options.dig(:outbound, :adapter) || channel.options.dig('outbound', 'adapter')
+        channel.destroy! if adapter == 'microsoft_graph_outbound'
+      end
+    end
+
+    it 'creates the channel' do
+      migrate
+
+      channel = Channel.where(area: 'Email::Notification').find do |ch|
+        adapter = ch.options.dig(:outbound, :adapter) || ch.options.dig('outbound', 'adapter')
+        adapter == 'microsoft_graph_outbound'
+      end
+
+      expect(channel).to have_attributes(
+        active:  false,
+        options: include(
+          outbound: include(adapter: 'microsoft_graph_outbound'),
+        ),
+      )
+    end
+  end
+
+  context 'when microsoft_graph_outbound notification channel already exists' do
+    before do
+      Channel.create!(
+        area:          'Email::Notification',
+        options:       { outbound: { adapter: 'microsoft_graph_outbound', options: {} } },
+        preferences:   { online_service_disable: true },
+        active:        false,
+        created_by_id: 1,
+        updated_by_id: 1,
+      )
+    end
+
+    it 'does not create a duplicate' do
+      expect { migrate }.not_to change {
+        Channel.where(area: 'Email::Notification').count { |ch|
+          adapter = ch.options.dig(:outbound, :adapter) || ch.options.dig('outbound', 'adapter')
+          adapter == 'microsoft_graph_outbound'
+        }
+      }
+    end
+  end
+end

--- a/spec/factories/channel.rb
+++ b/spec/factories/channel.rb
@@ -50,6 +50,36 @@ FactoryBot.define do
           }
         end
       end
+
+      trait :microsoft_graph_outbound do
+        transient do
+          microsoft_user { Faker::Internet.unique.email }
+        end
+
+        options do
+          {
+            outbound: {
+              'adapter' => 'microsoft_graph_outbound',
+              'options' => {
+                'user'     => microsoft_user,
+                'password' => 'test_access_token',
+              },
+            },
+            auth:     {
+              'type'          => 'XOAUTH2',
+              'provider'      => 'microsoft_graph',
+              'access_token'  => 'test_access_token',
+              'expires_in'    => 3599,
+              'refresh_token' => 'test_refresh_token',
+              'scope'         => 'offline_access openid profile email mail.send',
+              'token_type'    => 'Bearer',
+              'created_at'    => 30.days.ago,
+              'client_id'     => 'test_client_id',
+              'client_secret' => 'test_client_secret',
+            },
+          }
+        end
+      end
     end
 
     factory :email_channel do

--- a/spec/requests/channels_email_microsoft_graph_notification_spec.rb
+++ b/spec/requests/channels_email_microsoft_graph_notification_spec.rb
@@ -46,14 +46,6 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
   end
 
   describe 'GET /api/v1/external_credentials/microsoft_graph/callback (notification)' do
-    before do
-      create(:external_credential, name: 'microsoft_graph', credentials: {
-               client_id:     'test_client_id',
-               client_secret: 'test_client_secret',
-               client_tenant: 'common',
-             })
-    end
-
     let(:state_token) { SecureRandom.urlsafe_base64 }
 
     let(:token_response) do
@@ -75,6 +67,12 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
     let(:shared_mailbox) { nil }
 
     before do
+      create(:external_credential, name: 'microsoft_graph', credentials: {
+               client_id:     'test_client_id',
+               client_secret: 'test_client_secret',
+               client_tenant: 'common',
+             })
+
       # Simulate session state from link_account
       allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(
         {

--- a/spec/requests/channels_email_microsoft_graph_notification_spec.rb
+++ b/spec/requests/channels_email_microsoft_graph_notification_spec.rb
@@ -1,0 +1,139 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, authenticated_as: :admin, type: :request do
+  let(:admin) { create(:admin) }
+
+  describe 'POST /api/v1/channels_email_notification (microsoft_graph_outbound)' do
+    it 'returns a redirect to the OAuth URL' do
+      post '/api/v1/channels_email_notification', params: { adapter: 'microsoft_graph_outbound' }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(json_response).to include(
+        'result' => 'redirect',
+        'url'    => include('external_credentials/microsoft_graph/link_account', 'notification=true'),
+      )
+    end
+
+    context 'with shared mailbox' do
+      it 'passes shared_mailbox in the redirect URL' do
+        post '/api/v1/channels_email_notification', params: {
+          adapter: 'microsoft_graph_outbound',
+          options: { shared_mailbox: 'shared@example.com' },
+        }, as: :json
+
+        expect(json_response['url']).to include('shared_mailbox=shared%40example.com')
+      end
+    end
+  end
+
+  describe 'GET /api/v1/external_credentials/microsoft_graph/link_account (notification)' do
+    let!(:external_credential) do
+      create(:external_credential, name: 'microsoft_graph', credentials: {
+               client_id:     'test_client_id',
+               client_secret: 'test_client_secret',
+               client_tenant: 'common',
+             })
+    end
+
+    it 'stores notification flag in session and redirects to Microsoft OAuth' do
+      get '/api/v1/external_credentials/microsoft_graph/link_account', params: { notification: 'true' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.headers['Location']).to include('login.microsoftonline.com')
+    end
+  end
+
+  describe 'GET /api/v1/external_credentials/microsoft_graph/callback (notification)' do
+    let!(:external_credential) do
+      create(:external_credential, name: 'microsoft_graph', credentials: {
+               client_id:     'test_client_id',
+               client_secret: 'test_client_secret',
+               client_tenant: 'common',
+             })
+    end
+
+    let(:state_token) { SecureRandom.urlsafe_base64 }
+
+    let(:token_response) do
+      {
+        access_token:  'new_access_token',
+        refresh_token: 'new_refresh_token',
+        expires_in:    3600,
+        scope:         'offline_access openid profile email mail.send',
+        token_type:    'Bearer',
+        id_token:      jwt_id_token,
+      }
+    end
+
+    let(:jwt_id_token) do
+      payload = { preferred_username: 'user@example.com' }
+      "header.#{Base64.urlsafe_encode64(payload.to_json)}.signature"
+    end
+
+    before do
+      # Simulate session state from link_account
+      allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(
+        {
+          request_token: state_token,
+          notification:  true,
+          shared_mailbox: shared_mailbox,
+        }.with_indifferent_access,
+      )
+
+      allow(ExternalCredential::MicrosoftGraph).to receive(:authorize_tokens).and_return(token_response)
+    end
+
+    let(:shared_mailbox) { nil }
+
+    it 'exchanges code for tokens and updates the notification channel' do
+      get '/api/v1/external_credentials/microsoft_graph/callback', params: { code: 'auth_code', state: state_token }
+
+      expect(response).to have_http_status(:found)
+      expect(response.headers['Location']).to include('#channels/email')
+
+      channel = Channel.where(area: 'Email::Notification').find do |ch|
+        adapter = ch.options.dig(:outbound, :adapter) || ch.options.dig('outbound', 'adapter')
+        adapter == 'microsoft_graph_outbound'
+      end
+
+      expect(channel).to have_attributes(
+        active: true,
+        options: include(
+          outbound: include(
+            adapter: 'microsoft_graph_outbound',
+            options: include(user: 'user@example.com'),
+          ),
+          auth: include(
+            provider: 'microsoft_graph',
+            access_token: 'new_access_token',
+          ),
+        ),
+      )
+    end
+
+    context 'with shared mailbox' do
+      let(:shared_mailbox) { 'shared@example.com' }
+
+      it 'stores shared mailbox in outbound options' do
+        get '/api/v1/external_credentials/microsoft_graph/callback', params: { code: 'auth_code', state: state_token }
+
+        channel = Channel.where(area: 'Email::Notification').find do |ch|
+          adapter = ch.options.dig(:outbound, :adapter) || ch.options.dig('outbound', 'adapter')
+          adapter == 'microsoft_graph_outbound'
+        end
+
+        expect(channel.options.dig(:outbound, :options, :shared_mailbox)).to eq('shared@example.com')
+      end
+    end
+
+    context 'with invalid state token' do
+      it 'raises an error' do
+        expect do
+          get '/api/v1/external_credentials/microsoft_graph/callback', params: { code: 'auth_code', state: 'wrong_state' }
+        end.to raise_error(Exceptions::UnprocessableEntity, %r{Invalid OAuth state})
+      end
+    end
+  end
+end

--- a/spec/requests/channels_email_microsoft_graph_notification_spec.rb
+++ b/spec/requests/channels_email_microsoft_graph_notification_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
   end
 
   describe 'GET /api/v1/external_credentials/microsoft_graph/link_account (notification)' do
-    let!(:external_credential) do
+    before do
       create(:external_credential, name: 'microsoft_graph', credentials: {
                client_id:     'test_client_id',
                client_secret: 'test_client_secret',
@@ -46,7 +46,7 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
   end
 
   describe 'GET /api/v1/external_credentials/microsoft_graph/callback (notification)' do
-    let!(:external_credential) do
+    before do
       create(:external_credential, name: 'microsoft_graph', credentials: {
                client_id:     'test_client_id',
                client_secret: 'test_client_secret',
@@ -72,20 +72,20 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
       "header.#{Base64.urlsafe_encode64(payload.to_json)}.signature"
     end
 
+    let(:shared_mailbox) { nil }
+
     before do
       # Simulate session state from link_account
       allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(
         {
-          request_token: state_token,
-          notification:  true,
+          request_token:  state_token,
+          notification:   true,
           shared_mailbox: shared_mailbox,
         }.with_indifferent_access,
       )
 
       allow(ExternalCredential::MicrosoftGraph).to receive(:authorize_tokens).and_return(token_response)
     end
-
-    let(:shared_mailbox) { nil }
 
     it 'exchanges code for tokens and updates the notification channel' do
       get '/api/v1/external_credentials/microsoft_graph/callback', params: { code: 'auth_code', state: state_token }
@@ -99,14 +99,14 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
       end
 
       expect(channel).to have_attributes(
-        active: true,
+        active:  true,
         options: include(
           outbound: include(
             adapter: 'microsoft_graph_outbound',
             options: include(user: 'user@example.com'),
           ),
-          auth: include(
-            provider: 'microsoft_graph',
+          auth:     include(
+            provider:     'microsoft_graph',
             access_token: 'new_access_token',
           ),
         ),

--- a/spec/requests/channels_email_microsoft_graph_notification_spec.rb
+++ b/spec/requests/channels_email_microsoft_graph_notification_spec.rb
@@ -55,13 +55,8 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
         expires_in:    3600,
         scope:         'offline_access openid profile email mail.send',
         token_type:    'Bearer',
-        id_token:      jwt_id_token,
+        id_token:      'fake.id.token',
       }
-    end
-
-    let(:jwt_id_token) do
-      payload = { preferred_username: 'user@example.com' }
-      "header.#{Base64.urlsafe_encode64(payload.to_json)}.signature"
     end
 
     let(:shared_mailbox) { nil }
@@ -83,6 +78,7 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
       )
 
       allow(ExternalCredential::MicrosoftGraph).to receive(:authorize_tokens).and_return(token_response)
+      allow(ExternalCredential::MicrosoftGraph).to receive(:user_info).and_return({ preferred_username: 'user@example.com' })
     end
 
     it 'exchanges code for tokens and updates the notification channel' do

--- a/spec/requests/channels_email_microsoft_graph_notification_spec.rb
+++ b/spec/requests/channels_email_microsoft_graph_notification_spec.rb
@@ -77,8 +77,10 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
         }.with_indifferent_access,
       )
 
-      allow(ExternalCredential::MicrosoftGraph).to receive(:authorize_tokens).and_return(token_response)
-      allow(ExternalCredential::MicrosoftGraph).to receive(:user_info).and_return({ preferred_username: 'user@example.com' })
+      allow(ExternalCredential::MicrosoftGraph).to receive_messages(
+        authorize_tokens: token_response,
+        user_info:        { preferred_username: 'user@example.com' },
+      )
     end
 
     it 'exchanges code for tokens and updates the notification channel' do

--- a/spec/requests/channels_email_microsoft_graph_notification_spec.rb
+++ b/spec/requests/channels_email_microsoft_graph_notification_spec.rb
@@ -68,19 +68,21 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
                client_tenant: 'common',
              })
 
-      # Simulate session state from link_account
-      allow_any_instance_of(ActionDispatch::Request).to receive(:session).and_return(
-        {
-          request_token:  state_token,
-          notification:   true,
-          shared_mailbox: shared_mailbox,
-        }.with_indifferent_access,
+      allow(ExternalCredential).to receive(:request_account_to_link).and_return(
+        request_token: state_token,
+        authorize_url: 'https://login.microsoftonline.com/dummy',
       )
 
       allow(ExternalCredential::MicrosoftGraph).to receive_messages(
         authorize_tokens: token_response,
         user_info:        { preferred_username: 'user@example.com' },
       )
+
+      # Populate session via link_account so the real Rails session store is used
+      get '/api/v1/external_credentials/microsoft_graph/link_account', params: {
+        notification:   'true',
+        shared_mailbox: shared_mailbox,
+      }
     end
 
     it 'exchanges code for tokens and updates the notification channel' do
@@ -125,10 +127,10 @@ RSpec.describe 'Microsoft Graph Email Notification', aggregate_failures: true, a
     end
 
     context 'with invalid state token' do
-      it 'raises an error' do
-        expect do
-          get '/api/v1/external_credentials/microsoft_graph/callback', params: { code: 'auth_code', state: 'wrong_state' }
-        end.to raise_error(Exceptions::UnprocessableEntity, %r{Invalid OAuth state})
+      it 'returns unprocessable content' do
+        get '/api/v1/external_credentials/microsoft_graph/callback', params: { code: 'auth_code', state: 'wrong_state' }
+
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/services/service/system/set_email_notification_configuration_spec.rb
+++ b/spec/services/service/system/set_email_notification_configuration_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Service::System::SetEmailNotificationConfiguration do
           adapter:           'microsoft_graph_outbound',
           new_configuration: { user: 'user@example.com' },
         )
-      end.to raise_error(ArgumentError, /microsoft_graph_auth/)
+      end.to raise_error(ArgumentError, %r{microsoft_graph_auth})
     end
   end
 
@@ -126,7 +126,7 @@ RSpec.describe Service::System::SetEmailNotificationConfiguration do
                 password: 'test_access_token',
               ),
             ),
-            auth: include(
+            auth:     include(
               provider: 'microsoft_graph',
             ),
           ),

--- a/spec/services/service/system/set_email_notification_configuration_spec.rb
+++ b/spec/services/service/system/set_email_notification_configuration_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Service::System::SetEmailNotificationConfiguration do
           adapter:           'microsoft_graph_outbound',
           new_configuration: { user: 'user@example.com' },
         )
-      end.to raise_error(ArgumentError, %r{microsoft_graph_auth})
+      end.to raise_error(ArgumentError, %r{microsoft_graph_outbound})
     end
   end
 

--- a/spec/services/service/system/set_email_notification_configuration_spec.rb
+++ b/spec/services/service/system/set_email_notification_configuration_spec.rb
@@ -80,6 +80,17 @@ RSpec.describe Service::System::SetEmailNotificationConfiguration do
     end
   end
 
+  context 'when adapter is microsoft_graph_outbound without auth data' do
+    it 'raises ArgumentError' do
+      expect do
+        described_class.execute(
+          adapter:           'microsoft_graph_outbound',
+          new_configuration: { user: 'user@example.com' },
+        )
+      end.to raise_error(ArgumentError, /microsoft_graph_auth/)
+    end
+  end
+
   context 'when adapter is microsoft_graph_outbound' do
     let(:auth_data) do
       {

--- a/spec/services/service/system/set_email_notification_configuration_spec.rb
+++ b/spec/services/service/system/set_email_notification_configuration_spec.rb
@@ -80,6 +80,96 @@ RSpec.describe Service::System::SetEmailNotificationConfiguration do
     end
   end
 
+  context 'when adapter is microsoft_graph_outbound' do
+    let(:auth_data) do
+      {
+        access_token:  'test_access_token',
+        refresh_token: 'test_refresh_token',
+        provider:      'microsoft_graph',
+        type:          'XOAUTH2',
+        client_id:     'test_client_id',
+        client_secret: 'test_client_secret',
+        created_at:    Time.zone.now,
+      }
+    end
+
+    before do
+      described_class.execute(
+        adapter:              'microsoft_graph_outbound',
+        new_configuration:    { user: 'user@example.com' },
+        microsoft_graph_auth: auth_data,
+      )
+    end
+
+    it 'sets microsoft_graph_outbound to active with auth and outbound options' do
+      expect(channel_by_adapter('microsoft_graph_outbound'))
+        .to have_attributes(
+          active:       true,
+          status_out:   'ok',
+          last_log_out: nil,
+          options:      include(
+            outbound: include(
+              adapter: 'microsoft_graph_outbound',
+              options: include(
+                user:     'user@example.com',
+                password: 'test_access_token',
+              ),
+            ),
+            auth: include(
+              provider: 'microsoft_graph',
+            ),
+          ),
+        )
+    end
+
+    it 'sets smtp to inactive' do
+      expect(channel_by_adapter('smtp'))
+        .to have_attributes(active: false)
+    end
+
+    it 'sets sendmail to inactive' do
+      expect(channel_by_adapter('sendmail'))
+        .to have_attributes(active: false)
+    end
+
+    context 'with shared mailbox' do
+      before do
+        described_class.execute(
+          adapter:              'microsoft_graph_outbound',
+          new_configuration:    { user: 'user@example.com', shared_mailbox: 'shared@example.com' },
+          microsoft_graph_auth: auth_data,
+        )
+      end
+
+      it 'stores shared mailbox in outbound options' do
+        expect(channel_by_adapter('microsoft_graph_outbound').options.dig(:outbound, :options, :shared_mailbox))
+          .to eq('shared@example.com')
+      end
+    end
+
+    context 'when switching back to smtp' do
+      before do
+        described_class.execute(
+          adapter:           'smtp',
+          new_configuration: {
+            host: 'smtp.example.com', port: 25, ssl: true,
+            user: 'some@example.com', password: 'password',
+          },
+        )
+      end
+
+      it 'sets smtp to active' do
+        expect(channel_by_adapter('smtp'))
+          .to have_attributes(active: true)
+      end
+
+      it 'sets microsoft_graph_outbound to inactive' do
+        expect(channel_by_adapter('microsoft_graph_outbound'))
+          .to have_attributes(active: false)
+      end
+    end
+  end
+
   def channel_by_adapter(adapter)
     Channel
       .where(area: 'Email::Notification')


### PR DESCRIPTION
This Pull Request adds Microsoft 365 Graph functionality to Zammads notification channel.
Fair word of warning: While I manually verified all steps involved and its functionality, this PR was prepared with the help of AI. Some solutions the AI chose (and I felt being "resonable") might not be ideal or BS. Sorry if that's the case.

--

It supports shared and regular mailboxes and adds some management changes due to this:

- the notification channel now can also be configured within the Graph Channel management (to make it feel more "fluent"). This is only possible, if API connection was set up before.
- The 'Add account' button in the dialogue acts as authentication and re-authentication method (both tested)
- Adding a microsoft account to the graph notification channel visually works exactly like it does with an actual channel

## Flow

  1. Admin selects "Microsoft 365 Graph Email" → mailbox type fields appear (user/shared)
  2. Clicks "Authenticate" → POST to channels_email_notification → server returns OAuth redirect URL
  3. Browser follows redirect → Microsoft OAuth → callback exchanges tokens
  4. Service activates the microsoft_graph_outbound notification channel, deactivates smtp/sendmail
  5. NotificationFactory::Mailer picks up the active channel and delivers via Graph API

While this one waits and probably needs polishing, I have prepared an addon that can be installed in the mean time: https://cloud.smrg.de/index.php/s/ZXYZ62jnYWFznwk

Thanks for considering this improvement and taking the time to review it.

<img width="1304" height="794" alt="image" src="https://github.com/user-attachments/assets/75fd2331-a813-490c-8064-8edc70e7525d" />

