### PR TITLE
Fix checklist template item order

### DIFF
--- a/app/models/checklist.rb
+++ b/app/models/checklist.rb
@@ -105,10 +105,12 @@ class Checklist < ApplicationModel
     ActiveRecord::Base.transaction do
       Checklist.create!(name: template.name, ticket:)
         .tap do |checklist|
-          sorted_item_ids = template
-            .items
-            .map { |elem| checklist.items.create!(text: elem.text, initial_clone: true) }
-            .pluck(:id)
+          sorted_item_ids = template.sorted_items.map do |template_item|
+            checklist.items.create!(
+              text:          template_item.text,
+              initial_clone: true,
+            ).id
+          end
 
           checklist.update! sorted_item_ids:
         end


### PR DESCRIPTION
## Description

When creating a checklist from a checklist template, the template items were copied via the raw `template.items` association.

This association does not guarantee the configured item order and may return items in database order. As a result, checklist items could be copied to tickets in the wrong order, even though `sorted_item_ids` contained the correct order.

This change uses `template.sorted_items` instead, so the configured checklist template order is preserved when creating a checklist from a template.

## Testing

Manually tested on a local Zammad instance:

* Verified that `template.items.pluck(:id)` returned the unsorted database order.
* Verified that `template.sorted_item_ids` contained the expected item order.
* Verified that `template.sorted_items.pluck(:id)` returned the correct order.
* Created a checklist from the template and confirmed that the checklist items were copied to the ticket in the expected order.

## Issue reference

No existing issue found for this specific problem.

## Notes

The pull request targets the `develop` branch.
