### PR TITLE
feat(sso): support return_to query param for /auth/sso deep-link redirects

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -66,7 +66,7 @@ class SessionsController < ApplicationController
 
     initiate_session_for(user, 'SSO')
 
-    redirect_after_omniauth('/#')
+    redirect_after_omniauth(safe_return_to_path(params[:return_to]))
   end
 
   # "Delete" a login, aka "log the user out"
@@ -291,6 +291,28 @@ class SessionsController < ApplicationController
     return if trusted_ips.blank?
 
     raise Exceptions::Forbidden, __('SSO request from untrusted IP address.') if trusted_ips.exclude?(request.remote_ip)
+  end
+
+  SAFE_RETURN_TO_DEFAULT = '/#'.freeze
+  SAFE_RETURN_TO_MAX_LENGTH = 1024
+
+  # Validate the optional `return_to` parameter for the SSO flow.
+  #
+  # Only same-origin, relative paths are accepted to prevent open-redirect attacks:
+  #   * Must start with a single "/" and not "//" (which would be protocol-relative)
+  #   * Must not contain control characters or backslashes
+  #   * Must be at most SAFE_RETURN_TO_MAX_LENGTH characters long
+  #
+  # Anything that does not pass these checks falls back to SAFE_RETURN_TO_DEFAULT.
+  def safe_return_to_path(value)
+    return SAFE_RETURN_TO_DEFAULT if value.blank?
+    return SAFE_RETURN_TO_DEFAULT if !value.is_a?(String)
+    return SAFE_RETURN_TO_DEFAULT if value.length > SAFE_RETURN_TO_MAX_LENGTH
+    return SAFE_RETURN_TO_DEFAULT if !value.start_with?('/')
+    return SAFE_RETURN_TO_DEFAULT if value.start_with?('//')
+    return SAFE_RETURN_TO_DEFAULT if value.match?(%r{[\x00-\x1f\x7f\\]})
+
+    value
   end
 
   def authenticate_with_password

--- a/spec/requests/session_spec.rb
+++ b/spec/requests/session_spec.rb
@@ -277,6 +277,87 @@ RSpec.describe 'Sessions endpoints', type: :request do
       end
     end
 
+    context 'with optional return_to parameter' do
+      let(:user)    { create(:agent) }
+      let(:headers) { { 'X-Forwarded-User' => user.login } }
+
+      it 'redirects to "/#" when no return_to is given' do
+        get '/auth/sso', as: :json, headers: headers
+
+        expect(response).to redirect_to('/#')
+      end
+
+      it 'redirects to the given relative return_to path' do
+        get '/auth/sso', params: { return_to: '/#ticket/zoom/57' }, as: :json, headers: headers
+
+        expect(response).to redirect_to('/#ticket/zoom/57')
+      end
+
+      it 'preserves URL fragments' do
+        get '/auth/sso', params: { return_to: '/#dashboard' }, as: :json, headers: headers
+
+        expect(response).to redirect_to('/#dashboard')
+      end
+
+      it 'accepts deeper relative paths without a fragment' do
+        get '/auth/sso', params: { return_to: '/some/path' }, as: :json, headers: headers
+
+        expect(response).to redirect_to('/some/path')
+      end
+
+      it 'falls back to "/#" when return_to is empty' do
+        get '/auth/sso', params: { return_to: '' }, as: :json, headers: headers
+
+        expect(response).to redirect_to('/#')
+      end
+
+      it 'rejects absolute http/https URLs' do
+        %w[https://evil.example.com/ http://evil.example.com/path].each do |bad|
+          get '/auth/sso', params: { return_to: bad }, as: :json, headers: headers
+
+          expect(response).to redirect_to('/#')
+        end
+      end
+
+      it 'rejects protocol-relative URLs (//evil.example.com)' do
+        get '/auth/sso', params: { return_to: '//evil.example.com/' }, as: :json, headers: headers
+
+        expect(response).to redirect_to('/#')
+      end
+
+      it 'rejects javascript: and data: URLs' do
+        ['javascript:alert(1)', 'data:text/html,<script>alert(1)</script>'].each do |bad|
+          get '/auth/sso', params: { return_to: bad }, as: :json, headers: headers
+
+          expect(response).to redirect_to('/#')
+        end
+      end
+
+      it 'rejects URLs containing backslashes or control characters' do
+        ['/foo\bar', "/foo\nbar", "/foo\x00bar"].each do |bad|
+          get '/auth/sso', params: { return_to: bad }, as: :json, headers: headers
+
+          expect(response).to redirect_to('/#')
+        end
+      end
+
+      it 'rejects return_to longer than 1024 characters' do
+        long = "/#{'a' * 1100}"
+
+        get '/auth/sso', params: { return_to: long }, as: :json, headers: headers
+
+        expect(response).to redirect_to('/#')
+      end
+
+      it 'rejects paths that do not start with "/"' do
+        ['evil.example.com/', 'no-leading-slash', '?evil=1'].each do |bad|
+          get '/auth/sso', params: { return_to: bad }, as: :json, headers: headers
+
+          expect(response).to redirect_to('/#')
+        end
+      end
+    end
+
     context 'with trusted proxy IPs configured' do
       before do
         Setting.set('auth_sso_trusted_ips', '192.168.1.1, 10.0.0.0/8')


### PR DESCRIPTION
## Why

Today `/auth/sso` always redirects to `/#` after successful SSO authentication, which discards any URL hash the browser brought along. That makes deep-linking from an upstream portal into a specific Zammad ticket (e.g. `/#ticket/zoom/57`) effectively impossible — server redirects don't carry hash fragments, and modern browsers (Chromium 121+) block the cross-origin sub-resource cookie tricks that used to work around this. The remaining workaround (a JavaScript popup that establishes the session and a second top-level navigation in the original tab) is fragile and popup-blocker prone.

## What

Adds an optional `return_to` query parameter to `GET/POST /auth/sso`. When present and pointing to a safe relative path, it is used as the redirect target instead of the hardcoded `/#`.

## Security

`return_to` is validated as a strict same-origin relative path:

- Must start with a single `/`
- Must NOT start with `//` (protocol-relative URLs)
- Must NOT contain control characters or backslashes
- Must be at most 1024 chars

Anything that doesn't pass these checks falls back to the previous `/#` default — open-redirect attempts are silently ignored, not echoed back to the user. The validator lives in a small private helper (`safe_return_to_path`) so it can be unit-tested and reused if needed.

## Tests

New request specs in `spec/requests/session_spec.rb` cover:

- default behaviour (no `return_to` → `/#`)
- valid relative path with hash (`/#ticket/zoom/57`)
- preservation of URL fragments
- deeper relative paths without a fragment
- empty `return_to` falls back to default
- rejection of absolute http/https URLs
- rejection of protocol-relative URLs (`//evil.example.com`)
- rejection of `javascript:` and `data:` URLs
- rejection of backslashes and control characters
- rejection of paths longer than 1024 chars
- rejection of paths not starting with `/`

CI on the fork (full test suite, identical workflow as upstream) passes: [run 25288084186](https://github.com/MichaelUray/zammad/actions/runs/25288084186).

## Backwards compatibility

No callers are required to pass `return_to`. Existing integrations (which never set the parameter) continue to land on `/#` exactly as before.

## Use case

External SSO portal (Traefik ForwardAuth + REMOTE_USER) generates Zammad links pointing to specific tickets. Without `return_to`, the portal must use a fragile two-tab popup workaround to make deep-link navigation survive the SSO round-trip. With this change a single 302 to `/auth/sso?return_to=/%23ticket/zoom/<id>` is enough.