### PR TITLE
Maintenance: Do not truncate the GraphQL introspection dump on a failed generate.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "generate-graphql-api": "bundle exec rails generate zammad:graphql_introspection > app/graphql/graphql_introspection.json && pnpm exec graphql-codegen -c .graphql_code_generator.js",
+    "generate-graphql-api": "mkdir -p tmp && bundle exec rails generate zammad:graphql_introspection > tmp/graphql_introspection.json && mv tmp/graphql_introspection.json app/graphql/graphql_introspection.json && pnpm exec graphql-codegen -c .graphql_code_generator.js",
     "generate-setting-types": "bundle exec rails generate zammad:setting_types",
     "dev": "RAILS_ENV=development forego start -r -f Procfile.dev",
     "dev:https": "VITE_RUBY_HOST=0.0.0.0 VITE_RUBY_HTTPS=true RAILS_ENV=development forego start -r -f Procfile.dev-https",


### PR DESCRIPTION
Fixes #6265.

`generate-graphql-api` redirected straight into the tracked
`app/graphql/graphql_introspection.json`, so the shell truncated it to zero bytes before the
generator ran. Any failure — a checkout without `bundle install`, a mismatched Ruby version,
an unreachable database — left the tracked 1.1 MB file empty, with nothing reporting the loss.

The dump is now staged through `tmp/` and only moved into place once the generator has exited
successfully. `tmp/` is already covered by `.gitignore` (`/tmp/*`), and `mv` within the same
filesystem is an atomic `rename(2)`.

This guards against the generator *failing*, not against it exiting 0 while writing invalid
output — that seemed out of scope here, but happy to extend it if you would rather have a
sanity check on the dump.

No tests: the change is a single line in a package script. Verified by running
`pnpm generate-graphql-api` both in a working environment (dump regenerated, unchanged output)
and in a deliberately broken one (generator fails, tracked file untouched).
