### PR TITLE
Use an ampersand as the query string separator in the report download URL

### DIFF
--- a/app/assets/javascripts/app/controllers/report.coffee
+++ b/app/assets/javascripts/app/controllers/report.coffee
@@ -321,7 +321,7 @@ class Download extends App.Controller
     for key, value of @params.profileSelected
       if value
         profile_id = key
-    downloadUrl = "#{@apiPath}/reports/sets?sheet=true;metric=#{@params.metric};year=#{@params.year};month=#{@params.month};week=#{@params.week};day=#{@params.day};timeRange=#{@params.timeRange};profile_id=#{profile_id};downloadBackendSelected=#{@params.downloadBackendSelected}"
+    downloadUrl = "#{@apiPath}/reports/sets?sheet=true&metric=#{@params.metric}&year=#{@params.year}&month=#{@params.month}&week=#{@params.week}&day=#{@params.day}&timeRange=#{@params.timeRange}&profile_id=#{profile_id}&downloadBackendSelected=#{@params.downloadBackendSelected}"
 
     if count > 0
       @$('.js-dataDownloadButton').html(App.view('report/download_button')(


### PR DESCRIPTION
## What

The Reporting view's "Download as Excel" link is built with semicolons (`;`) as query-string separators, which Rack 2.2+ no longer treats as parameter separators. As a result, on any current Zammad release the download fails with HTTP 422.

## Steps to reproduce

1. Open `/#report` (any user with reporting permission, any profile).
2. Pick a profile so the `Download N record(s)` button appears.
3. Click it.

**Actual:** browser receives:

```
HTTP/2 422
content-type: application/json; charset=utf-8

{"error":"Required parameter 'profile' is missing.","error_human":"Required parameter 'profile' is missing.","unprocessable_content":null}
```

**Expected:** an `.xlsx` download.

## Why

`app/assets/javascripts/app/controllers/report.coffee#Download::tableRender` builds the URL as:

```coffee
downloadUrl = "#{@apiPath}/reports/sets?sheet=true;metric=#{@params.metric};year=#{@params.year};...;profile_id=#{profile_id};downloadBackendSelected=#{@params.downloadBackendSelected}"
```

Rack [stopped accepting `;` as a query-string separator](https://github.com/rack/rack/issues/1732) for the web-cache-poisoning concern, so on the backend that whole string is parsed as a single `sheet` parameter:

```
sheet  =>  "true;metric=count;year=...;profile_id=10;downloadBackendSelected=count::created"
```

…and `profile_id` (which the controller looks for as `profile`) is absent, hence the 422.

## Fix

Switch the URL builder to use `&`. One-character change. Verified on 7.0.1 (Rails 7 / Rack 3.1):

```js
> await fetch('/api/v1/reports/sets?sheet=true&metric=count&year=2026&month=4&week=18&day=30&timeRange=year&profile_id=10&downloadBackendSelected=count::created&profile=10')
< Response { status: 200, headers: { 'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' } }
```

200 OK with the expected xlsx body. The same URL with `;` returns 422.

## Notes

- This is the only place in `app/assets/javascripts/` that builds a URL with `;` separators (grepped the tree).
- Same bug exists on `develop`; this PR is against `develop`.
- Tested manually only — there are no JS unit tests for this controller path.