### PR TITLE
Feature: Ticket approval workflow

### DIFF
--- a/app/models/core_workflow/attributes/user.rb
+++ b/app/models/core_workflow/attributes/user.rb
@@ -9,7 +9,45 @@ class CoreWorkflow::Attributes::User < CoreWorkflow::Attributes::Base
       return ticket_owner_id
     end
 
+    if @attribute[:name] == 'approver' && @attributes.payload['class_name'] == 'Ticket'
+      return ticket_approver_ids
+    end
+
     []
+  end
+
+  # Approvers are limited to active members of the ticket requester's
+  # organization, so an employee can only request approval from someone within
+  # their own organization.
+  def ticket_approver_ids
+    organization = ticket_approver_organization
+    return [''] if organization.blank?
+
+    user_ids = organization.members.where(active: true).each_with_object([]) do |user, result|
+      result << user.id
+      assets(user)
+    end
+
+    return [''] if user_ids.blank?
+
+    user_ids
+  end
+
+  def ticket_approver_organization
+    requester = ticket_approver_requester
+    requester&.organization
+  end
+
+  def ticket_approver_requester
+    params = @attributes.payload['params'] || {}
+
+    if params['customer_id'].present? && @attributes.user.permissions?('ticket.agent')
+      User.find_by(id: params['customer_id'])
+    elsif !@attributes.user.permissions?('ticket.agent') && @attributes.user.permissions?('ticket.customer')
+      @attributes.user
+    else
+      @attributes.selected&.customer
+    end
   end
 
   def group_agent_user_ids(group_id)

--- a/app/models/core_workflow/custom/ticket_approval_state.rb
+++ b/app/models/core_workflow/custom/ticket_approval_state.rb
@@ -1,0 +1,56 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+# Controls who may change the ticket "approval_state" field.
+#
+# Agents can always change it. A customer may only change it when they are the
+# ticket's assigned approver; for everybody else the field is read-only. This
+# keeps the approval decision in the hands of the requested approver (or an
+# agent) without exposing it to other organization members who can see the
+# shared ticket.
+class CoreWorkflow::Custom::TicketApprovalState < CoreWorkflow::Custom::Backend
+  APPROVAL_STATE_FIELD = 'approval_state'.freeze
+  APPROVER_FIELD       = 'approver'.freeze
+
+  def saved_attribute_match?
+    object?(Ticket)
+  end
+
+  def selected_attribute_match?
+    object?(Ticket)
+  end
+
+  def perform
+    return if !approval_state_attribute?
+
+    # Agents keep full control over the approval state.
+    return if current_user.permissions?('ticket.agent')
+
+    return if current_user_is_approver?
+
+    result('set_readonly', APPROVAL_STATE_FIELD)
+  end
+
+  private
+
+  def approval_state_attribute?
+    ObjectManager::Attribute.exists?(
+      object_lookup_id: ObjectLookup.by_name('Ticket'),
+      name:             APPROVAL_STATE_FIELD,
+      active:           true,
+    )
+  end
+
+  def current_user_is_approver?
+    approver_id.present? && approver_id.to_s == current_user.id.to_s
+  end
+
+  # The currently effective approver: a value being set in the form takes
+  # precedence over the value saved on the ticket.
+  def approver_id
+    if params.present? && params.key?(APPROVER_FIELD)
+      params[APPROVER_FIELD]
+    else
+      saved&.public_send(APPROVER_FIELD)
+    end
+  end
+end

--- a/app/models/ticket/perform_changes/action/notification_email.rb
+++ b/app/models/ticket/perform_changes/action/notification_email.rb
@@ -239,6 +239,8 @@ class Ticket::PerformChanges::Action::NotificationEmail < Ticket::PerformChanges
 
       Rails.logger.warn "Can't find configured #{origin} Email recipient User with ID '#{$1}'"
       nil
+    when %r{\Aticket_custom_field_(.+)\z}
+      recipients_by_type_custom_field($1)
     else
       Rails.logger.error "Unknown email notification recipient '#{recipient_type}'"
       nil
@@ -261,6 +263,24 @@ class Ticket::PerformChanges::Action::NotificationEmail < Ticket::PerformChanges
 
   def recipients_by_type_user_group_access
     User.group_access(record.group_id, 'full').sort_by(&:login).map(&:email)
+  end
+
+  # Resolves the email address of the user referenced by a ticket custom field
+  # (e.g. an "approving lead" user attribute). This allows triggers to notify a
+  # per-ticket chosen user, such as the lead who has to approve a hardware or
+  # access request, instead of a statically configured recipient.
+  def recipients_by_type_custom_field(attribute_name)
+    return nil if attribute_name.blank?
+    return nil if !record.respond_to?(attribute_name)
+
+    user_id = record.public_send(attribute_name)
+    return nil if user_id.blank?
+
+    Array(user_id).filter_map do |id|
+      next if !User.exists?(id)
+
+      user_lookup_email(id)
+    end
   end
 
   def user_lookup_email(id)

--- a/app/models/ticket/perform_changes/action/notification_email.rb
+++ b/app/models/ticket/perform_changes/action/notification_email.rb
@@ -265,18 +265,22 @@ class Ticket::PerformChanges::Action::NotificationEmail < Ticket::PerformChanges
     User.group_access(record.group_id, 'full').sort_by(&:login).map(&:email)
   end
 
-  # Resolves the email address of the user referenced by a ticket custom field
-  # (e.g. an "approver" user attribute). This allows triggers to notify a
+  # Resolves the email address(es) of the user(s) referenced by a ticket custom
+  # field (e.g. an "approver" user attribute). This allows triggers to notify a
   # per-ticket chosen user, such as the approver who has to approve a hardware or
   # access request, instead of a statically configured recipient.
+  #
+  # Only real database columns are read (via `record[...]`, which never invokes
+  # methods), so an arbitrary/mistyped recipient configuration can never trigger
+  # an unrelated (potentially destructive) model method.
   def recipients_by_type_custom_field(attribute_name)
     return nil if attribute_name.blank?
-    return nil if !record.respond_to?(attribute_name)
+    return nil if record.class.column_names.exclude?(attribute_name)
 
-    user_id = record.public_send(attribute_name)
-    return nil if user_id.blank?
+    user_ids = record[attribute_name]
+    return nil if user_ids.blank?
 
-    Array(user_id).filter_map do |id|
+    Array(user_ids).filter_map do |id|
       next if !User.exists?(id)
 
       user_lookup_email(id)

--- a/app/models/ticket/perform_changes/action/notification_email.rb
+++ b/app/models/ticket/perform_changes/action/notification_email.rb
@@ -266,8 +266,8 @@ class Ticket::PerformChanges::Action::NotificationEmail < Ticket::PerformChanges
   end
 
   # Resolves the email address of the user referenced by a ticket custom field
-  # (e.g. an "approving lead" user attribute). This allows triggers to notify a
-  # per-ticket chosen user, such as the lead who has to approve a hardware or
+  # (e.g. an "approver" user attribute). This allows triggers to notify a
+  # per-ticket chosen user, such as the approver who has to approve a hardware or
   # access request, instead of a statically configured recipient.
   def recipients_by_type_custom_field(attribute_name)
     return nil if attribute_name.blank?

--- a/db/migrate/20120101000010_create_ticket.rb
+++ b/db/migrate/20120101000010_create_ticket.rb
@@ -83,6 +83,8 @@ class CreateTicket < ActiveRecord::Migration[4.2]
       t.column :escalation_at,                    :timestamp, limit: 3,   null: true
       t.column :pending_time,                     :timestamp, limit: 3,   null: true
       t.column :type,                             :string,    limit: 100, null: true
+      t.column :approver,                         :integer,               null: true
+      t.column :approval_state,                   :string,    limit: 100, null: true
       t.column :time_unit,                        :decimal, precision: 6, scale: 2, null: true
       t.column :preferences,                      :text, limit: 500.kilobytes + 1, null: true
       t.column :ai_agent_running,                 :boolean, default: false, null: false

--- a/db/migrate/20120101000010_create_ticket.rb
+++ b/db/migrate/20120101000010_create_ticket.rb
@@ -83,7 +83,7 @@ class CreateTicket < ActiveRecord::Migration[4.2]
       t.column :escalation_at,                    :timestamp, limit: 3,   null: true
       t.column :pending_time,                     :timestamp, limit: 3,   null: true
       t.column :type,                             :string,    limit: 100, null: true
-      t.column :approver,                         :integer,               null: true
+      t.column :approver,                         :string,    limit: 100, null: true
       t.column :approval_state,                   :string,    limit: 100, null: true
       t.column :time_unit,                        :decimal, precision: 6, scale: 2, null: true
       t.column :preferences,                      :text, limit: 500.kilobytes + 1, null: true

--- a/db/migrate/20260725000000_add_ticket_approval_attributes.rb
+++ b/db/migrate/20260725000000_add_ticket_approval_attributes.rb
@@ -8,11 +8,13 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
     UserInfo.current_user_id = 1
 
     create_columns
+    activate_type_attribute
     add_approver_attribute
     add_approval_state_attribute
     add_approval_trigger
     add_approval_state_note_trigger
     add_approval_state_workflow
+    add_approval_type_workflow
     add_waiting_for_approval_overview
   end
 
@@ -25,6 +27,56 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
     end
 
     Ticket.reset_column_information
+  end
+
+  # Activate the built-in ticket "type" field and add an "Approval Request"
+  # option. The approval fields are only shown for this type (see
+  # add_approval_type_workflow). Existing installs may have customized this
+  # attribute, so only add the option if it is missing and keep other options.
+  def activate_type_attribute
+    existing = ObjectManager::Attribute.get(object: 'Ticket', name: 'type')
+    options  = existing&.data_option&.dig(:options) || existing&.data_option&.dig('options') || {
+      'Incident'           => 'Incident',
+      'Problem'            => 'Problem',
+      'Request for Change' => 'Request for Change',
+    }
+    options = options.merge('Approval Request' => 'Approval Request')
+
+    ObjectManager::Attribute.add(
+      force:       true,
+      object:      'Ticket',
+      name:        'type',
+      display:     'Type',
+      data_type:   'select',
+      data_option: {
+        default:    '',
+        options:    options,
+        nulloption: true,
+        multiple:   false,
+        null:       true,
+        translate:  true,
+      },
+      editable:    true,
+      internal:    false,
+      active:      true,
+      screens:     {
+        create_middle: {
+          '-all-' => {
+            null:       false,
+            item_class: 'column',
+          },
+        },
+        edit:          {
+          'ticket.agent' => {
+            null: false,
+          },
+        },
+      },
+      to_create:   false,
+      to_migrate:  false,
+      to_delete:   false,
+      position:    20,
+    )
   end
 
   def add_approver_attribute
@@ -48,12 +100,14 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
       screens:     {
         create_middle: {
           '-all-' => {
-            null: true,
+            null:  true,
+            shown: false,
           },
         },
         edit:          {
           '-all-' => {
-            null: true,
+            null:  true,
+            shown: false,
           },
         },
       },
@@ -90,12 +144,14 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
       screens:     {
         create_middle: {
           'ticket.agent' => {
-            null: true,
+            null:  true,
+            shown: false,
           },
         },
         edit:          {
           '-all-' => {
-            null: true,
+            null:  true,
+            shown: false,
           },
         },
       },
@@ -199,6 +255,36 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
     )
   end
 
+  def add_approval_type_workflow
+    CoreWorkflow.create_if_not_exists(
+      name:               'base - show ticket approval fields for approval request type',
+      object:             'Ticket',
+      condition_saved:    {},
+      condition_selected: {
+        'ticket.type' => {
+          'operator' => 'is',
+          'value'    => ['Approval Request'],
+        },
+      },
+      perform:            {
+        'ticket.approver'       => {
+          'operator' => 'show',
+          'show'     => 'true',
+        },
+        'ticket.approval_state' => {
+          'operator' => 'show',
+          'show'     => 'true',
+        },
+      },
+      preferences:        {
+        'screen' => %w[create create_top create_middle create_bottom edit],
+      },
+      changeable:         false,
+      created_by_id:      1,
+      updated_by_id:      1,
+    )
+  end
+
   def add_waiting_for_approval_overview
     role = Role.find_by(name: 'Customer')
     return if role.blank?
@@ -212,6 +298,10 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
         'ticket.state_id'       => {
           operator: 'is',
           value:    Ticket::State.by_category_ids(:viewable),
+        },
+        'ticket.type'           => {
+          operator: 'is',
+          value:    ['Approval Request'],
         },
         'ticket.approver'       => {
           operator:      'is',

--- a/db/migrate/20260725000000_add_ticket_approval_attributes.rb
+++ b/db/migrate/20260725000000_add_ticket_approval_attributes.rb
@@ -7,6 +7,7 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
 
     UserInfo.current_user_id = 1
 
+    create_columns
     add_approver_attribute
     add_approval_state_attribute
     add_approval_trigger
@@ -14,12 +15,21 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
 
   private
 
+  def create_columns
+    change_table :tickets, bulk: true do |t|
+      t.column :approver,       :integer,             null: true if !column_exists?(:tickets, :approver)
+      t.column :approval_state, :string, limit: 100,  null: true if !column_exists?(:tickets, :approval_state)
+    end
+
+    Ticket.reset_column_information
+  end
+
   def add_approver_attribute
     ObjectManager::Attribute.add(
       force:       true,
       object:      'Ticket',
       name:        'approver',
-      display:     __('Approver'),
+      display:     'Approver',
       data_type:   'user_autocompletion',
       data_option: {
         relation:       'User',
@@ -28,7 +38,7 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
         guess:          false,
         null:           true,
         limit:          200,
-        placeholder:    __('Enter the approver who should approve this request'),
+        placeholder:    'Enter the approver who should approve this request',
         minLengt:       2,
         translate:      false,
         permission:     ['ticket.agent', 'ticket.customer'],
@@ -59,15 +69,15 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
       force:       true,
       object:      'Ticket',
       name:        'approval_state',
-      display:     __('Approval State'),
+      display:     'Approval State',
       data_type:   'select',
       data_option: {
         default:    'not_requested',
         options:    {
-          'not_requested' => __('Not requested'),
-          'pending'       => __('Pending approval'),
-          'approved'      => __('Approved'),
-          'rejected'      => __('Rejected'),
+          'not_requested' => 'Not requested',
+          'pending'       => 'Pending approval',
+          'approved'      => 'Approved',
+          'rejected'      => 'Rejected',
         },
         nulloption: false,
         multiple:   false,

--- a/db/migrate/20260725000000_add_ticket_approval_attributes.rb
+++ b/db/migrate/20260725000000_add_ticket_approval_attributes.rb
@@ -11,13 +11,16 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
     add_approver_attribute
     add_approval_state_attribute
     add_approval_trigger
+    add_approval_state_note_trigger
+    add_approval_state_workflow
+    add_waiting_for_approval_overview
   end
 
   private
 
   def create_columns
     change_table :tickets, bulk: true do |t|
-      t.column :approver,       :integer,             null: true if !column_exists?(:tickets, :approver)
+      t.column :approver,       :string, limit: 100,  null: true if !column_exists?(:tickets, :approver)
       t.column :approval_state, :string, limit: 100,  null: true if !column_exists?(:tickets, :approval_state)
     end
 
@@ -30,18 +33,15 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
       object:      'Ticket',
       name:        'approver',
       display:     'Approver',
-      data_type:   'user_autocompletion',
+      data_type:   'select',
       data_option: {
-        relation:       'User',
-        autocapitalize: false,
-        multiple:       false,
-        guess:          false,
-        null:           true,
-        limit:          200,
-        placeholder:    'Enter the approver who should approve this request',
-        minLengt:       2,
-        translate:      false,
-        permission:     ['ticket.agent', 'ticket.customer'],
+        default:    '',
+        relation:   'User',
+        nulloption: true,
+        multiple:   false,
+        null:       true,
+        translate:  false,
+        permission: ['ticket.agent', 'ticket.customer'],
       },
       editable:    true,
       active:      true,
@@ -83,17 +83,18 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
         multiple:   false,
         null:       true,
         translate:  true,
+        permission: ['ticket.agent', 'ticket.customer'],
       },
       editable:    true,
       active:      true,
       screens:     {
         create_middle: {
-          '-all-' => {
+          'ticket.agent' => {
             null: true,
           },
         },
         edit:          {
-          'ticket.agent' => {
+          '-all-' => {
             null: true,
           },
         },
@@ -143,6 +144,97 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
       active:                   true,
       created_by_id:            1,
       updated_by_id:            1,
+    )
+  end
+
+  def add_approval_state_note_trigger
+    Trigger.create_or_update(
+      name:                     'approval decision (add note to timeline)',
+      condition:                {
+        'ticket.action'         => {
+          'operator' => 'is',
+          'value'    => 'update',
+        },
+        'ticket.approval_state' => {
+          'operator' => 'has changed',
+        },
+      },
+      perform:                  {
+        'article.note' => {
+          # rubocop:disable Lint/InterpolationCheck
+          'subject'  => 'Approval state changed',
+          'body'     => 'The approval state was changed to <b>#{ticket.approval_state}</b> by #{user.firstname} #{user.lastname}.',
+          # rubocop:enable Lint/InterpolationCheck
+          'internal' => 'false',
+        },
+      },
+      activator:                'action',
+      execution_condition_mode: 'selective',
+      active:                   true,
+      created_by_id:            1,
+      updated_by_id:            1,
+    )
+  end
+
+  def add_approval_state_workflow
+    CoreWorkflow.create_if_not_exists(
+      name:            'base - restrict ticket approval state to approver',
+      object:          'Ticket',
+      condition_saved: {
+        'custom.module': {
+          operator: 'match all modules',
+          value:    [
+            'CoreWorkflow::Custom::TicketApprovalState',
+          ],
+        },
+      },
+      perform:         {
+        'custom.module': {
+          execute: ['CoreWorkflow::Custom::TicketApprovalState']
+        },
+      },
+      changeable:      false,
+      created_by_id:   1,
+      updated_by_id:   1,
+    )
+  end
+
+  def add_waiting_for_approval_overview
+    role = Role.find_by(name: 'Customer')
+    return if role.blank?
+
+    Overview.create_if_not_exists(
+      name:          'Waiting for my Approval',
+      link:          'waiting_for_my_approval',
+      prio:          1150,
+      role_ids:      [role.id],
+      condition:     {
+        'ticket.state_id'       => {
+          operator: 'is',
+          value:    Ticket::State.by_category_ids(:viewable),
+        },
+        'ticket.approver'       => {
+          operator:      'is',
+          pre_condition: 'current_user.id',
+          value:         '',
+        },
+        'ticket.approval_state' => {
+          operator: 'is',
+          value:    'pending',
+        },
+      },
+      order:         {
+        by:        'created_at',
+        direction: 'DESC',
+      },
+      view:          {
+        d:                 %w[title customer state created_at],
+        s:                 %w[number title state created_at],
+        m:                 %w[number title state created_at],
+        view_mode_default: 's',
+      },
+      created_by_id: 1,
+      updated_by_id: 1,
     )
   end
 end

--- a/db/migrate/20260725000000_add_ticket_approval_attributes.rb
+++ b/db/migrate/20260725000000_add_ticket_approval_attributes.rb
@@ -18,7 +18,7 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
     ObjectManager::Attribute.add(
       force:       true,
       object:      'Ticket',
-      name:        'approver_id',
+      name:        'approver',
       display:     __('Approver'),
       data_type:   'user_autocompletion',
       data_option: {
@@ -99,12 +99,14 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
     Trigger.create_or_update(
       name:                     'approval request (notify approver)',
       condition:                {
-        'ticket.action'      => {
+        'ticket.action'   => {
           'operator' => 'is',
           'value'    => 'create',
         },
-        'ticket.approver_id' => {
-          'operator' => 'is set',
+        'ticket.approver' => {
+          'operator'      => 'is not',
+          'pre_condition' => 'not_set',
+          'value'         => '',
         },
       },
       perform:                  {
@@ -122,7 +124,7 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
 <br/>
 <div>Your #{config.product_name} Team</div>',
           # rubocop:enable Lint/InterpolationCheck
-          'recipient' => 'ticket_custom_field_approver_id',
+          'recipient' => 'ticket_custom_field_approver',
           'subject'   => 'Approval requested for #{ticket.title}', # rubocop:disable Lint/InterpolationCheck
         },
       },

--- a/db/migrate/20260725000000_add_ticket_approval_attributes.rb
+++ b/db/migrate/20260725000000_add_ticket_approval_attributes.rb
@@ -1,0 +1,136 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
+  def change
+    # return if it's a new setup
+    return if !Setting.exists?(name: 'system_init_done')
+
+    UserInfo.current_user_id = 1
+
+    add_approving_lead_attribute
+    add_approval_state_attribute
+    add_approval_trigger
+  end
+
+  private
+
+  def add_approving_lead_attribute
+    ObjectManager::Attribute.add(
+      force:       true,
+      object:      'Ticket',
+      name:        'approving_lead_id',
+      display:     __('Approving Lead'),
+      data_type:   'user_autocompletion',
+      data_option: {
+        relation:       'User',
+        autocapitalize: false,
+        multiple:       false,
+        guess:          false,
+        null:           true,
+        limit:          200,
+        placeholder:    __('Enter the lead who should approve this request'),
+        minLengt:       2,
+        translate:      false,
+        permission:     ['ticket.agent', 'ticket.customer'],
+      },
+      editable:    true,
+      active:      true,
+      screens:     {
+        create_middle: {
+          '-all-' => {
+            null: true,
+          },
+        },
+        edit:          {
+          '-all-' => {
+            null: true,
+          },
+        },
+      },
+      to_create:   false,
+      to_migrate:  false,
+      to_delete:   false,
+      position:    1500,
+    )
+  end
+
+  def add_approval_state_attribute
+    ObjectManager::Attribute.add(
+      force:       true,
+      object:      'Ticket',
+      name:        'approval_state',
+      display:     __('Approval State'),
+      data_type:   'select',
+      data_option: {
+        default:    'not_requested',
+        options:    {
+          'not_requested' => __('Not requested'),
+          'pending'       => __('Pending approval'),
+          'approved'      => __('Approved'),
+          'rejected'      => __('Rejected'),
+        },
+        nulloption: false,
+        multiple:   false,
+        null:       true,
+        translate:  true,
+      },
+      editable:    true,
+      active:      true,
+      screens:     {
+        create_middle: {
+          '-all-' => {
+            null: true,
+          },
+        },
+        edit:          {
+          'ticket.agent' => {
+            null: true,
+          },
+        },
+      },
+      to_create:   false,
+      to_migrate:  false,
+      to_delete:   false,
+      position:    1510,
+    )
+  end
+
+  def add_approval_trigger
+    Trigger.create_or_update(
+      name:                     'approval request (notify approving lead)',
+      condition:                {
+        'ticket.action'             => {
+          'operator' => 'is',
+          'value'    => 'create',
+        },
+        'ticket.approving_lead_id'  => {
+          'operator' => 'is set',
+        },
+      },
+      perform:                  {
+        'notification.email' => {
+          # rubocop:disable Lint/InterpolationCheck
+          'body'      => '<div>Hello,</div>
+<br/>
+<div>#{ticket.customer.firstname} #{ticket.customer.lastname} has created the request <b>(#{config.ticket_hook}#{ticket.number})</b> and asks for your approval.</div>
+<br/>
+<div>Subject: #{ticket.title}</div>
+<br/>
+<div>Please review the request and approve or reject it here:
+<a href="#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}">#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}</a>
+</div>
+<br/>
+<div>Your #{config.product_name} Team</div>',
+          # rubocop:enable Lint/InterpolationCheck
+          'recipient' => 'ticket_custom_field_approving_lead_id',
+          'subject'   => 'Approval requested for #{ticket.title}', # rubocop:disable Lint/InterpolationCheck
+        },
+      },
+      activator:                'action',
+      execution_condition_mode: 'selective',
+      active:                   true,
+      created_by_id:            1,
+      updated_by_id:            1,
+    )
+  end
+end

--- a/db/migrate/20260725000000_add_ticket_approval_attributes.rb
+++ b/db/migrate/20260725000000_add_ticket_approval_attributes.rb
@@ -7,19 +7,19 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
 
     UserInfo.current_user_id = 1
 
-    add_approving_lead_attribute
+    add_approver_attribute
     add_approval_state_attribute
     add_approval_trigger
   end
 
   private
 
-  def add_approving_lead_attribute
+  def add_approver_attribute
     ObjectManager::Attribute.add(
       force:       true,
       object:      'Ticket',
-      name:        'approving_lead_id',
-      display:     __('Approving Lead'),
+      name:        'approver_id',
+      display:     __('Approver'),
       data_type:   'user_autocompletion',
       data_option: {
         relation:       'User',
@@ -28,7 +28,7 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
         guess:          false,
         null:           true,
         limit:          200,
-        placeholder:    __('Enter the lead who should approve this request'),
+        placeholder:    __('Enter the approver who should approve this request'),
         minLengt:       2,
         translate:      false,
         permission:     ['ticket.agent', 'ticket.customer'],
@@ -97,13 +97,13 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
 
   def add_approval_trigger
     Trigger.create_or_update(
-      name:                     'approval request (notify approving lead)',
+      name:                     'approval request (notify approver)',
       condition:                {
-        'ticket.action'             => {
+        'ticket.action'      => {
           'operator' => 'is',
           'value'    => 'create',
         },
-        'ticket.approving_lead_id'  => {
+        'ticket.approver_id' => {
           'operator' => 'is set',
         },
       },
@@ -122,7 +122,7 @@ class AddTicketApprovalAttributes < ActiveRecord::Migration[8.0]
 <br/>
 <div>Your #{config.product_name} Team</div>',
           # rubocop:enable Lint/InterpolationCheck
-          'recipient' => 'ticket_custom_field_approving_lead_id',
+          'recipient' => 'ticket_custom_field_approver_id',
           'subject'   => 'Approval requested for #{ticket.title}', # rubocop:disable Lint/InterpolationCheck
         },
       },

--- a/db/seeds/core_workflow.rb
+++ b/db/seeds/core_workflow.rb
@@ -191,3 +191,23 @@ CoreWorkflow.create_if_not_exists(
   created_by_id:   1,
   updated_by_id:   1,
 )
+CoreWorkflow.create_if_not_exists(
+  name:            'base - restrict ticket approval state to approver',
+  object:          'Ticket',
+  condition_saved: {
+    'custom.module': {
+      operator: 'match all modules',
+      value:    [
+        'CoreWorkflow::Custom::TicketApprovalState',
+      ],
+    },
+  },
+  perform:         {
+    'custom.module': {
+      execute: ['CoreWorkflow::Custom::TicketApprovalState']
+    },
+  },
+  changeable:      false,
+  created_by_id:   1,
+  updated_by_id:   1,
+)

--- a/db/seeds/core_workflow.rb
+++ b/db/seeds/core_workflow.rb
@@ -211,3 +211,30 @@ CoreWorkflow.create_if_not_exists(
   created_by_id:   1,
   updated_by_id:   1,
 )
+CoreWorkflow.create_if_not_exists(
+  name:               'base - show ticket approval fields for approval request type',
+  object:             'Ticket',
+  condition_saved:    {},
+  condition_selected: {
+    'ticket.type' => {
+      'operator' => 'is',
+      'value'    => ['Approval Request'], # rubocop:disable Zammad/DetectTranslatableString
+    },
+  },
+  perform:            {
+    'ticket.approver'       => {
+      'operator' => 'show',
+      'show'     => 'true',
+    },
+    'ticket.approval_state' => {
+      'operator' => 'show',
+      'show'     => 'true',
+    },
+  },
+  preferences:        {
+    'screen' => %w[create create_top create_middle create_bottom edit],
+  },
+  changeable:         false,
+  created_by_id:      1,
+  updated_by_id:      1,
+)

--- a/db/seeds/object_manager_attributes.rb
+++ b/db/seeds/object_manager_attributes.rb
@@ -30,7 +30,7 @@ ObjectManager::Attribute.add(
 ObjectManager::Attribute.add(
   force:       true,
   object:      'Ticket',
-  name:        'approver_id',
+  name:        'approver',
   display:     __('Approver'),
   data_type:   'user_autocompletion',
   data_option: {

--- a/db/seeds/object_manager_attributes.rb
+++ b/db/seeds/object_manager_attributes.rb
@@ -32,18 +32,15 @@ ObjectManager::Attribute.add(
   object:      'Ticket',
   name:        'approver',
   display:     __('Approver'),
-  data_type:   'user_autocompletion',
+  data_type:   'select',
   data_option: {
-    relation:       'User',
-    autocapitalize: false,
-    multiple:       false,
-    guess:          false,
-    null:           true,
-    limit:          200,
-    placeholder:    __('Enter the approver who should approve this request'),
-    minLengt:       2,
-    translate:      false,
-    permission:     ['ticket.agent', 'ticket.customer'],
+    default:    '',
+    relation:   'User',
+    nulloption: true,
+    multiple:   false,
+    null:       true,
+    translate:  false,
+    permission: ['ticket.agent', 'ticket.customer'],
   },
   editable:    true,
   active:      true,
@@ -83,17 +80,18 @@ ObjectManager::Attribute.add(
     multiple:   false,
     null:       true,
     translate:  true,
+    permission: ['ticket.agent', 'ticket.customer'],
   },
   editable:    true,
   active:      true,
   screens:     {
     create_middle: {
-      '-all-' => {
+      'ticket.agent' => {
         null: true,
       },
     },
     edit:          {
-      'ticket.agent' => {
+      '-all-' => {
         null: true,
       },
     },

--- a/db/seeds/object_manager_attributes.rb
+++ b/db/seeds/object_manager_attributes.rb
@@ -24,7 +24,84 @@ ObjectManager::Attribute.add(
   to_create:   false,
   to_migrate:  false,
   to_delete:   false,
-  position:    5,
+  position:    1450,
+)
+
+ObjectManager::Attribute.add(
+  force:       true,
+  object:      'Ticket',
+  name:        'approving_lead_id',
+  display:     __('Approving Lead'),
+  data_type:   'user_autocompletion',
+  data_option: {
+    relation:       'User',
+    autocapitalize: false,
+    multiple:       false,
+    guess:          false,
+    null:           true,
+    limit:          200,
+    placeholder:    __('Enter the lead who should approve this request'),
+    minLengt:       2,
+    translate:      false,
+    permission:     ['ticket.agent', 'ticket.customer'],
+  },
+  editable:    true,
+  active:      true,
+  screens:     {
+    create_middle: {
+      '-all-' => {
+        null: true,
+      },
+    },
+    edit:          {
+      '-all-' => {
+        null: true,
+      },
+    },
+  },
+  to_create:   false,
+  to_migrate:  false,
+  to_delete:   false,
+  position:    1500,
+)
+
+ObjectManager::Attribute.add(
+  force:       true,
+  object:      'Ticket',
+  name:        'approval_state',
+  display:     __('Approval State'),
+  data_type:   'select',
+  data_option: {
+    default:    'not_requested',
+    options:    {
+      'not_requested' => __('Not requested'),
+      'pending'       => __('Pending approval'),
+      'approved'      => __('Approved'),
+      'rejected'      => __('Rejected'),
+    },
+    nulloption: false,
+    multiple:   false,
+    null:       true,
+    translate:  true,
+  },
+  editable:    true,
+  active:      true,
+  screens:     {
+    create_middle: {
+      '-all-' => {
+        null: true,
+      },
+    },
+    edit:          {
+      'ticket.agent' => {
+        null: true,
+      },
+    },
+  },
+  to_create:   false,
+  to_migrate:  false,
+  to_delete:   false,
+  position:    1510,
 )
 
 ObjectManager::Attribute.add(

--- a/db/seeds/object_manager_attributes.rb
+++ b/db/seeds/object_manager_attributes.rb
@@ -47,12 +47,14 @@ ObjectManager::Attribute.add(
   screens:     {
     create_middle: {
       '-all-' => {
-        null: true,
+        null:  true,
+        shown: false,
       },
     },
     edit:          {
       '-all-' => {
-        null: true,
+        null:  true,
+        shown: false,
       },
     },
   },
@@ -87,12 +89,14 @@ ObjectManager::Attribute.add(
   screens:     {
     create_middle: {
       'ticket.agent' => {
-        null: true,
+        null:  true,
+        shown: false,
       },
     },
     edit:          {
       '-all-' => {
-        null: true,
+        null:  true,
+        shown: false,
       },
     },
   },
@@ -209,6 +213,7 @@ ObjectManager::Attribute.add(
       'Incident'           => __('Incident'),
       'Problem'            => __('Problem'),
       'Request for Change' => __('Request for Change'),
+      'Approval Request'   => __('Approval Request'),
     },
     nulloption: true,
     multiple:   false,
@@ -217,7 +222,7 @@ ObjectManager::Attribute.add(
   },
   editable:    true,
   internal:    false,
-  active:      false,
+  active:      true,
   screens:     {
     create_middle: {
       '-all-' => {

--- a/db/seeds/object_manager_attributes.rb
+++ b/db/seeds/object_manager_attributes.rb
@@ -30,8 +30,8 @@ ObjectManager::Attribute.add(
 ObjectManager::Attribute.add(
   force:       true,
   object:      'Ticket',
-  name:        'approving_lead_id',
-  display:     __('Approving Lead'),
+  name:        'approver_id',
+  display:     __('Approver'),
   data_type:   'user_autocompletion',
   data_option: {
     relation:       'User',
@@ -40,7 +40,7 @@ ObjectManager::Attribute.add(
     guess:          false,
     null:           true,
     limit:          200,
-    placeholder:    __('Enter the lead who should approve this request'),
+    placeholder:    __('Enter the approver who should approve this request'),
     minLengt:       2,
     translate:      false,
     permission:     ['ticket.agent', 'ticket.customer'],

--- a/db/seeds/overviews.rb
+++ b/db/seeds/overviews.rb
@@ -236,6 +236,37 @@ Overview.create_if_not_exists(
   },
 )
 Overview.create_if_not_exists(
+  name:      __('Waiting for my Approval'),
+  link:      'waiting_for_my_approval',
+  prio:      1150,
+  role_ids:  [overview_role.id],
+  condition: {
+    'ticket.state_id'       => {
+      operator: 'is',
+      value:    Ticket::State.by_category_ids(:viewable),
+    },
+    'ticket.approver'       => {
+      operator:      'is',
+      pre_condition: 'current_user.id',
+      value:         '',
+    },
+    'ticket.approval_state' => {
+      operator: 'is',
+      value:    'pending',
+    },
+  },
+  order:     {
+    by:        'created_at',
+    direction: 'DESC',
+  },
+  view:      {
+    d:                 %w[title customer state created_at],
+    s:                 %w[number title state created_at],
+    m:                 %w[number title state created_at],
+    view_mode_default: 's',
+  },
+)
+Overview.create_if_not_exists(
   name:                __('My Organization Tickets'),
   link:                'my_organization_tickets',
   prio:                1200,

--- a/db/seeds/overviews.rb
+++ b/db/seeds/overviews.rb
@@ -245,6 +245,10 @@ Overview.create_if_not_exists(
       operator: 'is',
       value:    Ticket::State.by_category_ids(:viewable),
     },
+    'ticket.type'           => {
+      operator: 'is',
+      value:    ['Approval Request'], # rubocop:disable Zammad/DetectTranslatableString
+    },
     'ticket.approver'       => {
       operator:      'is',
       pre_condition: 'current_user.id',

--- a/db/seeds/triggers.rb
+++ b/db/seeds/triggers.rb
@@ -122,3 +122,40 @@ Trigger.create_or_update(
   created_by_id:            1,
   updated_by_id:            1,
 )
+
+Trigger.create_or_update(
+  name:                     'approval request (notify approving lead)',
+  condition:                {
+    'ticket.action'            => {
+      'operator' => 'is',
+      'value'    => 'create',
+    },
+    'ticket.approving_lead_id' => {
+      'operator' => 'is set',
+    },
+  },
+  perform:                  {
+    'notification.email' => {
+      # rubocop:disable Lint/InterpolationCheck
+      'body'      => '<div>Hello,</div>
+<br/>
+<div>#{ticket.customer.firstname} #{ticket.customer.lastname} has created the request <b>(#{config.ticket_hook}#{ticket.number})</b> and asks for your approval.</div>
+<br/>
+<div>Subject: #{ticket.title}</div>
+<br/>
+<div>Please review the request and approve or reject it here:
+<a href="#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}">#{config.http_type}://#{config.fqdn}/#ticket/zoom/#{ticket.id}</a>
+</div>
+<br/>
+<div>Your #{config.product_name} Team</div>',
+      # rubocop:enable Lint/InterpolationCheck
+      'recipient' => 'ticket_custom_field_approving_lead_id',
+      'subject'   => 'Approval requested for #{ticket.title}', # rubocop:disable Lint/InterpolationCheck
+    },
+  },
+  activator:                'action',
+  execution_condition_mode: 'selective',
+  active:                   true,
+  created_by_id:            1,
+  updated_by_id:            1,
+)

--- a/db/seeds/triggers.rb
+++ b/db/seeds/triggers.rb
@@ -126,12 +126,14 @@ Trigger.create_or_update(
 Trigger.create_or_update(
   name:                     'approval request (notify approver)',
   condition:                {
-    'ticket.action'      => {
+    'ticket.action'   => {
       'operator' => 'is',
       'value'    => 'create',
     },
-    'ticket.approver_id' => {
-      'operator' => 'is set',
+    'ticket.approver' => {
+      'operator'      => 'is not',
+      'pre_condition' => 'not_set',
+      'value'         => '',
     },
   },
   perform:                  {
@@ -149,7 +151,7 @@ Trigger.create_or_update(
 <br/>
 <div>Your #{config.product_name} Team</div>',
       # rubocop:enable Lint/InterpolationCheck
-      'recipient' => 'ticket_custom_field_approver_id',
+      'recipient' => 'ticket_custom_field_approver',
       'subject'   => 'Approval requested for #{ticket.title}', # rubocop:disable Lint/InterpolationCheck
     },
   },

--- a/db/seeds/triggers.rb
+++ b/db/seeds/triggers.rb
@@ -124,13 +124,13 @@ Trigger.create_or_update(
 )
 
 Trigger.create_or_update(
-  name:                     'approval request (notify approving lead)',
+  name:                     'approval request (notify approver)',
   condition:                {
-    'ticket.action'            => {
+    'ticket.action'      => {
       'operator' => 'is',
       'value'    => 'create',
     },
-    'ticket.approving_lead_id' => {
+    'ticket.approver_id' => {
       'operator' => 'is set',
     },
   },
@@ -149,7 +149,7 @@ Trigger.create_or_update(
 <br/>
 <div>Your #{config.product_name} Team</div>',
       # rubocop:enable Lint/InterpolationCheck
-      'recipient' => 'ticket_custom_field_approving_lead_id',
+      'recipient' => 'ticket_custom_field_approver_id',
       'subject'   => 'Approval requested for #{ticket.title}', # rubocop:disable Lint/InterpolationCheck
     },
   },

--- a/db/seeds/triggers.rb
+++ b/db/seeds/triggers.rb
@@ -161,3 +161,30 @@ Trigger.create_or_update(
   created_by_id:            1,
   updated_by_id:            1,
 )
+
+Trigger.create_or_update(
+  name:                     'approval decision (add note to timeline)',
+  condition:                {
+    'ticket.action'         => {
+      'operator' => 'is',
+      'value'    => 'update',
+    },
+    'ticket.approval_state' => {
+      'operator' => 'has changed',
+    },
+  },
+  perform:                  {
+    'article.note' => {
+      # rubocop:disable Lint/InterpolationCheck, Zammad/DetectTranslatableString
+      'subject'  => 'Approval state changed',
+      'body'     => 'The approval state was changed to <b>#{ticket.approval_state}</b> by #{user.firstname} #{user.lastname}.',
+      # rubocop:enable Lint/InterpolationCheck, Zammad/DetectTranslatableString
+      'internal' => 'false',
+    },
+  },
+  activator:                'action',
+  execution_condition_mode: 'selective',
+  active:                   true,
+  created_by_id:            1,
+  updated_by_id:            1,
+)

--- a/spec/models/core_workflow/custom/ticket_approval_state_spec.rb
+++ b/spec/models/core_workflow/custom/ticket_approval_state_spec.rb
@@ -1,0 +1,84 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+require 'models/core_workflow/base'
+
+# The `approval_state` ticket field may only be changed by an agent or by the
+# ticket's assigned approver. For every other user it must be read-only.
+RSpec.describe CoreWorkflow::Custom::TicketApprovalState, db_strategy: :reset, type: :model do
+  include_context 'with core workflow base'
+
+  let(:organization) { create(:organization, shared: true) }
+  let(:requester)    { create(:customer, organization: organization) }
+  let(:approver)     { create(:customer, organization: organization) }
+  let(:other)        { create(:customer, organization: organization) }
+  let(:agent)        { create(:agent, groups: [group]) }
+
+  let(:ticket) do
+    create(:ticket,
+           group:          group,
+           customer:       requester,
+           approver:       approver.id.to_s,
+           approval_state: 'pending')
+  end
+
+  before do
+    UserInfo.current_user_id = 1
+
+    add_select_attribute('approver', relation: 'User')
+    add_select_attribute('approval_state',
+                         options: { 'not_requested' => 'Not requested', 'pending' => 'Pending', 'approved' => 'Approved', 'rejected' => 'Rejected' })
+    ObjectManager::Attribute.migration_execute
+
+    ticket
+  end
+
+  def add_select_attribute(name, relation: nil, options: {})
+    ObjectManager::Attribute.add(
+      force:       true,
+      object:      'Ticket',
+      name:        name,
+      display:     name.humanize,
+      data_type:   'select',
+      data_option: {
+        'default'    => '',
+        'relation'   => relation.to_s,
+        'options'    => options,
+        'nulloption' => true,
+        'multiple'   => false,
+        'null'       => true,
+        'translate'  => false,
+      },
+      editable:    true,
+      active:      true,
+      screens:     { 'edit' => { '-all-' => { 'null' => true } } },
+      to_create:   true,
+      to_migrate:  true,
+      to_delete:   false,
+    )
+  end
+
+  def readonly_for(user)
+    payload = base_payload.merge(
+      'screen' => 'edit',
+      'params' => { 'id' => ticket.id, 'approver' => ticket.approver }
+    )
+    CoreWorkflow.perform(payload: payload, user: user)[:readonly]['approval_state'] == true
+  end
+
+  it 'lets the assigned approver edit the approval state' do
+    expect(readonly_for(approver)).to be(false)
+  end
+
+  it 'makes the approval state read-only for the requester' do
+    expect(readonly_for(requester)).to be(true)
+  end
+
+  it 'makes the approval state read-only for another organization member' do
+    expect(readonly_for(other)).to be(true)
+  end
+
+  it 'lets an agent edit the approval state' do
+    expect(readonly_for(agent)).to be(false)
+  end
+end

--- a/spec/models/core_workflow/custom/ticket_approval_type_spec.rb
+++ b/spec/models/core_workflow/custom/ticket_approval_type_spec.rb
@@ -1,0 +1,115 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+require 'models/core_workflow/base'
+
+# The ticket approval fields (approver, approval_state) are only shown when the
+# ticket type is "Approval Request". They default to hidden (shown: false) and
+# a Core Workflow reveals them for the matching type.
+RSpec.describe 'CoreWorkflow > ticket approval fields shown only for approval request type', db_strategy: :reset, type: :model do
+  include_context 'with core workflow base'
+
+  before do
+    UserInfo.current_user_id = 1
+
+    add_type_attribute
+    add_hidden_select_attribute('approver', relation: 'User')
+    add_hidden_select_attribute('approval_state',
+                                options: { 'not_requested' => 'Not requested', 'pending' => 'Pending' })
+    ObjectManager::Attribute.migration_execute
+
+    create(:core_workflow,
+           object:             'Ticket',
+           condition_selected: {
+             'ticket.type': { operator: 'is', value: ['Approval Request'] },
+           },
+           perform:            {
+             'ticket.approver':       { operator: 'show', show: 'true' },
+             'ticket.approval_state': { operator: 'show', show: 'true' },
+           })
+  end
+
+  def add_type_attribute
+    ObjectManager::Attribute.add(
+      force:       true,
+      object:      'Ticket',
+      name:        'type',
+      display:     'Type',
+      data_type:   'select',
+      data_option: {
+        'default'    => '',
+        'options'    => { 'Incident' => 'Incident', 'Approval Request' => 'Approval Request' },
+        'nulloption' => true,
+        'multiple'   => false,
+        'null'       => true,
+        'translate'  => true,
+      },
+      editable:    true,
+      active:      true,
+      screens:     { 'create_middle' => { '-all-' => { 'null' => true } }, 'edit' => { '-all-' => { 'null' => true } } },
+      to_create:   true,
+      to_migrate:  true,
+      to_delete:   false,
+    )
+  end
+
+  def add_hidden_select_attribute(name, relation: nil, options: {})
+    ObjectManager::Attribute.add(
+      force:       true,
+      object:      'Ticket',
+      name:        name,
+      display:     name.humanize,
+      data_type:   'select',
+      data_option: {
+        'default'    => '',
+        'relation'   => relation.to_s,
+        'options'    => options,
+        'nulloption' => true,
+        'multiple'   => false,
+        'null'       => true,
+        'translate'  => false,
+      },
+      editable:    true,
+      active:      true,
+      screens:     {
+        'create_middle' => { '-all-' => { 'null' => true, 'shown' => false } },
+        'edit'          => { '-all-' => { 'null' => true, 'shown' => false } },
+      },
+      to_create:   true,
+      to_migrate:  true,
+      to_delete:   false,
+    )
+  end
+
+  context 'when the ticket type is "Approval Request"' do
+    let(:payload) { base_payload.merge('params' => { 'type' => 'Approval Request' }) }
+
+    it 'shows the approver field' do
+      expect(result[:visibility]['approver']).to eq('show')
+    end
+
+    it 'shows the approval_state field' do
+      expect(result[:visibility]['approval_state']).to eq('show')
+    end
+  end
+
+  context 'when the ticket type is something else' do
+    let(:payload) { base_payload.merge('params' => { 'type' => 'Incident' }) }
+
+    it 'does not show the approver field' do
+      expect(result[:visibility]['approver']).not_to eq('show')
+    end
+
+    it 'does not show the approval_state field' do
+      expect(result[:visibility]['approval_state']).not_to eq('show')
+    end
+  end
+
+  context 'when no ticket type is set' do
+    let(:payload) { base_payload.merge('params' => {}) }
+
+    it 'does not show the approver field' do
+      expect(result[:visibility]['approver']).not_to eq('show')
+    end
+  end
+end

--- a/spec/models/core_workflow/custom/ticket_approver_organization_spec.rb
+++ b/spec/models/core_workflow/custom/ticket_approver_organization_spec.rb
@@ -1,0 +1,83 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+require 'models/core_workflow/base'
+
+# The `approver` ticket attribute (a User select) must only offer users that
+# belong to the same organization as the ticket requester. This is driven by
+# CoreWorkflow::Attributes::User#values, applied as a restrict_values default
+# on every Ticket core workflow run.
+RSpec.describe 'CoreWorkflow > ticket approver limited to requester organization', db_strategy: :reset, type: :model do
+  include_context 'with core workflow base'
+
+  let(:organization1) { create(:organization) }
+  let(:organization2) { create(:organization) }
+
+  let(:org1_customer) { create(:customer, organization: organization1) }
+  let(:org1_lead)     { create(:customer, organization: organization1) }
+  let(:org2_customer) { create(:customer, organization: organization2) }
+  let(:org2_lead)     { create(:customer, organization: organization2) }
+
+  before do
+    UserInfo.current_user_id = 1
+    ObjectManager::Attribute.add(
+      force:       true,
+      object:      'Ticket',
+      name:        'approver',
+      display:     'Approver',
+      data_type:   'select',
+      data_option: {
+        'default'    => '',
+        'relation'   => 'User',
+        'options'    => {},
+        'nulloption' => true,
+        'multiple'   => false,
+        'null'       => true,
+        'translate'  => false,
+      },
+      editable:    true,
+      active:      true,
+      screens:     {
+        'create_middle' => { '-all-' => { 'null' => true } },
+        'edit'          => { '-all-' => { 'null' => true } },
+      },
+      to_create:   true,
+      to_migrate:  true,
+      to_delete:   false,
+      position:    1500,
+    )
+    ObjectManager::Attribute.migration_execute
+
+    # make sure both orgs and their members exist before the workflow runs
+    org1_customer && org1_lead && org2_customer && org2_lead
+  end
+
+  def approver_restrict_values
+    result[:restrict_values]['approver']
+  end
+
+  # The field allows "no approver", so an empty option is always present.
+  context 'when a customer creates their own ticket' do
+    let(:result) { CoreWorkflow.perform(payload: payload, user: org1_customer) }
+
+    it 'offers members of the customer organization' do
+      expect(approver_restrict_values).to include(org1_customer.id.to_s, org1_lead.id.to_s)
+    end
+
+    it 'does not offer members of another organization' do
+      expect(approver_restrict_values).not_to include(org2_customer.id.to_s, org2_lead.id.to_s)
+    end
+  end
+
+  context 'when an agent creates a ticket for a customer' do
+    let(:payload) { base_payload.merge('params' => { 'customer_id' => org2_customer.id }) }
+
+    it 'offers members of the selected customer organization' do
+      expect(approver_restrict_values).to include(org2_customer.id.to_s, org2_lead.id.to_s)
+    end
+
+    it 'does not offer members of a different organization' do
+      expect(approver_restrict_values).not_to include(org1_customer.id.to_s, org1_lead.id.to_s)
+    end
+  end
+end

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -428,22 +428,22 @@ RSpec.describe Trigger, type: :model do
           end
         end
 
-        context 'ticket custom field user recipient (approving lead)' do
+        context 'ticket custom field user recipient (approver)' do
           before do
-            create(:object_manager_attribute_user_autocompletion, object_name: 'Ticket', name: 'approving_lead_id')
+            create(:object_manager_attribute_user_autocompletion, object_name: 'Ticket', name: 'approver_id')
             ObjectManager::Attribute.migration_execute
           end
 
-          let!(:ticket) { create(:ticket, approving_lead_id: recipient1.id) }
+          let!(:ticket) { create(:ticket, approver_id: recipient1.id) }
 
-          let(:recipient) { 'ticket_custom_field_approving_lead_id' }
+          let(:recipient) { 'ticket_custom_field_approver_id' }
 
           it 'notifies the user referenced by the custom field' do
             expect(ticket.articles.last.to).to eq(recipient1.email)
           end
 
           context 'when the custom field is empty' do
-            let(:ticket) { create(:ticket, approving_lead_id: nil) }
+            let(:ticket) { create(:ticket, approver_id: nil) }
 
             it 'sends no notification' do
               expect(ticket.articles.count { |a| a.subject == 'Hello' }).to eq(0)
@@ -451,7 +451,7 @@ RSpec.describe Trigger, type: :model do
           end
 
           context 'when the referenced user does not exist' do
-            let(:ticket) { create(:ticket, approving_lead_id: 0) }
+            let(:ticket) { create(:ticket, approver_id: 0) }
 
             it 'sends no notification' do
               expect(ticket.articles.count { |a| a.subject == 'Hello' }).to eq(0)

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -903,6 +903,42 @@ RSpec.describe Trigger, type: :model do
 
       let!(:ticket) { create(:ticket).tap { TransactionDispatcher.commit } }
 
+      context 'with an article.note perform on approval_state change' do
+        let(:condition) do
+          {
+            'ticket.action'         => { 'operator' => 'is', 'value' => 'update' },
+            'ticket.approval_state' => { 'operator' => 'has changed' },
+          }
+        end
+        let(:perform) do
+          {
+            'article.note' => {
+              'subject'  => 'Approval state changed',
+              'body'     => 'The approval state was changed to #{ticket.approval_state}.', # rubocop:disable Lint/InterpolationCheck
+              'internal' => 'false',
+            }
+          }
+        end
+
+        # `approval_state` is a seeded Ticket attribute, so the column exists.
+        let!(:ticket) { create(:ticket, approval_state: 'pending').tap { TransactionDispatcher.commit } }
+
+        it 'adds a note article when approval_state changes' do
+          ticket.update!(approval_state: 'approved')
+
+          expect { TransactionDispatcher.commit }
+            .to change { ticket.reload.articles.count }.by(1)
+          expect(ticket.reload.articles.last.body).to include('approved')
+        end
+
+        it 'adds no note when approval_state does not change' do
+          ticket.update!(title: 'unrelated change')
+
+          expect { TransactionDispatcher.commit }
+            .not_to change { ticket.reload.articles.count }
+        end
+      end
+
       context 'when new article is created directly' do
         context 'with empty #preferences hash' do
           let!(:article) { create(:ticket_article, ticket: ticket) }

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -427,6 +427,37 @@ RSpec.describe Trigger, type: :model do
             expect(ticket.articles.last.to).to eq(ticket.customer.email.to_s)
           end
         end
+
+        context 'ticket custom field user recipient (approving lead)' do
+          before do
+            create(:object_manager_attribute_user_autocompletion, object_name: 'Ticket', name: 'approving_lead_id')
+            ObjectManager::Attribute.migration_execute
+          end
+
+          let!(:ticket) { create(:ticket, approving_lead_id: recipient1.id) }
+
+          let(:recipient) { 'ticket_custom_field_approving_lead_id' }
+
+          it 'notifies the user referenced by the custom field' do
+            expect(ticket.articles.last.to).to eq(recipient1.email)
+          end
+
+          context 'when the custom field is empty' do
+            let(:ticket) { create(:ticket, approving_lead_id: nil) }
+
+            it 'sends no notification' do
+              expect(ticket.articles.count { |a| a.subject == 'Hello' }).to eq(0)
+            end
+          end
+
+          context 'when the referenced user does not exist' do
+            let(:ticket) { create(:ticket, approving_lead_id: 0) }
+
+            it 'sends no notification' do
+              expect(ticket.articles.count { |a| a.subject == 'Hello' }).to eq(0)
+            end
+          end
+        end
       end
 
       context 'active S/MIME integration' do

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -447,9 +447,9 @@ RSpec.describe Trigger, type: :model do
           }
         end
 
+        # The `approver` user attribute (and its DB column) ship with the
+        # seeds / base migration, so it already exists here.
         before do
-          create(:object_manager_attribute_user_autocompletion, object_name: 'Ticket', name: 'approver')
-          ObjectManager::Attribute.migration_execute
           trigger
         end
 

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -427,35 +427,62 @@ RSpec.describe Trigger, type: :model do
             expect(ticket.articles.last.to).to eq(ticket.customer.email.to_s)
           end
         end
+      end
 
-        context 'ticket custom field user recipient (approver)' do
-          before do
-            create(:object_manager_attribute_user_autocompletion, object_name: 'Ticket', name: 'approver_id')
-            ObjectManager::Attribute.migration_execute
-          end
+      context 'notification.email recipient via ticket custom field user (approver)' do
+        let(:approver) { create(:user, email: 'approver@zammad-test.com') }
+        let(:condition) do
+          {
+            'ticket.action'   => { 'operator' => 'is', 'value' => 'create' },
+            'ticket.approver' => { 'operator' => 'is not', 'pre_condition' => 'not_set', 'value' => '' },
+          }
+        end
+        let(:perform) do
+          {
+            'notification.email' => {
+              'recipient' => 'ticket_custom_field_approver',
+              'subject'   => 'Approval',
+              'body'      => 'Please approve',
+            }
+          }
+        end
 
-          let!(:ticket) { create(:ticket, approver_id: recipient1.id) }
+        before do
+          create(:object_manager_attribute_user_autocompletion, object_name: 'Ticket', name: 'approver')
+          ObjectManager::Attribute.migration_execute
+          trigger
+        end
 
-          let(:recipient) { 'ticket_custom_field_approver_id' }
+        context 'when the custom field references an existing user' do
+          let(:ticket) { create(:ticket, approver: approver.id) }
 
           it 'notifies the user referenced by the custom field' do
-            expect(ticket.articles.last.to).to eq(recipient1.email)
+            ticket
+            TransactionDispatcher.commit
+
+            expect(ticket.reload.articles.last.to).to eq(approver.email)
           end
+        end
 
-          context 'when the custom field is empty' do
-            let(:ticket) { create(:ticket, approver_id: nil) }
+        context 'when the custom field is empty' do
+          let(:ticket) { create(:ticket, approver: nil) }
 
-            it 'sends no notification' do
-              expect(ticket.articles.count { |a| a.subject == 'Hello' }).to eq(0)
-            end
+          it 'adds no notification article' do
+            ticket
+
+            expect { TransactionDispatcher.commit }
+              .not_to change(ticket.articles, :count)
           end
+        end
 
-          context 'when the referenced user does not exist' do
-            let(:ticket) { create(:ticket, approver_id: 0) }
+        context 'when the referenced user does not exist' do
+          let(:ticket) { create(:ticket, approver: 0) }
 
-            it 'sends no notification' do
-              expect(ticket.articles.count { |a| a.subject == 'Hello' }).to eq(0)
-            end
+          it 'adds no notification article' do
+            ticket
+
+            expect { TransactionDispatcher.commit }
+              .not_to change(ticket.articles, :count)
           end
         end
       end


### PR DESCRIPTION
Hi, zammad is really nice but we are missing a feature to get approvals.
When a User need Hardware or access they need to get the approval from their Lead. 
At the moment this is missing in zammad, so we can't really use it yet. 

## What it adds

- New ticket type "Approval Request". The approval feature is scoped to this ticket type; it doesn't clutter regular tickets.

- Approver field (User select) — the person asked to approve. Only shown for the "Approval Request" type.
Approval State field — Not requested / Pending approval / Approved / Rejected. Only shown for the "Approval Request" type.

- Approver is scoped to the requester's organization — you can only pick someone from your own organization (via Core Workflow).

- Approval State is editable only by the assigned approver or an agent — everyone else sees it read-only (via Core Workflow).

- Email notification to the approver when an approval-request ticket is created (Trigger + a new custom-field recipient resolver).

- Timeline note added automatically whenever the approval state changes, recording who changed it and to what (Trigger).

- "Waiting for my Approval" overview listing tickets pending the current user's decision.

Request: https://community.zammad.org/t/get-approval-for-tickets-by-lead/20745

<img width="1218" height="581" alt="Bildschirmfoto 2026-07-25 um 16 45 00" src="https://github.com/user-attachments/assets/7501a0a8-b750-48ae-ac2a-356e73670c0a" />

<img width="1234" height="484" alt="Bildschirmfoto 2026-07-25 um 16 45 45" src="https://github.com/user-attachments/assets/72b4be2c-f815-498b-a9d2-02b8439a4276" />

<img width="1147" height="553" alt="Bildschirmfoto 2026-07-25 um 16 46 09" src="https://github.com/user-attachments/assets/d9bb6b6f-f488-41ee-837b-1ceef7e14e7e" />

<img width="1006" height="186" alt="Bildschirmfoto 2026-07-25 um 16 54 09" src="https://github.com/user-attachments/assets/ee02a0c0-5025-4654-91b3-c3d024831ba3" />

