### PR TITLE
Add separate permissions for accessing the i-doit, GitHub and GitLab integrations as an agent

### DIFF
--- a/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee
@@ -10,6 +10,7 @@ class App.SidebarGitIssue extends App.Controller
 
   sidebarItem: =>
     return if !@Config.get("#{@providerIdentifier}_integration")
+    return if !@permissionCheck("integration.#{@providerIdentifier}")
 
     isAgentTicketZoom   = (@ticket and @ticket.currentView() is 'agent')
     isAgentTicketCreate = (!@ticket and @taskKey and @taskKey.match('TicketCreateScreen-'))

--- a/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee
@@ -1,6 +1,7 @@
 class SidebarIdoit extends App.Controller
   sidebarItem: =>
     return if !@Config.get('idoit_integration')
+    return if !@permissionCheck('integration.idoit')
 
     isAgentTicketZoom   = (@ticket and @ticket.currentView() is 'agent')
     isAgentTicketCreate = (!@ticket and @taskKey and @taskKey.match('TicketCreateScreen-'))

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-github.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-github.spec.ts
@@ -27,7 +27,7 @@ import { mockTicketExternalReferencesIssueTrackerItemListQuery } from '../../gra
 
 describe('Ticket create GitHub links', () => {
   it('displays sidebar', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.github'])
 
     await mockApplicationConfig({
       github_integration: true,
@@ -56,7 +56,7 @@ describe('Ticket create GitHub links', () => {
   })
 
   it('hides sidebar when not available', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.github'])
 
     await mockApplicationConfig({
       github_integration: false,

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-gitlab.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-gitlab.spec.ts
@@ -27,7 +27,7 @@ import { mockTicketExternalReferencesIssueTrackerItemListQuery } from '../../gra
 
 describe('Ticket create - GitLab links', () => {
   it('displays sidebar', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.gitlab'])
 
     await mockApplicationConfig({
       gitlab_integration: true,
@@ -56,7 +56,7 @@ describe('Ticket create - GitLab links', () => {
   })
 
   it('hides sidebar when not available', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.gitlab'])
 
     await mockApplicationConfig({
       gitlab_integration: false,

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-idoit.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-idoit.spec.ts
@@ -26,7 +26,7 @@ describe('Ticket create i-doit links', () => {
         ui_task_mananger_max_task_count: 30,
         ui_ticket_create_available_types: ['phone-in', 'phone-out', 'email-out'],
       })
-      mockPermissions(['ticket.agent'])
+      mockPermissions(['ticket.agent', 'integration.idoit'])
       handleMockFormUpdaterQuery({
         pending_time: {
           show: false,
@@ -116,7 +116,7 @@ describe('Ticket create i-doit links', () => {
     mockApplicationConfig({
       idoit_integration: true,
     })
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.idoit'])
 
     const uid = getUuid()
     const view = await visitView(`/ticket/create/${uid}`)
@@ -127,7 +127,7 @@ describe('Ticket create i-doit links', () => {
   })
 
   it('hides i-doit integration when not available', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.idoit'])
 
     mockApplicationConfig({
       idoit_integration: false,

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-github.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-github.spec.ts
@@ -12,7 +12,7 @@ import { mockTicketExternalReferencesIssueTrackerItemListQuery } from '#desktop/
 
 describe('Ticket detail view - GitHub integration', () => {
   it('displays sidebar', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.github'])
 
     await mockApplicationConfig({
       github_integration: true,
@@ -30,7 +30,7 @@ describe('Ticket detail view - GitHub integration', () => {
   })
 
   it('hides sidebar when not available', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.github'])
 
     await mockApplicationConfig({
       github_integration: false,

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-gitlab.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-gitlab.spec.ts
@@ -12,7 +12,7 @@ import { mockTicketExternalReferencesIssueTrackerItemListQuery } from '#desktop/
 
 describe('Ticket detail view - GitLab integration', () => {
   it('displays sidebar', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.gitlab'])
 
     await mockApplicationConfig({
       gitlab_integration: true,
@@ -30,7 +30,7 @@ describe('Ticket detail view - GitLab integration', () => {
   })
 
   it('hides sidebar when not available', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.gitlab'])
 
     mockTicketExternalReferencesIssueTrackerItemListQuery({
       ticketExternalReferencesIssueTrackerItemList: [],
@@ -52,7 +52,7 @@ describe('Ticket detail view - GitLab integration', () => {
   })
 
   it('hides sidebar when Agent-Customer see a specific ticket as a customer', async () => {
-    mockPermissions(['ticket.agent', 'ticket.customer'])
+    mockPermissions(['ticket.agent', 'ticket.customer', 'integration.gitlab'])
 
     await mockApplicationConfig({
       gitlab_integration: true,

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-idoit.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-idoit.spec.ts
@@ -12,7 +12,7 @@ import { mockTicketExternalReferencesIdoitObjectListQuery } from '#desktop/pages
 
 describe('Ticket detail view i-doit integration', () => {
   it('displays i-doit integration', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.idoit'])
 
     await mockApplicationConfig({
       idoit_integration: true,
@@ -30,7 +30,7 @@ describe('Ticket detail view i-doit integration', () => {
   })
 
   it('hides i-doit integration when not available', async () => {
-    mockPermissions(['ticket.agent'])
+    mockPermissions(['ticket.agent', 'integration.idoit'])
 
     mockTicketExternalReferencesIdoitObjectListQuery({
       ticketExternalReferencesIdoitObjectList: [],

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/github.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/github.ts
@@ -10,7 +10,7 @@ import type { TicketSidebarPlugin } from './types.ts'
 export default <TicketSidebarPlugin>{
   title: __('GitHub'),
   component: TicketSidebarGitHub,
-  permissions: ['ticket.agent'],
+  permissions: ['integration.github'],
   screens: [TicketSidebarScreenType.TicketDetailView, TicketSidebarScreenType.TicketCreate],
   views: ['agent'],
   icon: 'github',

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/gitlab.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/gitlab.ts
@@ -10,7 +10,7 @@ import type { TicketSidebarPlugin } from './types.ts'
 export default <TicketSidebarPlugin>{
   title: __('GitLab'),
   component: TicketSidebarGitLab,
-  permissions: ['ticket.agent'],
+  permissions: ['integration.gitlab'],
   screens: [TicketSidebarScreenType.TicketDetailView, TicketSidebarScreenType.TicketCreate],
   views: ['agent'],
   icon: 'gitlab',

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/idoit.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/idoit.ts
@@ -10,7 +10,7 @@ import type { TicketSidebarPlugin } from './types.ts'
 export default <TicketSidebarPlugin>{
   title: __('i-doit'),
   component: TicketSidebarIdoit,
-  permissions: ['ticket.agent'],
+  permissions: ['integration.idoit'],
   screens: [TicketSidebarScreenType.TicketDetailView, TicketSidebarScreenType.TicketCreate],
   views: ['agent'],
   icon: 'i-doit-logo', // icon does not exist underlying cmp will use it as a base to get light and dark icon name

--- a/app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb
@@ -9,11 +9,8 @@ module Gql::Mutations
 
     field :idoit_objects, [Gql::Types::Ticket::ExternalReferences::IdoitObjectType], description: 'The added / resolved idoit objects'
 
+    requires_permission 'integration.idoit'
     requires_enabled_setting 'idoit_integration', error_message: __('i-doit integration is not enabled')
-
-    def authorized?(idoit_object_ids:, ticket: nil)
-      ticket.present? || context.current_user.permissions?('ticket.agent')
-    end
 
     def resolve(idoit_object_ids:, ticket: nil)
       results = []

--- a/app/graphql/gql/mutations/ticket/external_references/idoit_object_remove.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/idoit_object_remove.rb
@@ -9,6 +9,7 @@ module Gql::Mutations
 
     field :success, Boolean, description: 'Was the mutation successful?'
 
+    requires_permission 'integration.idoit'
     requires_enabled_setting 'idoit_integration', error_message: __('i-doit integration is not enabled')
 
     def resolve(idoit_object_id:, ticket: nil)

--- a/app/graphql/gql/mutations/ticket/external_references/issue_tracker_item_add.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/issue_tracker_item_add.rb
@@ -11,7 +11,7 @@ module Gql::Mutations
     field :issue_tracker_item, Gql::Types::Ticket::ExternalReferences::IssueTrackerItemType, description: 'The added issue tracker item'
 
     def authorized?(issue_tracker_link:, issue_tracker_type:, ticket: nil)
-      ticket.present? || context.current_user.permissions?('ticket.agent')
+      context.current_user.permissions?("integration.#{issue_tracker_type}")
     end
 
     def resolve(issue_tracker_link:, issue_tracker_type:, ticket: nil)

--- a/app/graphql/gql/mutations/ticket/external_references/issue_tracker_item_remove.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/issue_tracker_item_remove.rb
@@ -10,6 +10,10 @@ module Gql::Mutations
 
     field :success, Boolean, description: 'Was the mutation successful?'
 
+    def authorized?(ticket:, issue_tracker_link:, issue_tracker_type:)
+      context.current_user.permissions?("integration.#{issue_tracker_type}")
+    end
+
     def resolve(ticket:, issue_tracker_link:, issue_tracker_type:)
       ticket
         .preferences

--- a/app/graphql/gql/queries/autocomplete_search/idoit_object_types.rb
+++ b/app/graphql/gql/queries/autocomplete_search/idoit_object_types.rb
@@ -9,7 +9,7 @@ module Gql::Queries
 
     type [Gql::Types::AutocompleteSearch::EntryType], null: false
 
-    requires_permission 'ticket.agent'
+    requires_permission 'integration.idoit'
     requires_enabled_setting 'idoit_integration', error_message: __('i-doit integration is not enabled')
 
     def resolve(input:)

--- a/app/graphql/gql/queries/ticket/external_references/idoit_object_list.rb
+++ b/app/graphql/gql/queries/ticket/external_references/idoit_object_list.rb
@@ -9,7 +9,7 @@ module Gql::Queries
 
     type [Gql::Types::Ticket::ExternalReferences::IdoitObjectType], null: false
 
-    requires_permission 'ticket.agent'
+    requires_permission 'integration.idoit'
     requires_enabled_setting 'idoit_integration', error_message: __('i-doit integration is not enabled')
 
     def resolve(input:)

--- a/app/graphql/gql/queries/ticket/external_references/idoit_object_search.rb
+++ b/app/graphql/gql/queries/ticket/external_references/idoit_object_search.rb
@@ -11,7 +11,7 @@ module Gql::Queries
 
     type [Gql::Types::Ticket::ExternalReferences::IdoitObjectType], null: false
 
-    requires_permission 'ticket.agent'
+    requires_permission 'integration.idoit'
     requires_enabled_setting 'idoit_integration', error_message: __('i-doit integration is not enabled')
 
     def resolve(query: '', limit: 10, idoit_type_id: nil)

--- a/app/graphql/gql/queries/ticket/external_references/issue_tracker_item_list.rb
+++ b/app/graphql/gql/queries/ticket/external_references/issue_tracker_item_list.rb
@@ -10,7 +10,9 @@ module Gql::Queries
 
     type [Gql::Types::Ticket::ExternalReferences::IssueTrackerItemType], null: false
 
-    requires_permission 'ticket.agent'
+    def authorized?(issue_tracker_type:, input:)
+      context.current_user.permissions?("integration.#{issue_tracker_type}")
+    end
 
     def resolve(issue_tracker_type:, input:)
       if input.ticket.present?

--- a/app/policies/controllers/integration/github_controller_policy.rb
+++ b/app/policies/controllers/integration/github_controller_policy.rb
@@ -1,7 +1,7 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
 class Controllers::Integration::GitHubControllerPolicy < Controllers::ApplicationControllerPolicy
-  permit! %i[query update], to: 'ticket.agent'
+  permit! %i[query update], to: 'integration.github'
   permit! :verify, to: 'admin.integration.github'
-  default_permit!(['agent.integration.github', 'admin.integration.github'])
+  default_permit!(['integration.github', 'admin.integration.github'])
 end

--- a/app/policies/controllers/integration/gitlab_controller_policy.rb
+++ b/app/policies/controllers/integration/gitlab_controller_policy.rb
@@ -1,7 +1,7 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
 class Controllers::Integration::GitLabControllerPolicy < Controllers::ApplicationControllerPolicy
-  permit! %i[query update], to: 'ticket.agent'
+  permit! %i[query update], to: 'integration.gitlab'
   permit! :verify, to: 'admin.integration.gitlab'
-  default_permit!(['agent.integration.gitlab', 'admin.integration.gitlab'])
+  default_permit!(['integration.gitlab', 'admin.integration.gitlab'])
 end

--- a/app/policies/controllers/integration/idoit_controller_policy.rb
+++ b/app/policies/controllers/integration/idoit_controller_policy.rb
@@ -1,7 +1,7 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
 class Controllers::Integration::IdoitControllerPolicy < Controllers::ApplicationControllerPolicy
-  permit! %i[query update], to: 'ticket.agent'
+  permit! %i[query update], to: 'integration.idoit'
   permit! :verify, to: 'admin.integration.idoit'
-  default_permit!(['agent.integration.idoit', 'admin.integration.idoit'])
+  default_permit!(['integration.idoit', 'admin.integration.idoit'])
 end

--- a/db/migrate/20260528120000_add_integration_permissions.rb
+++ b/db/migrate/20260528120000_add_integration_permissions.rb
@@ -1,0 +1,57 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class AddIntegrationPermissions < ActiveRecord::Migration[8.0]
+  def up
+    # return if it's a new setup
+    return if !Setting.exists?(name: 'system_init_done')
+
+    add_permissions
+    grant_to_existing_agent_roles
+  end
+
+  def down
+    %w[
+      integration.idoit
+      integration.github
+      integration.gitlab
+      integration
+    ].each do |name|
+      Permission.find_by(name:)&.destroy
+    end
+  end
+
+  def add_permissions
+    Permission.create_if_not_exists(
+      name:        'integration',
+      label:       'Integration',
+      description: 'Access to third-party integrations in the ticket interface.',
+      preferences: {
+        prio:     1720,
+        disabled: true,
+      },
+    )
+    {
+      'integration.idoit'  => 'i-doit',
+      'integration.github' => 'GitHub',
+      'integration.gitlab' => 'GitLab',
+    }.each_with_index do |(name, label), index|
+      Permission.create_if_not_exists(
+        name:        name,
+        label:       label,
+        description: "Access the #{label} integration features.",
+        preferences: { prio: 1730 + (index * 10) },
+      )
+    end
+  end
+
+  # Preserve the existing behaviour: every role that can currently use the
+  #   integrations (i.e. holds 'ticket.agent') keeps access after the upgrade.
+  #   Admins can then revoke it per role as needed.
+  def grant_to_existing_agent_roles
+    Role.with_permissions('ticket.agent').each do |role|
+      role.permission_grant('integration.idoit')
+      role.permission_grant('integration.github')
+      role.permission_grant('integration.gitlab')
+    end
+  end
+end

--- a/db/seeds/permissions.rb
+++ b/db/seeds/permissions.rb
@@ -545,6 +545,33 @@ Permission.create_if_not_exists(
   },
   allow_signup: true,
 )
+Permission.create_if_not_exists(
+  name:        'integration',
+  label:       __('Integration'),
+  description: __('Access to third-party integrations in the ticket interface.'),
+  preferences: {
+    prio:     1720,
+    disabled: true,
+  },
+)
+Permission.create_if_not_exists(
+  name:        'integration.idoit',
+  label:       __('i-doit'),
+  description: __('Access the i-doit integration features.'),
+  preferences: { prio: 1730 }
+)
+Permission.create_if_not_exists(
+  name:        'integration.github',
+  label:       __('GitHub'),
+  description: __('Access the GitHub integration features.'),
+  preferences: { prio: 1740 }
+)
+Permission.create_if_not_exists(
+  name:        'integration.gitlab',
+  label:       __('GitLab'),
+  description: __('Access the GitLab integration features.'),
+  preferences: { prio: 1750 }
+)
 
 admin = Role.find_by(name: 'Admin')
 admin.permission_grant('user_preferences')
@@ -557,6 +584,9 @@ agent.permission_grant('user_preferences')
 agent.permission_grant('ticket.agent')
 agent.permission_grant('chat.agent')
 agent.permission_grant('cti.agent')
+agent.permission_grant('integration.idoit')
+agent.permission_grant('integration.github')
+agent.permission_grant('integration.gitlab')
 agent.permission_grant('knowledge_base.reader')
 
 customer = Role.find_by(name: 'Customer')

--- a/i18n/zammad.pot
+++ b/i18n/zammad.pot
@@ -882,12 +882,24 @@ msgstr ""
 msgid "Access denied"
 msgstr ""
 
+#: db/seeds/permissions.rb:566
+msgid "Access the GitHub integration features."
+msgstr ""
+
+#: db/seeds/permissions.rb:572
+msgid "Access the GitLab integration features."
+msgstr ""
+
 #: db/seeds/permissions.rb:360
 msgid "Access the agent chat features."
 msgstr ""
 
 #: db/seeds/permissions.rb:375
 msgid "Access the agent phone features."
+msgstr ""
+
+#: db/seeds/permissions.rb:560
+msgid "Access the i-doit integration features."
 msgstr ""
 
 #: db/seeds/permissions.rb:390
@@ -924,6 +936,10 @@ msgstr ""
 
 #: db/seeds/permissions.rb:409
 msgid "Access to the ticket interface."
+msgstr ""
+
+#: db/seeds/permissions.rb:551
+msgid "Access to third-party integrations in the ticket interface."
 msgstr ""
 
 #: app/assets/javascripts/app/views/whatsapp/account_cloud_api.jst.eco:19
@@ -3022,7 +3038,7 @@ msgstr ""
 msgid "Change Customer"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:17
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:18
 msgid "Change Objects"
 msgstr ""
 
@@ -4408,7 +4424,7 @@ msgstr ""
 
 #: app/assets/javascripts/app/controllers/ticket_zoom/attribute_bar.coffee:145
 #: app/frontend/apps/desktop/components/AiAgent/AiAgentPopoverWithTrigger.vue:27
-#: app/frontend/apps/desktop/components/Ticket/TicketListTable.vue:219
+#: app/frontend/apps/desktop/components/Ticket/TicketListTable.vue:220
 #: app/frontend/apps/mobile/components/Ticket/TicketItem.vue:35
 #: app/frontend/apps/mobile/pages/ticket/components/TicketDetailView/TicketViewersDialog.vue:41
 msgid "Currently processing this ticket…"
@@ -7796,6 +7812,7 @@ msgstr ""
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarExternalIssueTracker/useTicketExternalIssueTracker.ts:47
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/github.ts:11
 #: app/frontend/shared/composables/authentication/useThirdPartyAuthentication.ts:59
+#: db/seeds/permissions.rb:565
 #: db/seeds/settings.rb:1608
 msgid "GitHub"
 msgstr ""
@@ -7829,6 +7846,7 @@ msgstr ""
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarExternalIssueTracker/useTicketExternalIssueTracker.ts:48
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/gitlab.ts:11
 #: app/frontend/shared/composables/authentication/useThirdPartyAuthentication.ts:66
+#: db/seeds/permissions.rb:571
 #: db/seeds/settings.rb:1673
 msgid "GitLab"
 msgstr ""
@@ -8981,6 +8999,10 @@ msgstr ""
 msgid "Integer field"
 msgstr ""
 
+#: db/seeds/permissions.rb:266
+msgid "Integration"
+msgstr ""
+
 #: app/assets/javascripts/app/controllers/integrations.coffee:3
 #: db/seeds/permissions.rb:266
 msgid "Integrations"
@@ -9729,7 +9751,7 @@ msgstr ""
 msgid "Link already exists"
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:26
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:27
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarExternalIssueTracker/IssueTrackerLinkFlyout.vue:69
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarExternalIssueTracker/IssueTrackerList.vue:272
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarExternalIssueTracker/TicketSidebarGitHub/TicketSidebarGitHub.vue:70
@@ -9845,8 +9867,8 @@ msgstr ""
 #: app/assets/javascripts/app/controllers/knowledge_base/search_field_widget.coffee:103
 #: app/assets/javascripts/app/controllers/password_reset.coffee:92
 #: app/assets/javascripts/app/controllers/ssl_certificate.coffee:46
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:87
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:76
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:88
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:77
 #: app/assets/javascripts/app/controllers/widget/payload_example.coffee:34
 #: app/assets/javascripts/app/models/knowledge_base_answer_translation.coffee:61
 msgid "Loading failed."
@@ -11449,7 +11471,7 @@ msgstr ""
 msgid "No knowledge base locale configured."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:193
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:194
 msgid "No linked issues"
 msgstr ""
 
@@ -16883,11 +16905,11 @@ msgstr ""
 msgid "The identifier for a ticket, e.g. Ticket#, Call#, MyTicket#. The default is Ticket#."
 msgstr ""
 
-#: app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb:30
+#: app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb:27
 msgid "The idoit object could not be found."
 msgstr ""
 
-#: app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb:24
+#: app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb:21
 msgid "The idoit object is already present on the ticket."
 msgstr ""
 
@@ -16919,7 +16941,7 @@ msgstr ""
 msgid "The installed attachment plugin could not handle the request payload. Ensure that the correct attachment plugin is installed (ingest-attachment)."
 msgstr ""
 
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:79
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_git_issue.coffee:80
 msgid "The issue could not be saved."
 msgstr ""
 
@@ -16993,7 +17015,7 @@ msgstr ""
 #: app/assets/javascripts/app/controllers/_settings/area_ticket_number.coffee:134
 #: app/assets/javascripts/app/controllers/_settings/form.coffee:91
 #: app/assets/javascripts/app/controllers/object_manager.coffee:331
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:142
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:143
 #: app/assets/javascripts/app/controllers/user.coffee:235
 msgid "The object could not be updated."
 msgstr ""
@@ -21535,8 +21557,9 @@ msgid "https://example.com/?q=#{object.attribute_name} - use ticket, user or org
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/idoit_object_selector.coffee:5
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:13
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:14
 #: app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/idoit.ts:11
+#: db/seeds/permissions.rb:559
 msgid "i-doit"
 msgstr ""
 
@@ -21548,8 +21571,8 @@ msgstr ""
 msgid "i-doit integration"
 msgstr ""
 
-#: app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb:12
-#: app/graphql/gql/mutations/ticket/external_references/idoit_object_remove.rb:12
+#: app/graphql/gql/mutations/ticket/external_references/idoit_object_add.rb:13
+#: app/graphql/gql/mutations/ticket/external_references/idoit_object_remove.rb:13
 #: app/graphql/gql/queries/autocomplete_search/idoit_object_types.rb:13
 #: app/graphql/gql/queries/ticket/external_references/idoit_object_list.rb:13
 #: app/graphql/gql/queries/ticket/external_references/idoit_object_search.rb:15
@@ -21991,7 +22014,7 @@ msgid "no upcoming events"
 msgstr ""
 
 #: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_article_attachments.coffee:25
-#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:63
+#: app/assets/javascripts/app/controllers/ticket_zoom/sidebar_idoit.coffee:64
 #: app/assets/javascripts/app/controllers/ticket_zoom/time_unit.coffee:34
 #: app/assets/javascripts/app/views/channel/email_account_overview.jst.eco:140
 #: app/assets/javascripts/app/views/channel_account/list.jst.eco:110

--- a/spec/db/migrate/add_integration_permissions_spec.rb
+++ b/spec/db/migrate/add_integration_permissions_spec.rb
@@ -1,0 +1,26 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe AddIntegrationPermissions, type: :db_migration do
+  let(:integration_permissions) { %w[integration.idoit integration.github integration.gitlab] }
+  let!(:role)                   { create(:role, permission_names: %w[ticket.agent]) }
+
+  it 'creates the integration permissions' do
+    migrate
+    expect(Permission.where(name: ['integration', *integration_permissions]).count).to eq(4)
+  end
+
+  it 'grants the integration permissions to roles holding ticket.agent (preserving existing access)' do
+    expect { migrate }
+      .to change { role.reload.permissions.where(name: integration_permissions).count }
+      .from(0).to(integration_permissions.size)
+  end
+
+  it 'does not grant the integration permissions to roles without ticket.agent' do
+    customer_role = create(:role, permission_names: %w[ticket.customer])
+
+    expect { migrate }
+      .not_to change { customer_role.reload.permissions.where(name: integration_permissions).count }
+  end
+end

--- a/spec/graphql/gql/mutations/ticket/external_references/idoit_object_add_spec.rb
+++ b/spec/graphql/gql/mutations/ticket/external_references/idoit_object_add_spec.rb
@@ -104,6 +104,16 @@ RSpec.describe Gql::Mutations::Ticket::ExternalReferences::IdoitObjectAdd, type:
     end
   end
 
+  context 'with an agent without the i-doit permission', authenticated_as: :agent_without_permission do
+    let(:agent_without_permission) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])]) }
+    let(:variables)                { { idoitObjectIds: [26] } }
+
+    it 'raises an authorization error' do
+      gql.execute(mutation, variables: variables)
+      expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+    end
+  end
+
   context 'when unauthenticated' do
     before { gql.execute(mutation, variables:) }
 

--- a/spec/graphql/gql/mutations/ticket/external_references/idoit_object_remove_spec.rb
+++ b/spec/graphql/gql/mutations/ticket/external_references/idoit_object_remove_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe Gql::Mutations::Ticket::ExternalReferences::IdoitObjectRemove, ty
     end
   end
 
+  context 'with an agent without the i-doit permission', authenticated_as: :agent_without_permission do
+    let(:agent_without_permission) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])], groups: [ticket.group]) }
+
+    it 'raises an authorization error' do
+      gql.execute(mutation, variables: variables)
+      expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+    end
+  end
+
   context 'when unauthenticated' do
     before { gql.execute(mutation, variables:) }
 

--- a/spec/graphql/gql/mutations/ticket/external_references/issue_tracker_item_add_spec.rb
+++ b/spec/graphql/gql/mutations/ticket/external_references/issue_tracker_item_add_spec.rb
@@ -154,6 +154,16 @@ RSpec.describe Gql::Mutations::Ticket::ExternalReferences::IssueTrackerItemAdd, 
     end
   end
 
+  context 'with an agent without the GitHub permission', authenticated_as: :agent_without_permission do
+    let(:agent_without_permission) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])]) }
+    let(:variables)                { { issueTrackerType: issue_tracker_type, issueTrackerLink: issue_tracker_link } }
+
+    it 'raises an authorization error' do
+      gql.execute(mutation, variables: variables)
+      expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+    end
+  end
+
   context 'when unauthenticated' do
     before { gql.execute(mutation, variables:) }
 

--- a/spec/graphql/gql/mutations/ticket/external_references/issue_tracker_item_remove_spec.rb
+++ b/spec/graphql/gql/mutations/ticket/external_references/issue_tracker_item_remove_spec.rb
@@ -66,6 +66,15 @@ RSpec.describe Gql::Mutations::Ticket::ExternalReferences::IssueTrackerItemRemov
     end
   end
 
+  context 'with an agent without the GitHub permission', authenticated_as: :agent_without_permission do
+    let(:agent_without_permission) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])], groups: [ticket.group]) }
+
+    it 'raises an authorization error' do
+      gql.execute(mutation, variables:)
+      expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+    end
+  end
+
   context 'when unauthenticated' do
     before { gql.execute(mutation, variables:) }
 

--- a/spec/graphql/gql/queries/autocomplete_search/idoit_object_types_spec.rb
+++ b/spec/graphql/gql/queries/autocomplete_search/idoit_object_types_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe Gql::Queries::AutocompleteSearch::IdoitObjectTypes, authenticated
       end
     end
 
+    context 'without the i-doit permission', authenticated_as: :agent_without_permission do
+      let(:agent_without_permission) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])]) }
+
+      it 'raises an authorization error' do
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
     it_behaves_like 'graphql responds with error if unauthenticated'
   end
 end

--- a/spec/graphql/gql/queries/ticket/external_references/idoit_object_list_spec.rb
+++ b/spec/graphql/gql/queries/ticket/external_references/idoit_object_list_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe Gql::Queries::Ticket::ExternalReferences::IdoitObjectList, type: 
     end
   end
 
+  context 'with an agent without the i-doit permission', authenticated_as: :agent_without_permission do
+    let(:agent_without_permission) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])], groups: [ticket.group]) }
+
+    before do
+      Setting.set('idoit_integration', true)
+      gql.execute(query, variables: variables)
+    end
+
+    it 'raises an authorization error' do
+      expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+    end
+  end
+
   context 'when unauthenticated' do
     before do
       Setting.set('idoit_integration', true)

--- a/spec/graphql/gql/queries/ticket/external_references/idoit_object_search_spec.rb
+++ b/spec/graphql/gql/queries/ticket/external_references/idoit_object_search_spec.rb
@@ -105,6 +105,19 @@ RSpec.describe Gql::Queries::Ticket::ExternalReferences::IdoitObjectSearch, type
     end
   end
 
+  context 'with an agent without the i-doit permission', authenticated_as: :agent_without_permission do
+    let(:agent_without_permission) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])]) }
+
+    before do
+      Setting.set('idoit_integration', true)
+      gql.execute(query, variables: variables)
+    end
+
+    it 'raises an authorization error' do
+      expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+    end
+  end
+
   context 'when unauthenticated' do
     before do
       Setting.set('idoit_integration', true)

--- a/spec/graphql/gql/queries/ticket/external_references/issue_tracker_item_list_spec.rb
+++ b/spec/graphql/gql/queries/ticket/external_references/issue_tracker_item_list_spec.rb
@@ -141,6 +141,34 @@ RSpec.describe Gql::Queries::Ticket::ExternalReferences::IssueTrackerItemList, t
     end
   end
 
+  context 'with an agent permitted for only one integration type', authenticated_as: :agent_partial do
+    let(:agent_partial) { create(:agent, roles: [create(:role, permission_names: %w[ticket.agent integration.gitlab])], groups: [ticket.group]) }
+
+    context 'when requesting an integration the agent lacks permission for (GitHub)' do
+      let(:issue_tracker_type) { 'github' }
+
+      before { gql.execute(query, variables: variables) }
+
+      it 'raises an authorization error' do
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
+    context 'when requesting an integration the agent has permission for (GitLab)' do
+      let(:issue_tracker_type) { 'gitlab' }
+
+      before do
+        allow(Service::Ticket::ExternalReferences::IssueTracker::TicketList)
+          .to receive(:execute).and_return([])
+        gql.execute(query, variables: variables)
+      end
+
+      it 'does not raise an authorization error' do
+        expect(gql.result.data).to eq([])
+      end
+    end
+  end
+
   context 'when unauthenticated' do
     before do
       gql.execute(query, variables: variables)

--- a/spec/requests/integration/idoit_spec.rb
+++ b/spec/requests/integration/idoit_spec.rb
@@ -172,6 +172,15 @@ RSpec.describe 'Idoit', type: :request do
       expect(json_response['response']['result'][0]['cmdb_status_title']).to eq('in operation')
 
     end
+
+    it 'does forbid querying for agents without the i-doit permission' do
+      agent_without_permission = create(:agent, roles: [create(:role, permission_names: %w[ticket.agent])], groups: Group.all)
+
+      authenticated_as(agent_without_permission)
+      post '/api/v1/integration/idoit', params: { method: 'cmdb.object_types' }, as: :json
+
+      expect(response).to have_http_status(:forbidden)
+    end
   end
 
   describe 'SSL verification' do


### PR DESCRIPTION
<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
This PR adds separate permissions for accessing the i-doit, GitHub and GitLab integrations as an agent. Before, every agent always had access to them.

At our org, Zammad is used by multiple departments in agent roles but only some should have access to the i-doit integration. With this PR, this becomes possible.

**Warning**: While I manually verified the code changes and functionality, I want to point out that this PR was prepared with the help of LLMs.

## Changes

- Added 3 new permissions (integration.idoit, integration.github, integration.gitlab) in the backend (REST controller policies + GraphQL mutations/queries)
- Show/hide the integrations in the ticket sidebar in both the old Coffescript and new Vue frontend according to the new permissions
- Added migration to create the permissions and grant it to all existing agent roles (so the effective permissions on existing installations don't change after updating)
- Regenerated the translation catalog (zammad.pot)

## Tests

Added:
- new migration spec: verify permissions are created and granted to existing agents on upgrade
- New authorization cases on the endpoints (GraphQL and REST)

Updated:
- Existing frontend sidebar specs updated to require new permissions

Ran:
Backend (Rspec)
```
RAILS_ENV=test VITE_TEST_MODE=1 bundle exec rspec \
  spec/db/migrate/add_integration_permissions_spec.rb \
  spec/graphql/gql/mutations/ticket/external_references/ \
  spec/graphql/gql/queries/autocomplete_search/idoit_object_types_spec.rb \
  spec/graphql/gql/queries/ticket/external_references/ \
  spec/requests/integration/idoit_spec.rb
```

Frontend (Vitest)
```
pnpm test --run \
  app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-github.spec.ts \
  app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-gitlab.spec.ts \
  app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-idoit.spec.ts \
  app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-github.spec.ts \
  app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-gitlab.spec.ts \
  app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-idoit.spec.ts
```

rubocop
```
bundle exec rubocop $(git diff --name-only 86a22e48dc...HEAD -- '*.rb')
```

All tests pass. Behaviour was also manually tested.