### PR TITLE
Fix: KB root category creation fails with 'Couldn't find KnowledgeBase::Category without an ID'

### DIFF
--- a/app/policies/controllers/knowledge_base/categories_controller_policy.rb
+++ b/app/policies/controllers/knowledge_base/categories_controller_policy.rb
@@ -29,7 +29,7 @@ class Controllers::KnowledgeBase::CategoriesControllerPolicy < Controllers::Know
 
   def verify_parent
     if record.params[:parent_id].blank?
-      parent = object.knowledge_base
+      parent = KnowledgeBase.find(record.params[:knowledge_base_id])
 
       return KnowledgeBasePolicy.new(user, parent).update?
     end


### PR DESCRIPTION
## Problem

Creating a root-level Knowledge Base category always fails with:

```
Couldn't find KnowledgeBase::Category without an ID
```

This affects the admin UI and the API. The KB becomes completely unusable for new installations since you can't create the first category.

## Root Cause

In `Controllers::KnowledgeBase::CategoriesControllerPolicy#verify_parent`, when `parent_id` is blank (root category), the code calls `object.knowledge_base` to look up the parent KB for authorization. But `object` is defined as:

```ruby
def object
  @object ||= record.klass.find(record.params[:id])
end
```

For a `create` action, `params[:id]` is `nil`, so `KnowledgeBase::Category.find(nil)` raises `ActiveRecord::RecordNotFound`.

The `object` method is correctly used by `show?`, `update?`, and `destroy?` (which all have `params[:id]`), but `create?` has no `params[:id]`.

## Fix

In `verify_parent`, when `parent_id` is blank, look up the `KnowledgeBase` directly from `params[:knowledge_base_id]` which is always present in the nested route (`/api/v1/knowledge_bases/:knowledge_base_id/categories`):

```ruby
# Before (buggy)
parent = object.knowledge_base

# After (fixed)
parent = KnowledgeBase.find(record.params[:knowledge_base_id])
```

## Testing

```bash
curl -X POST \
  -H "Authorization: Token token=<admin_token>" \
  -H "Content-Type: application/json" \
  -d '{"translations_attributes":[{"title":"General","kb_locale_id":1}],"category_icon":"f115"}' \
  https://<zammad>/api/v1/knowledge_bases/1/categories
```

Should return `201 Created` instead of `404 Couldn't find KnowledgeBase::Category without an ID`.

Closes #6148