### PR TITLE
Feature: Snipe-IT integration

### DIFF
--- a/app/assets/javascripts/app/controllers/_integration/snipeit.coffee
+++ b/app/assets/javascripts/app/controllers/_integration/snipeit.coffee
@@ -1,0 +1,127 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Snipeit extends App.ControllerIntegrationBase
+  featureIntegration: 'snipeit_integration'
+  featureName: 'Snipe-IT'
+  featureConfig: 'snipeit_config'
+  description: [
+    [__('This service allows you to connect %s with %s.'), 'Snipe-IT', 'Zammad']
+  ]
+  events:
+    'change .js-switch input': 'switch'
+
+  render: =>
+    super
+    new Form(
+      el: @$('.js-form')
+    )
+
+    new App.HttpLog(
+      el: @$('.js-log')
+      facility: 'snipeit'
+    )
+
+class Form extends App.Controller
+  elements:
+    '.js-sslVerifyAlert': 'sslVerifyAlert'
+  events:
+    'change .js-sslVerify select': 'handleSslVerifyAlert'
+    'submit form':                 'update'
+
+  constructor: ->
+    super
+    @render()
+    @handleSslVerifyAlert()
+
+  currentConfig: ->
+    App.Setting.get('snipeit_config')
+
+  setConfig: (value) ->
+    App.Setting.set('snipeit_config', value, {notify: true})
+
+  render: =>
+    @config = @currentConfig()
+
+    # Ensure config has default values
+    @config ||= {}
+    @config.endpoint ||= ''
+    @config.api_token ||= ''
+    @config.verify_ssl = true if @config.verify_ssl == undefined
+
+    verify_ssl = App.UiElement.boolean.render(
+      name: 'verify_ssl'
+      null: false
+      default: true
+      value: @config.verify_ssl
+      class: 'form-control form-control--small'
+    )
+
+    content = $(App.view('integration/snipeit')(
+      config: @config
+    ))
+
+    content.find('.js-sslVerify').html verify_ssl
+
+    @html content
+
+  update: (e) =>
+    e.preventDefault()
+    @config = @formParam(e.target)
+    @validateAndSave()
+
+  validateAndSave: =>
+    @ajax(
+      id:    'snipeit'
+      type:  'POST'
+      url:   "#{@apiPath}/integration/snipeit/verify"
+      data:  JSON.stringify(
+        api_token: @config.api_token
+        endpoint: @config.endpoint
+        verify_ssl: @config.verify_ssl
+      )
+      success: (data, status, xhr) =>
+        if data.result is 'failed'
+          new App.ErrorModal(
+            message: data.message
+            container: @el.closest('.content')
+          )
+          return
+        @setConfig(@config)
+        @notify(
+          type: 'success'
+          msg:  App.i18n.translateContent('Saving was successful!')
+        )
+
+      error: (data, status) =>
+
+        # do not close window if request is aborted
+        return if status is 'abort'
+
+        details = data.responseJSON || {}
+        @notify(
+          type: 'error'
+          msg:  details.error_human || details.error || __('Saving failed.')
+        )
+    )
+
+  handleSslVerifyAlert: =>
+    if @formParam(@el).verify_ssl
+      @sslVerifyAlert.addClass('hide')
+    else
+      @sslVerifyAlert.removeClass('hide')
+
+class State
+  @current: ->
+    App.Setting.get('snipeit_integration')
+
+App.Config.set(
+  'IntegrationSnipeit'
+  {
+    name: 'Snipe-IT'
+    target: '#system/integration/snipeit'
+    description: __('A free open-source IT asset/license management system.')
+    controller: Snipeit
+    state: State
+  }
+  'NavBarIntegrations'
+)

--- a/app/assets/javascripts/app/controllers/snipeit_asset_selector.coffee
+++ b/app/assets/javascripts/app/controllers/snipeit_asset_selector.coffee
@@ -1,0 +1,73 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class App.SnipeitAssetSelector extends App.ControllerModal
+  buttonClose: true
+  buttonCancel: true
+  buttonSubmit: true
+  head: __('Snipe-IT')
+  lastSearchTermEmpty: false
+
+  content: ->
+    content = App.view('integration/snipeit_asset_selector')()
+    controller = @
+    App.Delay.set( ->
+      searchField = controller.el.find('input.js-searchField')
+
+      # Auto-search with customer email if available (but don't show it in field)
+      if controller.customerEmail
+        controller.search({ search: controller.customerEmail })
+
+      searchField.on('keyup', (e) ->
+        params = controller.formParam(e.target)
+        controller.search(params)
+      )
+
+      searchField.trigger('focus')
+    , 100, 'snipeit-asset-selector-focus')
+    content
+
+  search: (filter) =>
+    if _.isEmpty(filter.search)
+      @lastSearchTermEmpty = true
+      @renderResult([])
+      return
+
+    @lastSearchTermEmpty = false
+    @ajax(
+      id:    'snipeit-asset-selector'
+      type:  'POST'
+      url:   "#{@apiPath}/integration/snipeit"
+      data:  JSON.stringify(method: 'hardware', search: filter.search)
+      success: (data, status, xhr) =>
+        return if @lastSearchTermEmpty
+        if data.result && data.result.rows
+          @renderResult(data.result.rows)
+        else
+          @renderResult([])
+
+      error: (xhr, status, error) =>
+
+        # do not close window if request is aborted
+        return if status is 'abort'
+
+        # show error message
+        @contentInline = __('Content could not be loaded.')
+        @render()
+    )
+
+  renderResult: (items) =>
+    table = App.view('integration/snipeit_asset_result')(
+      items: items
+    )
+    @el.find('.js-result').html(table)
+
+  onSubmit: (e) =>
+    form = @el.find('.js-result')
+    params = @formParam(form)
+    return if _.isEmpty(params.asset_id)
+    assetIds = []
+    if _.isArray(params.asset_id)
+      assetIds = params.asset_id
+    else
+      assetIds.push params.asset_id
+    @callback(assetIds, @)

--- a/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_snipeit.coffee
+++ b/app/assets/javascripts/app/controllers/ticket_zoom/sidebar_snipeit.coffee
@@ -1,0 +1,193 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class SidebarSnipeit extends App.Controller
+  sidebarItem: =>
+    return if !@Config.get('snipeit_integration')
+
+    isAgentTicketZoom   = (@ticket and @ticket.currentView() is 'agent')
+    isAgentTicketCreate = (!@ticket and @taskKey and @taskKey.match('TicketCreateScreen-'))
+
+    return if !isAgentTicketZoom and !isAgentTicketCreate
+
+    @item = {
+      name: 'snipeit'
+      badgeIcon: 'printer'
+      badgeCallback: @badgeRender
+      sidebarHead: __('Snipe-IT')
+      sidebarCallback: @showAssets
+      sidebarActions: [
+        {
+          title:    __('Add Assets')
+          name:     'assets-change'
+          callback: @changeAssets
+        },
+      ]
+    }
+    @item
+
+  changeAssets: =>
+    customerEmail = null
+    customerId = null
+
+    # Try to get customer from saved ticket
+    if @ticket && @ticket.customer_id
+      customerId = @ticket.customer_id
+
+    # For new tickets, check the form for selected customer
+    if !customerId
+      formCustomerId = @formParam($('.content.active .newTicket'))?.customer_id
+      customerId = formCustomerId if formCustomerId
+
+    # Get customer email
+    if customerId && App.User.exists(customerId)
+      customer = App.User.find(customerId)
+      customerEmail = customer.email if customer.email
+
+    new App.SnipeitAssetSelector(
+      taskKey: @taskKey
+      container: @el.closest('.content')
+      customerEmail: customerEmail
+      callback: (assetIds, assetSelectorUi) =>
+        if @ticket && @ticket.id
+
+          # add new assetIds to list of all @assetIds
+          # and transfer the complete list to the backend
+          @assetIds = @assetIds.concat(assetIds)
+
+          @updateTicket(@ticket.id, @assetIds, =>
+            assetSelectorUi.close()
+            @showAssetsContent(assetIds)
+          )
+          return
+        assetSelectorUi.close()
+        @showAssetsContent(assetIds)
+    )
+
+  showAssets: (el) =>
+    @el = el
+
+    # show placeholder
+    @assetIds ||= []
+    if @ticket && @ticket.preferences && @ticket.preferences.snipeit && @ticket.preferences.snipeit.asset_ids
+      @assetIds = @ticket.preferences.snipeit.asset_ids
+    queryParams = @queryParam()
+    if queryParams && queryParams.snipeit_asset_ids
+      @assetIds.push queryParams.snipeit_asset_ids
+    @showAssetsContent()
+
+  badgeRender: (el) =>
+    @badgeEl = el
+    @badgeRenderLocal()
+
+  badgeRenderLocal: =>
+    assetCount = 0
+    if @ticket && @ticket.preferences && @ticket.preferences.snipeit && @ticket.preferences.snipeit.asset_ids
+      assetCount = @ticket.preferences.snipeit.asset_ids.length
+
+    counter = if assetCount > 0 then assetCount else ''
+    @badgeEl.html(App.view('generic/sidebar_tabs_item')(
+      name: 'snipeit'
+      icon: 'printer'
+      counterPossible: true
+      counter: counter
+    ))
+
+  showAssetsContent: (assetIds) =>
+    if assetIds
+      @assetIds = @assetIds.concat(assetIds)
+      @assetIds = _.uniq(@assetIds)
+
+    # show placeholder
+    if _.isEmpty(@assetIds)
+      @html("<div>#{App.i18n.translateInline('none')}</div>")
+      return
+
+    # ajax call to show items
+    @ajax(
+      id:    "snipeit-#{@taskKey}"
+      type:  'POST'
+      url:   "#{@apiPath}/integration/snipeit"
+      data:  JSON.stringify(method: 'hardware', ids: @assetIds)
+      success: (data, status, xhr) =>
+        if data.result
+          @showList(data.result.rows)
+          return
+        @showError(__('Loading failed.'))
+
+      error: (xhr, status, error) =>
+
+        # do not close window if request is aborted
+        return if status is 'abort'
+
+        # show error message
+        @showError(__('Loading failed.'))
+    )
+
+  showList: (assets) =>
+    list = $(App.view('ticket_zoom/sidebar_snipeit')(
+      assets: assets
+    ))
+    list.on('click', '.js-delete', (e) =>
+      e.preventDefault()
+      assetId = $(e.currentTarget).attr 'data-asset-id'
+      @delete(assetId)
+    )
+    @html(list)
+
+  showError: (message) =>
+    @html App.i18n.translateInline(message)
+
+  reload: =>
+    @showAssetsContent()
+
+  delete: (assetId) =>
+    localAssets = []
+    for localAssetId in @assetIds
+      if assetId.toString() isnt localAssetId.toString()
+        localAssets.push localAssetId
+    @assetIds = localAssets
+    if @ticket && @ticket.id
+      @updateTicket(@ticket.id, @assetIds)
+    @showAssetsContent()
+
+  postParams: (args) =>
+    return if !args.ticket
+    return if args.ticket.created_at
+    return if !@assetIds
+    return if _.isEmpty(@assetIds)
+    args.ticket.preferences ||= {}
+    args.ticket.preferences.snipeit ||= {}
+    args.ticket.preferences.snipeit.asset_ids = @assetIds
+
+  updateTicket: (ticket_id, assetIds, callback) =>
+    App.Ajax.request(
+      id:    "snipeit-update-#{ticket_id}"
+      type:  'POST'
+      url:   "#{@apiPath}/integration/snipeit_ticket_update"
+      data:  JSON.stringify(ticket_id: ticket_id, asset_ids: assetIds)
+      success: (data, status, xhr) =>
+        # Update local ticket object to reflect new asset count
+        if @ticket
+          @ticket.preferences ||= {}
+          @ticket.preferences.snipeit ||= {}
+          @ticket.preferences.snipeit.asset_ids = assetIds
+        @badgeRenderLocal()
+        if callback
+          callback(assetIds)
+
+      error: (xhr, status, details) =>
+
+        # do not close window if request is aborted
+        return if status is 'abort'
+
+        # show error message
+        @log 'errors', details
+        @notify(
+          type:    'error'
+          msg:     details.error_human || details.error || __('The asset could not be updated.')
+          timeout: 6000
+        )
+    )
+
+App.Config.set('500-Snipeit', SidebarSnipeit, 'TicketCreateSidebar')
+App.Config.set('500-Snipeit', SidebarSnipeit, 'TicketZoomSidebar')

--- a/app/assets/javascripts/app/views/integration/snipeit.jst.eco
+++ b/app/assets/javascripts/app/views/integration/snipeit.jst.eco
@@ -1,0 +1,32 @@
+<form>
+  <h2><%- @T('Settings') %></h2>
+  <div class="settings-entry">
+    <div class="alert alert--warning js-sslVerifyAlert hide" role="alert">
+      <%- @T('Turning off SSL verification is a security risk and should be used only temporary. Use this option at your own risk!') %>
+    </div>
+    <table class="settings-list" style="width: 100%;">
+      <thead>
+        <tr>
+          <th width="20%"><%- @T('Name') %></th>
+          <th width="80%"><%- @T('Value') %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="settings-list-row-control"><%- @T('Endpoint') %> *</td>
+          <td class="settings-list-control-cell"><input type="text" class="form-control form-control--small" value="<%= @config.endpoint %>" placeholder="https://snipeit.example.com" name="endpoint"></td>
+        </tr>
+        <tr>
+          <td class="settings-list-row-control"><%- @T('API token') %> *</td>
+          <td class="settings-list-control-cell"><input type="password" class="form-control form-control--small" value="<%= @config.api_token %>" name="api_token"></td>
+        </tr>
+        <tr>
+          <td class="settings-list-row-control"><%- @T('SSL verification') %></td>
+          <td class="settings-list-control-cell js-sslVerify"></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <button type="submit" class="btn btn--primary js-submit"><%- @T('Save') %></button>
+</form>

--- a/app/assets/javascripts/app/views/integration/snipeit_asset_result.jst.eco
+++ b/app/assets/javascripts/app/views/integration/snipeit_asset_result.jst.eco
@@ -1,0 +1,28 @@
+<% if @items && @items.length > 0: %>
+  <table class="table table-striped table-hover">
+    <thead>
+      <tr>
+        <th style="width: 40px"></th>
+        <th><%- @T('Name') %></th>
+        <th><%- @T('Asset Tag') %></th>
+        <th><%- @T('Serial') %></th>
+        <th><%- @T('Model') %></th>
+        <th><%- @T('Status') %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% for item in @items: %>
+        <tr>
+          <td><input type="checkbox" value="<%= item.id %>" name="asset_id"/></td>
+          <td title="<%= item.name %>"><%= item.name %></td>
+          <td><a href="<%= item.link %>" target="_blank" title="<%- @T('Open in Snipe-IT') %>"><%= item.asset_tag %></a></td>
+          <td title="<%= item.serial %>"><%= item.serial %></td>
+          <td title="<%= item.model?.name || '' %>"><%= item.model?.name || '' %></td>
+          <td title="<%= item.status_label?.name || '' %>"><%= item.status_label?.name || '' %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else: %>
+  <p class="help-text"><%- @T('Start typing to search for assets...') %></p>
+<% end %>

--- a/app/assets/javascripts/app/views/integration/snipeit_asset_selector.jst.eco
+++ b/app/assets/javascripts/app/views/integration/snipeit_asset_selector.jst.eco
@@ -1,0 +1,4 @@
+<form class="js-search">
+  <input type="text" name="search" value="" autocomplete="off" placeholder="<%- @Ti('Search for asset name, serial, or tag') %>" class="form-control js-input js-searchField"/>
+</form>
+<form class="js-result"></form>

--- a/app/assets/javascripts/app/views/ticket_zoom/sidebar_snipeit.jst.eco
+++ b/app/assets/javascripts/app/views/ticket_zoom/sidebar_snipeit.jst.eco
@@ -1,0 +1,19 @@
+<% for asset in @assets: %>
+  <div class="sidebar-block">
+    <label class="horizontal">
+      <%- @T('ID:') %> <%- @T(asset.id) %>
+      <div class="list-item-delete js-delete" data-asset-id="<%= asset.id %>" data-type="remove">
+        <%- @Icon('diagonal-cross') %>
+      </div>
+    </label>
+    <a href="<%- asset.link %>" target="_blank" title="<%= asset.name %>"><%= asset.name %><br></a>
+    <%- @T('Asset Tag:') %> <a href="<%- asset.link %>" target="_blank" title="<%- @T('Open in Snipe-IT') %>"><%= asset.asset_tag %></a><br>
+    <%- @T('Serial:') %> <span title="<%= asset.serial %>"><%= asset.serial %></span><br>
+    <% if asset.model?.name: %>
+      <%- @T('Model:') %> <span title="<%= asset.model.name %>"><%= asset.model.name %></span><br>
+    <% end %>
+    <% if asset.status_label?.name: %>
+      <%- @T('Status:') %> <span title="<%= asset.status_label.name %>"><%= asset.status_label.name %></span><br>
+    <% end %>
+  </div>
+<% end %>

--- a/app/controllers/integration/snipeit_controller.rb
+++ b/app/controllers/integration/snipeit_controller.rb
@@ -97,33 +97,18 @@ class Integration::SnipeitController < ApplicationController
     params[:search].present? && params[:search].include?('@')
   end
 
-  # Look up the Snipe-IT user for the given customer email and return the assets assigned
-  # to them. Returns nil if no matching user exists, so that the caller falls back to a
+  # Returns nil if no Snipe-IT user has that address, so that the caller falls back to a
   # regular search.
   def assets_by_customer_email(email)
-    user = snipeit_user_by_email(email)
-    if !user
+    rows = ::Snipeit.assets_assigned_to_email(email)
+    if rows.nil?
       logger.info "No exact email match found in Snipe-IT for #{email}"
       return
     end
 
-    logger.info "Found Snipe-IT user: #{user['username']} (ID: #{user['id']}) for email #{email}"
-
-    ::Snipeit.query('hardware', {
-                      assigned_to:   user['id'],
-                      assigned_type: 'App\\Models\\User',
-                    }) || { total: 0, rows: [] }
+    { total: rows.length, rows: rows }
   rescue => e
     logger.error "Failed to search user by email: #{e.message}"
     nil
-  end
-
-  # Snipe-IT matches 'email' exactly, unlike 'search', which would return a fuzzy first page
-  # the customer may not even be part of. The find below stays as a defensive re-check.
-  def snipeit_user_by_email(email)
-    response = ::Snipeit.query('users', { email: email })
-    return if response.blank? || response['rows'].blank?
-
-    response['rows'].find { |user| user['email']&.downcase == email.downcase }
   end
 end

--- a/app/controllers/integration/snipeit_controller.rb
+++ b/app/controllers/integration/snipeit_controller.rb
@@ -47,14 +47,12 @@ class Integration::SnipeitController < ApplicationController
   end
 
   def update
-    params[:asset_ids] ||= []
     ticket = Ticket.find(params[:ticket_id])
-    ticket.with_lock do
-      authorize!(ticket, :update?)
-      ticket.preferences[:snipeit] ||= {}
-      ticket.preferences[:snipeit][:asset_ids] = Array(params[:asset_ids]).map(&:to_i).uniq
-      ticket.save!
-    end
+    authorize!(ticket, :update?)
+
+    Service::Ticket::ExternalReferences::Snipeit::LinkAssets
+      .with_current_user(current_user)
+      .execute(ticket: ticket, asset_ids: params[:asset_ids])
 
     render json: {
       result: 'ok',

--- a/app/controllers/integration/snipeit_controller.rb
+++ b/app/controllers/integration/snipeit_controller.rb
@@ -1,0 +1,131 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Integration::SnipeitController < ApplicationController
+  prepend_before_action :authenticate_and_authorize!
+
+  # Not applied to #verify, because admins have to be able to test a configuration before
+  # switching the integration on.
+  before_action :check_integration_enabled, only: %i[query update]
+
+  SENSITIVE_FIELDS = [:api_token].freeze
+
+  # Endpoints the legacy frontend is allowed to reach through the generic query action.
+  ALLOWED_QUERY_METHODS = %w[hardware users categories models].freeze
+
+  def verify
+    unmasked_params = unmask_sensitive_params(params, Setting.get('snipeit_config'))
+
+    response = ::Snipeit.verify(unmasked_params[:api_token], unmasked_params[:endpoint], verify_ssl: unmasked_params[:verify_ssl])
+    render json: {
+      result:   'ok',
+      response: response,
+    }
+  rescue => e
+    logger.error e
+
+    render json: {
+      result:  'failed',
+      message: e.message,
+    }
+  end
+
+  def query
+    result   = assets_by_ids if params[:ids].present?
+    result ||= assets_by_customer_email(params[:search]) if customer_email_search?
+    result ||= ::Snipeit.query(query_method, query_filter)
+
+    render json: {
+      result: result,
+    }
+  rescue => e
+    logger.error e
+
+    render json: {
+      result:  'failed',
+      message: e.message,
+    }
+  end
+
+  def update
+    params[:asset_ids] ||= []
+    ticket = Ticket.find(params[:ticket_id])
+    ticket.with_lock do
+      authorize!(ticket, :update?)
+      ticket.preferences[:snipeit] ||= {}
+      ticket.preferences[:snipeit][:asset_ids] = Array(params[:asset_ids]).map(&:to_i).uniq
+      ticket.save!
+    end
+
+    render json: {
+      result: 'ok',
+    }
+  end
+
+  private
+
+  def check_integration_enabled
+    Service::CheckFeatureEnabled.execute(
+      name:                   'snipeit_integration',
+      custom_exception_class: Exceptions::Forbidden,
+      custom_error_message:   __('Snipe-IT integration is not enabled'),
+    )
+  end
+
+  def query_method
+    method = params[:method].presence || 'hardware'
+    raise format(__("Unsupported Snipe-IT query method '%s'."), method) if ALLOWED_QUERY_METHODS.exclude?(method)
+
+    method
+  end
+
+  def query_filter
+    filter = params[:filter].present? ? params[:filter].permit!.to_h.symbolize_keys : {}
+    filter[:search] = params[:search] if params[:search].present?
+    filter
+  end
+
+  def assets_by_ids
+    rows = Array(params[:ids]).filter_map do |asset_id|
+      ::Snipeit.asset(asset_id)
+    rescue => e
+      logger.error "Failed to fetch asset #{asset_id}: #{e.message}"
+      nil
+    end
+
+    { rows: rows }
+  end
+
+  def customer_email_search?
+    params[:search].present? && params[:search].include?('@')
+  end
+
+  # Look up the Snipe-IT user for the given customer email and return the assets assigned
+  # to them. Returns nil if no matching user exists, so that the caller falls back to a
+  # regular search.
+  def assets_by_customer_email(email)
+    user = snipeit_user_by_email(email)
+    if !user
+      logger.info "No exact email match found in Snipe-IT for #{email}"
+      return
+    end
+
+    logger.info "Found Snipe-IT user: #{user['username']} (ID: #{user['id']}) for email #{email}"
+
+    ::Snipeit.query('hardware', {
+                      assigned_to:   user['id'],
+                      assigned_type: 'App\\Models\\User',
+                    }) || { total: 0, rows: [] }
+  rescue => e
+    logger.error "Failed to search user by email: #{e.message}"
+    nil
+  end
+
+  # Snipe-IT matches 'email' exactly, unlike 'search', which would return a fuzzy first page
+  # the customer may not even be part of. The find below stays as a defensive re-check.
+  def snipeit_user_by_email(email)
+    response = ::Snipeit.query('users', { email: email })
+    return if response.blank? || response['rows'].blank?
+
+    response['rows'].find { |user| user['email']&.downcase == email.downcase }
+  end
+end

--- a/app/frontend/apps/desktop/initializer/assets/snipeit-logo-dark.svg
+++ b/app/frontend/apps/desktop/initializer/assets/snipeit-logo-dark.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="12" fill="#353535"/>
+  <path d="M7 8.5h10v1.5H7V8.5zm0 3h10v1.5H7V11.5zm0 3h6.5V16H7v-1.5z" fill="white"/>
+  <rect x="15.5" y="14" width="2.5" height="3.5" rx="0.5" fill="#1ABC9C"/>
+</svg>

--- a/app/frontend/apps/desktop/initializer/assets/snipeit-logo-light.svg
+++ b/app/frontend/apps/desktop/initializer/assets/snipeit-logo-light.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="12" fill="white"/>
+  <path d="M7 8.5h10v1.5H7V8.5zm0 3h10v1.5H7V11.5zm0 3h6.5V16H7v-1.5z" fill="#171E24"/>
+  <rect x="15.5" y="14" width="2.5" height="3.5" rx="0.5" fill="#1ABC9C"/>
+</svg>

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-snipeit.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-create/ticket-create-snipeit.spec.ts
@@ -1,0 +1,40 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import { within } from '@testing-library/vue'
+
+import { visitView } from '#tests/support/components/visitView.ts'
+import { mockApplicationConfig } from '#tests/support/mock-applicationConfig.ts'
+import { mockPermissions } from '#tests/support/mock-permissions.ts'
+
+import getUuid from '#shared/utils/getUuid.ts'
+
+describe('Ticket create Snipe-IT links', () => {
+  it('displays Snipe-IT integration', async () => {
+    mockApplicationConfig({
+      snipeit_integration: true,
+    })
+    mockPermissions(['ticket.agent'])
+
+    const uid = getUuid()
+    const view = await visitView(`/ticket/create/${uid}`)
+
+    const sidebar = view.getByLabelText('Content sidebar')
+
+    expect(within(sidebar).getByRole('button', { name: 'Snipe-IT' })).toBeInTheDocument()
+  })
+
+  it('hides Snipe-IT integration when not available', async () => {
+    mockPermissions(['ticket.agent'])
+
+    mockApplicationConfig({
+      snipeit_integration: false,
+    })
+
+    const uid = getUuid()
+    const view = await visitView(`/ticket/create/${uid}`)
+
+    const sidebar = view.getByLabelText('Content sidebar')
+
+    expect(within(sidebar).queryByRole('button', { name: 'Snipe-IT' })).not.toBeInTheDocument()
+  })
+})

--- a/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-snipeit.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/__tests__/ticket-detail-view/ticket-detail-view-snipeit.spec.ts
@@ -1,0 +1,53 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+import { within } from '@testing-library/vue'
+
+import { visitView } from '#tests/support/components/visitView.ts'
+import { mockApplicationConfig } from '#tests/support/mock-applicationConfig.ts'
+import { mockPermissions } from '#tests/support/mock-permissions.ts'
+
+import { mockTicketQuery } from '#shared/entities/ticket/graphql/queries/ticket.mocks.ts'
+import { createDummyTicket } from '#shared/entities/ticket-article/__tests__/mocks/ticket.ts'
+
+import { mockTicketExternalReferencesSnipeitAssetListQuery } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.mocks.ts'
+
+describe('Ticket detail view Snipe-IT integration', () => {
+  it('displays Snipe-IT integration', async () => {
+    mockPermissions(['ticket.agent'])
+
+    await mockApplicationConfig({
+      snipeit_integration: true,
+    })
+
+    const ticket = createDummyTicket()
+
+    mockTicketQuery({ ticket })
+
+    const view = await visitView('/tickets/1')
+
+    const sidebar = view.getByLabelText('Content sidebar')
+
+    expect(within(sidebar).getByRole('button', { name: 'Snipe-IT' })).toBeInTheDocument()
+  })
+
+  it('hides Snipe-IT integration when not available', async () => {
+    mockPermissions(['ticket.agent'])
+
+    mockTicketExternalReferencesSnipeitAssetListQuery({
+      ticketExternalReferencesSnipeitAssetList: [],
+    })
+
+    await mockApplicationConfig({
+      snipeit_integration: false,
+    })
+
+    const ticket = createDummyTicket()
+
+    mockTicketQuery({ ticket })
+
+    const view = await visitView('/tickets/1')
+
+    const sidebar = view.getByLabelText('Content sidebar')
+
+    expect(within(sidebar).queryByRole('button', { name: 'Snipe-IT' })).not.toBeInTheDocument()
+  })
+})

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue
@@ -1,0 +1,213 @@
+<!-- Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/ -->
+
+<script setup lang="ts">
+import { useDebounceFn } from '@vueuse/core'
+import { computed, watchEffect } from 'vue'
+
+import Form from '#shared/components/Form/Form.vue'
+import type { FormSchemaNode } from '#shared/components/Form/types.ts'
+import { useForm } from '#shared/components/Form/useForm.ts'
+import { useDebouncedLoading } from '#shared/composables/useDebouncedLoading.ts'
+import UserError from '#shared/errors/UserError.ts'
+import { QueryHandler } from '#shared/server/apollo/handler/index.ts'
+
+import CommonFlyout from '#desktop/components/CommonFlyout/CommonFlyout.vue'
+import { closeFlyout } from '#desktop/components/CommonFlyout/useFlyout.ts'
+import CommonLoader from '#desktop/components/CommonLoader/CommonLoader.vue'
+import type { TableItem } from '#desktop/components/CommonTable/types'
+import SnipeitAssetList from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout/SnipeitAssetList.vue'
+import type { FormDataRecords } from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/types.ts'
+import { AutocompleteSearchSnipeitCategoriesDocument } from '#desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.api.ts'
+import { AutocompleteSearchSnipeitModelsDocument } from '#desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.api.ts'
+import { useTicketExternalReferencesSnipeitAssetSearchQuery } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.api.ts'
+
+interface Props {
+  assetIds: number[]
+  onSubmit: (formData: FormDataRecords) => Promise<unknown>
+  icon: string
+}
+
+const props = defineProps<Props>()
+
+const { form, values, updateFieldValues, onChangedField, formSetErrors } = useForm()
+
+const FETCH_LIMIT = 10
+const FETCH_DEBOUNCE = 300
+
+const flyoutName = 'snipeit'
+
+const assetSearchQuery = new QueryHandler(
+  useTicketExternalReferencesSnipeitAssetSearchQuery(
+    {
+      limit: FETCH_LIMIT,
+      categoryId: values.value?.category as string,
+      modelId: values.value?.model as string,
+      query: values.value?.filter as string,
+    },
+    {
+      fetchPolicy: 'no-cache',
+    },
+  ),
+  {
+    errorShowNotification: false,
+  },
+)
+
+const result = assetSearchQuery.result()
+
+const isLoading = assetSearchQuery.loading()
+
+assetSearchQuery.onError(() => {
+  formSetErrors(
+    new UserError([
+      {
+        field: 'category',
+        message: __('Error fetching Snipe-IT information. Please contact your administrator.'),
+      },
+    ]),
+  )
+})
+
+const { debouncedLoading, loading } = useDebouncedLoading()
+
+watchEffect(() => {
+  loading.value = isLoading.value
+})
+
+const assetItems = computed(
+  () =>
+    result.value?.ticketExternalReferencesSnipeitAssetSearch.map((asset) => ({
+      id: asset.snipeitAssetId,
+      snipeitAssetId: asset.snipeitAssetId,
+      name: {
+        link: asset.link,
+        label: asset.name,
+        openInNewTab: true,
+        external: true,
+      },
+      status: asset.status,
+      assetTag: asset.assetTag,
+      disabled: props.assetIds.includes(asset.snipeitAssetId),
+      checked: props.assetIds.includes(asset.snipeitAssetId),
+    })) || [],
+)
+
+const refetchAssets = (overrides: Record<string, unknown> = {}) =>
+  assetSearchQuery.refetch({
+    limit: FETCH_LIMIT,
+    categoryId: values.value?.category as string,
+    modelId: values.value?.model as string,
+    query: values.value?.filter as string,
+    ...overrides,
+  })
+
+onChangedField(
+  'filter',
+  useDebounceFn((query) => refetchAssets({ query: query as string }), FETCH_DEBOUNCE),
+)
+
+onChangedField('category', async (category) => refetchAssets({ categoryId: category as string }))
+
+onChangedField('model', async (model) => refetchAssets({ modelId: model as string }))
+
+const schema: FormSchemaNode[] = [
+  {
+    type: 'autocomplete',
+    name: 'category',
+    label: __('Category'),
+    props: {
+      gqlQuery: AutocompleteSearchSnipeitCategoriesDocument,
+      clearable: true,
+      defaultFilter: '*',
+      classes: {
+        outer: 'mb-3',
+      },
+    },
+  },
+  {
+    type: 'autocomplete',
+    name: 'model',
+    label: __('Model'),
+    props: {
+      gqlQuery: AutocompleteSearchSnipeitModelsDocument,
+      clearable: true,
+      defaultFilter: '*',
+      classes: {
+        outer: 'mb-3',
+      },
+    },
+  },
+  {
+    type: 'text',
+    name: 'filter',
+    label: __('Filter'),
+    placeholder: __('Search…'),
+    props: {
+      prefixIcon: 'search',
+      classes: {
+        input: 'rtl:pr-2 ltr:pl-1 ltr:pl-2 rtl:pr-1',
+        outer: 'mb-4',
+      },
+    },
+  },
+  {
+    type: 'hidden',
+    name: 'assetIds',
+  },
+]
+
+const handleAssetSelection = (selectedRows: TableItem[]) =>
+  updateFieldValues({
+    assetIds: selectedRows
+      .filter((asset) => !asset.disabled)
+      .map(({ snipeitAssetId }) => snipeitAssetId) as number[],
+  })
+
+const preselectedAssetIds = computed(() => props.assetIds.map((id) => id.toString()))
+
+// Only count newly added assets
+const isValid = computed(
+  () =>
+    ((values.value?.assetIds as number[])?.filter((id) => !props.assetIds.includes(id)) || [])
+      .length > 0,
+)
+
+const submitAssets = async (data: FormDataRecords) => {
+  await props.onSubmit(data)
+
+  return () => closeFlyout(flyoutName)
+}
+</script>
+
+<template>
+  <CommonFlyout
+    :header-icon="icon"
+    :header-title="__('Snipe-IT: Link assets')"
+    :name="flyoutName"
+    no-close-on-action
+    :form="form"
+    :footer-action-options="{
+      actionLabel: $t('Link assets'),
+      actionButton: {
+        type: 'submit',
+        disabled: !isValid,
+      },
+    }"
+  >
+    <Form
+      ref="form"
+      should-autofocus
+      :schema="schema"
+      @submit="submitAssets($event as FormDataRecords)"
+    />
+
+    <CommonLoader :loading="debouncedLoading">
+      <SnipeitAssetList
+        class="w-full"
+        :items="assetItems"
+        :disabled-checkbox-ids="preselectedAssetIds"
+        @update:checked-rows="handleAssetSelection"
+      />
+    </CommonLoader>
+  </CommonFlyout>
+</template>

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue
@@ -106,7 +106,13 @@ onChangedField(
   useDebounceFn((query) => refetchAssets({ query: query as string }), FETCH_DEBOUNCE),
 )
 
-onChangedField('category', async (category) => refetchAssets({ categoryId: category as string }))
+onChangedField('category', async (category) => {
+  // Models belong to a category, so a model picked under the previous category would
+  // silently keep filtering the list down to nothing.
+  if (values.value?.model) updateFieldValues({ model: undefined })
+
+  return refetchAssets({ categoryId: category as string, modelId: undefined })
+})
 
 onChangedField('model', async (model) => refetchAssets({ modelId: model as string }))
 
@@ -132,6 +138,10 @@ const schema: FormSchemaNode[] = [
       gqlQuery: AutocompleteSearchSnipeitModelsDocument,
       clearable: true,
       defaultFilter: '*',
+      // Spread into the query input, so the model list follows the selected category.
+      additionalQueryParams: () => ({
+        categoryId: values.value?.category as string,
+      }),
       classes: {
         outer: 'mb-3',
       },

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue
@@ -25,6 +25,7 @@ interface Props {
   assetIds: number[]
   onSubmit: (formData: FormDataRecords) => Promise<unknown>
   icon: string
+  customerId?: string
 }
 
 const props = defineProps<Props>()
@@ -43,6 +44,7 @@ const assetSearchQuery = new QueryHandler(
       categoryId: values.value?.category as string,
       modelId: values.value?.model as string,
       query: values.value?.filter as string,
+      customerId: props.customerId,
     },
     {
       fetchPolicy: 'no-cache',
@@ -98,6 +100,7 @@ const refetchAssets = (overrides: Record<string, unknown> = {}) =>
     categoryId: values.value?.category as string,
     modelId: values.value?.model as string,
     query: values.value?.filter as string,
+    customerId: props.customerId,
     ...overrides,
   })
 

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout/SnipeitAssetList.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout/SnipeitAssetList.vue
@@ -1,0 +1,35 @@
+<!-- Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/ -->
+
+<script setup lang="ts">
+import CommonSimpleTable from '#desktop/components/CommonTable/CommonSimpleTable.vue'
+import type { TableSimpleHeader, TableItem } from '#desktop/components/CommonTable/types'
+
+interface Props {
+  items: TableItem[]
+}
+
+defineProps<Props>()
+
+const headers: TableSimpleHeader[] = [
+  { key: 'snipeitAssetId', label: 'ID', truncate: true },
+  {
+    key: 'name',
+    label: __('Name'),
+    type: 'link',
+    truncate: true,
+  },
+  { key: 'assetTag', label: __('Asset Tag'), truncate: true },
+  { key: 'status', label: __('Status'), truncate: true },
+]
+</script>
+
+<template>
+  <CommonSimpleTable
+    v-if="items.length"
+    :caption="$t('Snipe-IT assets')"
+    :items="items"
+    :headers="headers"
+    has-checkbox-column
+  />
+  <CommonLabel v-else>{{ $t('No results found') }}</CommonLabel>
+</template>

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout/__tests__/SnipeitAssetList.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout/__tests__/SnipeitAssetList.spec.ts
@@ -1,0 +1,60 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+import { within } from '@testing-library/vue'
+
+import renderComponent from '#tests/support/components/renderComponent.ts'
+
+import SnipeitAssetList from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout/SnipeitAssetList.vue'
+
+describe('SnipeitAssetList', () => {
+  it('renders table correctly', () => {
+    const wrapper = renderComponent(SnipeitAssetList, {
+      props: {
+        items: [
+          {
+            id: 26,
+            snipeitAssetId: 26,
+            name: {
+              link: 'http://localhost:9001/hardware/26',
+              label: 'Laptop-001',
+              openInNewTab: true,
+              external: true,
+            },
+            assetTag: 'LAP001',
+            status: 'Ready to Deploy',
+          },
+        ],
+      },
+      router: true,
+      form: true,
+    })
+
+    const container = wrapper.getByRole('table')
+
+    const link = within(container).getByRole('link')
+
+    expect(link).toHaveTextContent('Laptop-001')
+    expect(link).toHaveAttribute('href', 'http://localhost:9001/hardware/26')
+    expect(link).toHaveAttribute('target', '_blank')
+
+    expect(container).toHaveTextContent('ID')
+    expect(container).toHaveTextContent('26')
+
+    expect(container).toHaveTextContent('Asset Tag')
+    expect(container).toHaveTextContent('LAP001')
+
+    expect(container).toHaveTextContent('Status')
+    expect(container).toHaveTextContent('Ready to Deploy')
+
+    expect(wrapper.getByRole('cell', { name: '26' })).toBeInTheDocument()
+  })
+
+  it('shows empty state message', () => {
+    const wrapper = renderComponent(SnipeitAssetList, {
+      props: {
+        items: [],
+      },
+    })
+
+    expect(wrapper.getByText('No results found')).toBeInTheDocument()
+  })
+})

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeit.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeit.vue
@@ -3,6 +3,8 @@
 <script setup lang="ts">
 import { computed, onMounted, watch, toRef } from 'vue'
 
+import { convertToGraphQLId } from '#shared/graphql/utils.ts'
+
 import TicketSidebarSnipeitContent from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeitContent.vue'
 import type { ExternalReferencesFormValues } from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/types.ts'
 import { usePersistentStates } from '#desktop/pages/ticket/composables/usePersistentStates.ts'
@@ -48,6 +50,17 @@ const assetIds = computed(() => {
   return props.context.ticket?.value?.preferences?.snipeit?.asset_ids || []
 })
 
+// The flyout suggests the assets assigned to the ticket customer while no filter is set.
+// On the create screen the customer only exists in the form, not on a ticket yet.
+const customerId = computed(() => {
+  if (props.context.screenType === TicketSidebarScreenType.TicketCreate) {
+    const formCustomerId = props.context.formValues?.customer_id
+    return formCustomerId ? convertToGraphQLId('User', formCustomerId as string) : undefined
+  }
+
+  return props.context.ticket?.value?.customer?.id
+})
+
 const assetBadges = computed(() =>
   assetIds.value?.length
     ? {
@@ -91,6 +104,7 @@ if (props.context.screenType === TicketSidebarScreenType.TicketDetailView) {
       v-model="persistentStates"
       :screen-type="context.screenType"
       :ticket-id="context.ticket?.value?.id"
+      :customer-id="customerId"
       :sidebar-plugin="plugin"
       :asset-ids="assetIds"
       :form="context.form"

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeit.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeit.vue
@@ -1,0 +1,100 @@
+<!-- Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/ -->
+
+<script setup lang="ts">
+import { computed, onMounted, watch, toRef } from 'vue'
+
+import TicketSidebarSnipeitContent from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeitContent.vue'
+import type { ExternalReferencesFormValues } from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/types.ts'
+import { usePersistentStates } from '#desktop/pages/ticket/composables/usePersistentStates.ts'
+import {
+  TicketSidebarScreenType,
+  type TicketSidebarEmits,
+  type TicketSidebarProps,
+  TicketSidebarButtonBadgeType,
+} from '#desktop/pages/ticket/types/sidebar.ts'
+import { useThemeStore } from '#desktop/stores/theme.ts'
+
+import TicketSidebarWrapper from '../../TicketSidebarWrapper.vue'
+
+const props = defineProps<TicketSidebarProps>()
+
+const { persistentStates } = usePersistentStates()
+
+const emit = defineEmits<TicketSidebarEmits>()
+
+const isTicketEditable = computed(
+  () => props.context.isTicketEditable?.value ?? true, // True for ticket create screen.
+)
+
+const isDarkMode = toRef(useThemeStore(), 'isDarkMode')
+
+const plugin = computed(() => {
+  const icon = isDarkMode.value
+    ? `${props.sidebarPlugin.icon}-light`
+    : `${props.sidebarPlugin.icon}-dark`
+
+  return {
+    ...props.sidebarPlugin,
+    icon,
+  }
+})
+
+const assetIds = computed(() => {
+  if (props.context.screenType === TicketSidebarScreenType.TicketCreate)
+    return (
+      (props.context.formValues as ExternalReferencesFormValues).externalReferences?.snipeit || []
+    )
+
+  return props.context.ticket?.value?.preferences?.snipeit?.asset_ids || []
+})
+
+const assetBadges = computed(() =>
+  assetIds.value?.length
+    ? {
+        label: __('Assets'),
+        type: TicketSidebarButtonBadgeType.Default,
+        value: assetIds.value?.length,
+      }
+    : undefined,
+)
+
+const hideSidebar = computed(() => !assetIds.value?.length && !isTicketEditable.value)
+
+if (props.context.screenType === TicketSidebarScreenType.TicketDetailView) {
+  watch(
+    hideSidebar,
+    (value) => {
+      if (value) {
+        emit('hide')
+      } else {
+        emit('show')
+      }
+    },
+    { immediate: true },
+  )
+} else {
+  onMounted(() => {
+    emit('show')
+  })
+}
+</script>
+
+<template>
+  <TicketSidebarWrapper
+    :key="sidebar"
+    :sidebar="sidebar"
+    :sidebar-plugin="plugin"
+    :selected="selected"
+    :badge="assetBadges"
+  >
+    <TicketSidebarSnipeitContent
+      v-model="persistentStates"
+      :screen-type="context.screenType"
+      :ticket-id="context.ticket?.value?.id"
+      :sidebar-plugin="plugin"
+      :asset-ids="assetIds"
+      :form="context.form"
+      :is-ticket-editable="isTicketEditable"
+    />
+  </TicketSidebarWrapper>
+</template>

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeitContent.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeitContent.vue
@@ -30,6 +30,7 @@ interface Props {
   screenType: TicketSidebarScreenType
   isTicketEditable: boolean
   ticketId?: string
+  customerId?: string
   form?: FormRef
 }
 const props = defineProps<Props>()
@@ -132,6 +133,7 @@ const openFlyout = () =>
   open({
     assetIds: props.assetIds,
     ticketId: props.ticketId,
+    customerId: props.customerId,
     onSubmit: addAssets,
     icon: props.sidebarPlugin.icon,
   })

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeitContent.vue
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeitContent.vue
@@ -1,0 +1,239 @@
+<!-- Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/ -->
+
+<script setup lang="ts">
+import { isEqual } from 'lodash-es'
+import { computed, ref, toRef, watch } from 'vue'
+
+import type { FormRef } from '#shared/components/Form/types.ts'
+import { MutationHandler, QueryHandler } from '#shared/server/apollo/handler/index.ts'
+import type { ObjectLike } from '#shared/types/utils.ts'
+
+import CommonButton from '#desktop/components/CommonButton/CommonButton.vue'
+import { useFlyout } from '#desktop/components/CommonFlyout/useFlyout.ts'
+import CommonLoader from '#desktop/components/CommonLoader/CommonLoader.vue'
+import type { MenuItem } from '#desktop/components/CommonPopoverMenu/types.ts'
+import type { TicketSidebarPlugin } from '#desktop/pages/ticket/components/TicketSidebar/plugins/types.ts'
+import TicketSidebarContent from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarContent.vue'
+import ExternalReferenceContent from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/ExternalReferenceContent.vue'
+import ExternalReferenceLink from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/ExternalReferenceLink.vue'
+import type { FormDataRecords } from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/types.ts'
+import { useSnipeitCacheHandlers } from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/useSnipeitCacheHandlers.ts'
+import { useSnipeitFormHelpers } from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/useSnipeitFormHelpers.ts'
+import { useTicketExternalReferencesSnipeitAssetAddMutation } from '#desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetAdd.api.ts'
+import { useTicketExternalReferencesSnipeitAssetRemoveMutation } from '#desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.api.ts'
+import { useTicketExternalReferencesSnipeitAssetListQuery } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.api.ts'
+import { TicketSidebarScreenType } from '#desktop/pages/ticket/types/sidebar.ts'
+
+interface Props {
+  sidebarPlugin: TicketSidebarPlugin
+  assetIds: number[]
+  screenType: TicketSidebarScreenType
+  isTicketEditable: boolean
+  ticketId?: string
+  form?: FormRef
+}
+const props = defineProps<Props>()
+
+const persistentStates = defineModel<ObjectLike>({ required: true })
+
+const skipNextAssetUpdate = ref(false)
+
+const { open } = useFlyout({
+  name: 'snipeit',
+  component: () => import('./SnipeitFlyout.vue'),
+})
+
+const assetListQuery = new QueryHandler(
+  useTicketExternalReferencesSnipeitAssetListQuery(
+    () => ({
+      ticketId: props.ticketId,
+      snipeitAssetIds: props.ticketId ? undefined : props.assetIds,
+    }),
+    () => ({
+      enabled:
+        props.screenType === TicketSidebarScreenType.TicketCreate
+          ? props.assetIds?.length > 0
+          : !!props.ticketId,
+      fetchPolicy:
+        props.screenType === TicketSidebarScreenType.TicketCreate
+          ? 'cache-first'
+          : 'cache-and-network',
+    }),
+  ),
+  {
+    errorShowNotification: false,
+  },
+)
+
+const result = assetListQuery.result()
+
+const isLoading = assetListQuery.loading()
+
+const queryError = assetListQuery.operationError()
+
+const error = computed(() =>
+  queryError.value
+    ? __(`Error fetching information from Snipe-IT. Please contact your administrator.`)
+    : null,
+)
+
+const assetList = computed(() => {
+  return result.value?.ticketExternalReferencesSnipeitAssetList || []
+})
+
+const { removeAssetListCacheUpdate, modifyAssetItemAddCache } = useSnipeitCacheHandlers(
+  toRef(props, 'assetIds'),
+  toRef(props, 'ticketId'),
+)
+
+const { addAssetIdsToForm, removeAssetFromForm } = useSnipeitFormHelpers(toRef(props, 'form'))
+
+const removeAssetMutation = new MutationHandler(
+  useTicketExternalReferencesSnipeitAssetRemoveMutation(),
+)
+
+const removeAsset = async ({ id }: { id: number }) => {
+  const revertCacheUpdate = removeAssetListCacheUpdate(id)
+
+  if (props.screenType === TicketSidebarScreenType.TicketCreate) return removeAssetFromForm(id)
+
+  return removeAssetMutation
+    .send({
+      snipeitAssetId: id,
+      ticketId: props.ticketId!,
+    })
+    .catch(() => revertCacheUpdate)
+}
+
+const addAssetMutation = new MutationHandler(
+  useTicketExternalReferencesSnipeitAssetAddMutation({
+    update: modifyAssetItemAddCache,
+  }),
+)
+
+const addAssets = async (formData: FormDataRecords) => {
+  skipNextAssetUpdate.value = true
+
+  return addAssetMutation
+    .send({
+      snipeitAssetIds: formData.assetIds,
+      ticketId: props.ticketId,
+    })
+    .then((result) => {
+      if (props.screenType === TicketSidebarScreenType.TicketCreate)
+        addAssetIdsToForm(result?.ticketExternalReferencesSnipeitAssetAdd?.snipeitAssets)
+    })
+    .finally(() => {
+      skipNextAssetUpdate.value = false
+    })
+}
+
+const openFlyout = () =>
+  open({
+    assetIds: props.assetIds,
+    ticketId: props.ticketId,
+    onSubmit: addAssets,
+    icon: props.sidebarPlugin.icon,
+  })
+
+const actions = computed((): MenuItem[] =>
+  props.assetIds?.length && !error.value
+    ? [
+        {
+          key: 'link-snipeit-asset',
+          label: __('Link assets'),
+          show: () => props.isTicketEditable,
+          onClick: openFlyout,
+          icon: 'link-45deg',
+        },
+      ]
+    : [],
+)
+
+if (props.ticketId) {
+  watch(
+    () => props.assetIds,
+    (newValue) => {
+      if (
+        isEqual(
+          newValue,
+          assetList.value.map((asset) => asset.snipeitAssetId),
+        ) ||
+        skipNextAssetUpdate.value
+      ) {
+        skipNextAssetUpdate.value = false
+        return
+      }
+
+      assetListQuery.refetch()
+    },
+  )
+}
+</script>
+
+<template>
+  <TicketSidebarContent
+    v-model="persistentStates.scrollPosition"
+    :title="sidebarPlugin.title"
+    :icon="sidebarPlugin.icon"
+    :actions="actions"
+  >
+    <CommonButton
+      v-if="!assetIds?.length"
+      size="medium"
+      variant="primary"
+      class="block ltr:w-full rtl:w-full"
+      @click="openFlyout"
+    >
+      {{ $t('Link assets') }}
+    </CommonButton>
+
+    <CommonLoader v-if="assetIds?.length" :loading="isLoading" :error="error">
+      <div class="space-y-6" tabindex="-1">
+        <div
+          v-for="asset in assetList"
+          :key="asset.snipeitAssetId"
+          class="group space-y-2"
+          role="group"
+        >
+          <ExternalReferenceLink
+            :id="asset.snipeitAssetId"
+            :title="asset.name"
+            :link="asset.link!"
+            :is-editable="isTicketEditable"
+            :tooltip="$t('Unlink asset')"
+            @remove="removeAsset"
+          />
+
+          <ExternalReferenceContent :label="$t('ID')" :values="[asset.snipeitAssetId.toString()]" />
+
+          <ExternalReferenceContent
+            v-if="asset.assetTag"
+            :label="$t('Asset Tag')"
+            :values="[asset.assetTag]"
+          />
+          <ExternalReferenceContent
+            v-if="asset.status"
+            :label="$t('Status')"
+            :values="[asset.status]"
+          />
+          <ExternalReferenceContent
+            v-if="asset.model"
+            :label="$t('Model')"
+            :values="[asset.model]"
+          />
+          <ExternalReferenceContent
+            v-if="asset.category"
+            :label="$t('Category')"
+            :values="[asset.category]"
+          />
+          <ExternalReferenceContent
+            v-if="asset.location"
+            :label="$t('Location')"
+            :values="[asset.location]"
+          />
+        </div>
+      </div>
+    </CommonLoader>
+  </TicketSidebarContent>
+</template>

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/SnipeitFlyout.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/SnipeitFlyout.spec.ts
@@ -2,7 +2,14 @@
 
 import renderComponent from '#tests/support/components/renderComponent.ts'
 
+import { convertToGraphQLId } from '#shared/graphql/utils.ts'
+
 import SnipeitFlyout from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue'
+import { mockAutocompleteSearchSnipeitCategoriesQuery } from '#desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.mocks.ts'
+import {
+  mockAutocompleteSearchSnipeitModelsQuery,
+  waitForAutocompleteSearchSnipeitModelsQueryCalls,
+} from '#desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.mocks.ts'
 import { mockTicketExternalReferencesSnipeitAssetSearchQuery } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.mocks.ts'
 
 describe('SnipeitFlyout', () => {
@@ -53,5 +60,63 @@ describe('SnipeitFlyout', () => {
     expect(wrapper.getByLabelText('Filter')).toBeInTheDocument()
 
     expect(await wrapper.findByText('LG Power')).toBeInTheDocument()
+  })
+
+  it('asks for the assets assigned to the ticket customer', async () => {
+    const calls = mockTicketExternalReferencesSnipeitAssetSearchQuery({
+      ticketExternalReferencesSnipeitAssetSearch: [],
+    })
+
+    renderComponent(SnipeitFlyout, {
+      props: {
+        name: 'flyout-snipeit',
+        assetIds: [],
+        onSubmit: vi.fn(),
+        icon: 'snipeit-logo-light',
+        customerId: convertToGraphQLId('User', 42),
+      },
+      form: true,
+      router: true,
+      flyout: true,
+    })
+
+    const [call] = await calls.waitForCalls()
+
+    expect(call.variables).toEqual(
+      expect.objectContaining({ customerId: convertToGraphQLId('User', 42) }),
+    )
+  })
+
+  it('reloads the model list when the category changes', async () => {
+    mockTicketExternalReferencesSnipeitAssetSearchQuery({
+      ticketExternalReferencesSnipeitAssetSearch: [],
+    })
+    mockAutocompleteSearchSnipeitCategoriesQuery({
+      autocompleteSearchSnipeitCategories: [{ value: '3', label: 'Laptops' }],
+    })
+    mockAutocompleteSearchSnipeitModelsQuery({
+      autocompleteSearchSnipeitModels: [{ value: '1', label: 'MacBook Pro' }],
+    })
+
+    const wrapper = renderComponent(SnipeitFlyout, {
+      props: {
+        name: 'flyout-snipeit',
+        assetIds: [],
+        onSubmit: vi.fn(),
+        icon: 'snipeit-logo-light',
+      },
+      form: true,
+      router: true,
+      flyout: true,
+    })
+
+    await wrapper.events.click(wrapper.getByLabelText('Category'))
+    await wrapper.events.click(await wrapper.findByRole('option', { name: 'Laptops' }))
+
+    const calls = await waitForAutocompleteSearchSnipeitModelsQueryCalls()
+
+    expect(calls.at(-1)?.variables).toEqual({
+      input: expect.objectContaining({ categoryId: '3' }),
+    })
   })
 })

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/SnipeitFlyout.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/SnipeitFlyout.spec.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import renderComponent from '#tests/support/components/renderComponent.ts'
+
+import SnipeitFlyout from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/SnipeitFlyout.vue'
+import { mockTicketExternalReferencesSnipeitAssetSearchQuery } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.mocks.ts'
+
+describe('SnipeitFlyout', () => {
+  it('renders flyout Ui correctly', async () => {
+    mockTicketExternalReferencesSnipeitAssetSearchQuery({
+      ticketExternalReferencesSnipeitAssetSearch: [
+        {
+          snipeitAssetId: 26,
+          link: 'http://localhost:9001/hardware/26',
+          name: 'Test',
+          assetTag: 'TEST001',
+          status: 'Ready to Deploy',
+          model: 'MacBook Pro',
+          category: 'Laptops',
+        },
+        {
+          snipeitAssetId: 27,
+          link: 'http://localhost:9001/hardware/27',
+          name: 'LG Power',
+          assetTag: 'MON001',
+          status: 'Deployed',
+          model: 'UltraSharp',
+          category: 'Monitors',
+        },
+      ],
+    })
+
+    const mockSubmit = vi.fn()
+
+    const wrapper = renderComponent(SnipeitFlyout, {
+      props: {
+        name: 'flyout-snipeit',
+        assetIds: [26, 27],
+        onSubmit: mockSubmit,
+        icon: 'snipeit-logo-light',
+      },
+      form: true,
+      router: true,
+      flyout: true,
+    })
+
+    expect(wrapper.getByRole('heading', { level: 2 })).toHaveTextContent('Snipe-IT: Link assets')
+
+    expect(wrapper.getByIconName('snipeit-logo-light')).toBeInTheDocument()
+
+    expect(wrapper.getByLabelText('Category')).toBeInTheDocument()
+    expect(wrapper.getByLabelText('Model')).toBeInTheDocument()
+    expect(wrapper.getByLabelText('Filter')).toBeInTheDocument()
+
+    expect(await wrapper.findByText('LG Power')).toBeInTheDocument()
+  })
+})

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/TicketSidebarSnipeit.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/TicketSidebarSnipeit.spec.ts
@@ -21,6 +21,7 @@ import {
   mockTicketExternalReferencesSnipeitAssetListQuery,
   mockTicketExternalReferencesSnipeitAssetListQueryError,
 } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.mocks.ts'
+import { waitForTicketExternalReferencesSnipeitAssetSearchQueryCalls } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.mocks.ts'
 import { TicketSidebarScreenType } from '#desktop/pages/ticket/types/sidebar.ts'
 
 import snipeitPlugin from '../../../plugins/snipeit.ts'
@@ -257,6 +258,24 @@ describe('TicketSidebarSnipeit', () => {
     expect(wrapper.getAllByIconName('snipeit-logo-dark')).toHaveLength(3)
 
     expect(flyout).toBeInTheDocument()
+  })
+
+  it('passes the ticket customer on to the flyout so their assets are suggested', async () => {
+    const wrapper = renderSnipeitSidebar()
+
+    await wrapper.events.click(await wrapper.findByRole('button', { name: 'Action menu button' }))
+
+    const menu = await wrapper.findByRole('menu')
+
+    await wrapper.events.click(within(menu).getByRole('button', { name: 'Link assets' }))
+
+    await wrapper.findByRole('complementary', { name: 'Snipe-IT: Link assets' })
+
+    const calls = await waitForTicketExternalReferencesSnipeitAssetSearchQueryCalls()
+
+    expect(calls.at(-1)?.variables).toEqual(
+      expect.objectContaining({ customerId: createDummyTicket().customer?.id }),
+    )
   })
 
   it('removes an asset if entries are present', async () => {

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/TicketSidebarSnipeit.spec.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/__tests__/TicketSidebarSnipeit.spec.ts
@@ -1,0 +1,369 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import { within } from '@testing-library/vue'
+import { vi } from 'vitest'
+import { computed, ref } from 'vue'
+
+import renderComponent from '#tests/support/components/renderComponent.ts'
+import { mockApplicationConfig } from '#tests/support/mock-applicationConfig.ts'
+import { mockUserCurrent } from '#tests/support/mock-userCurrent.ts'
+import { mockRouterHooks } from '#tests/support/mock-vue-router.ts'
+import { waitForNextTick } from '#tests/support/utils.ts'
+
+import { createDummyTicket } from '#shared/entities/ticket-article/__tests__/mocks/ticket.ts'
+import { convertToGraphQLId } from '#shared/graphql/utils.ts'
+import { GraphQLErrorTypes } from '#shared/types/error.ts'
+
+import TicketSidebarSnipeit from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeit.vue'
+import { TICKET_SIDEBAR_SYMBOL } from '#desktop/pages/ticket/composables/useTicketSidebar.ts'
+import { waitForTicketExternalReferencesSnipeitAssetRemoveMutationCalls } from '#desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.mocks.ts'
+import {
+  mockTicketExternalReferencesSnipeitAssetListQuery,
+  mockTicketExternalReferencesSnipeitAssetListQueryError,
+} from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.mocks.ts'
+import { TicketSidebarScreenType } from '#desktop/pages/ticket/types/sidebar.ts'
+
+import snipeitPlugin from '../../../plugins/snipeit.ts'
+
+vi.mock('#shared/server/apollo/client.ts', () => ({
+  getApolloClient: () => ({
+    cache: {
+      readQuery: vi.fn(),
+      writeQuery: vi.fn(),
+    },
+  }),
+}))
+
+mockRouterHooks()
+
+const mockedData = [
+  {
+    snipeitAssetId: 111,
+    name: 'Asset 1',
+    link: 'www.snipeit.com/hardware/111',
+    status: 'Ready to Deploy',
+    model: 'MacBook Pro',
+    category: 'Laptops',
+    assetTag: 'LAP001',
+  },
+  {
+    snipeitAssetId: 2222,
+    name: 'Asset 2',
+    link: 'www.snipeit.com/hardware/222',
+    status: 'Deployed',
+    model: 'UltraSharp',
+    category: 'Monitors',
+    assetTag: 'MON001',
+  },
+]
+
+const renderSnipeitSidebar = (
+  isTicketEditable = true,
+  assets = mockedData,
+  customMocks = false,
+) => {
+  mockApplicationConfig({
+    snipeit_integration: true,
+  })
+
+  if (!customMocks) {
+    mockTicketExternalReferencesSnipeitAssetListQuery({
+      ticketExternalReferencesSnipeitAssetList: assets,
+    })
+  }
+
+  const snipeitIds: number[] = []
+
+  if (assets?.length) {
+    assets.forEach(({ snipeitAssetId }) => {
+      snipeitIds.push(snipeitAssetId)
+    })
+  }
+  const ticket = createDummyTicket({
+    preferences: { snipeit: { asset_ids: snipeitIds } },
+  })
+
+  return renderComponent(TicketSidebarSnipeit, {
+    props: {
+      sidebar: 'snipeit',
+      sidebarPlugin: snipeitPlugin,
+      selected: true,
+      context: {
+        screenType: TicketSidebarScreenType.TicketDetailView,
+        formValues: {},
+        toggleCollapse: () => {},
+        isCollapsed: false,
+        ticket: computed(() => ticket),
+        isTicketEditable: computed(() => isTicketEditable),
+      },
+    },
+    global: {
+      stubs: {
+        teleport: true,
+      },
+    },
+    flyout: true,
+    form: true,
+    router: true,
+    store: true,
+  })
+}
+
+describe('TicketSidebarSnipeit', () => {
+  it('displays on ticket create screen correctly without assets', async () => {
+    await mockApplicationConfig({
+      snipeit_integration: true,
+    })
+
+    const wrapper = renderComponent(TicketSidebarSnipeit, {
+      props: {
+        sidebar: 'snipeit',
+        sidebarPlugin: snipeitPlugin,
+        selected: true,
+        context: {
+          screenType: TicketSidebarScreenType.TicketCreate,
+          formValues: {},
+          form: {
+            formInitialSettled: true,
+          },
+          toggleCollapse: () => {},
+          isCollapsed: false,
+        },
+      },
+      provide: [
+        [
+          TICKET_SIDEBAR_SYMBOL,
+          {
+            shownSidebars: ref('snipeit'),
+            activeSidebar: ref('snipeit'),
+            switchSidebar: vi.fn(),
+          },
+        ],
+      ],
+      global: {
+        stubs: {
+          teleport: true,
+        },
+      },
+      router: true,
+      flyout: true,
+      form: true,
+    })
+
+    await wrapper.events.click(await wrapper.findByRole('button', { name: 'Snipe-IT' }))
+
+    await waitForNextTick()
+
+    expect(wrapper.getByRole('button', { name: 'Link assets' })).toBeInTheDocument()
+
+    expect(wrapper.queryByRole('status', { name: 'Assets' })).not.toBeInTheDocument()
+
+    expect(wrapper.queryByRole('button', { name: 'Action menu button' })).not.toBeInTheDocument()
+  })
+
+  it('displays on ticket create screen correctly with assets', async () => {
+    await mockApplicationConfig({
+      snipeit_integration: true,
+    })
+
+    mockTicketExternalReferencesSnipeitAssetListQuery({
+      ticketExternalReferencesSnipeitAssetList: mockedData,
+    })
+
+    const wrapper = renderComponent(TicketSidebarSnipeit, {
+      props: {
+        sidebar: 'snipeit',
+        sidebarPlugin: snipeitPlugin,
+        selected: true,
+        context: {
+          screenType: TicketSidebarScreenType.TicketCreate,
+          formValues: {
+            externalReferences: {
+              snipeit: [111, 2222],
+            },
+          },
+          form: {
+            formInitialSettled: true,
+          },
+          toggleCollapse: () => {},
+          isCollapsed: false,
+        },
+      },
+      provide: [
+        [
+          TICKET_SIDEBAR_SYMBOL,
+          {
+            shownSidebars: ref('snipeit'),
+            activeSidebar: ref('snipeit'),
+            switchSidebar: vi.fn(),
+          },
+        ],
+      ],
+      global: {
+        stubs: {
+          teleport: true,
+        },
+      },
+      router: true,
+      flyout: true,
+      form: true,
+    })
+
+    expect(wrapper.queryByRole('status', { name: 'Assets' })).toBeInTheDocument()
+
+    expect(wrapper.queryByRole('button', { name: 'Action menu button' })).toBeInTheDocument()
+
+    const group = await wrapper.findAllByRole('group')
+
+    expect(group).toHaveLength(2)
+  })
+
+  it('displays the snipeit sidebar with assets', async () => {
+    const wrapper = renderSnipeitSidebar(true, [mockedData[0]])
+
+    expect(wrapper.getByRole('heading', { name: 'Snipe-IT', level: 2 }))
+    expect(wrapper.getAllByIconName('snipeit-logo-dark')).toHaveLength(2)
+
+    expect(wrapper.getByRole('button', { name: 'Snipe-IT' })).toBeInTheDocument()
+    expect(wrapper.getByRole('status', { name: 'Assets' })).toHaveTextContent('1')
+
+    const link = await wrapper.findByRole('link')
+
+    expect(link).toHaveTextContent('Asset 1')
+    expect(link).toHaveAttribute('href', 'www.snipeit.com/hardware/111')
+
+    const group = wrapper.getByRole('group')
+
+    expect(group).toHaveTextContent('ID')
+    expect(group).toHaveTextContent('Asset Tag')
+    expect(group).toHaveTextContent('Status')
+    expect(group).toHaveTextContent('Model')
+    expect(group).toHaveTextContent('Category')
+  })
+
+  it('adds a new asset with assets present', async () => {
+    const wrapper = renderSnipeitSidebar()
+
+    await wrapper.events.click(await wrapper.findByRole('button', { name: 'Action menu button' }))
+
+    const menu = await wrapper.findByRole('menu')
+
+    await wrapper.events.click(within(menu).getByRole('button', { name: 'Link assets' }))
+
+    const flyout = await wrapper.findByRole('complementary', {
+      name: 'Snipe-IT: Link assets',
+    })
+
+    expect(wrapper.getAllByIconName('snipeit-logo-dark')).toHaveLength(3)
+
+    expect(flyout).toBeInTheDocument()
+  })
+
+  it('removes an asset if entries are present', async () => {
+    const wrapper = renderSnipeitSidebar()
+
+    const unlinkButtons = await wrapper.findAllByRole('button', {
+      name: 'Unlink asset',
+    })
+
+    await wrapper.events.click(unlinkButtons[0])
+
+    const calls = await waitForTicketExternalReferencesSnipeitAssetRemoveMutationCalls()
+
+    expect(calls.at(-1)?.variables).toEqual({
+      ticketId: convertToGraphQLId('Ticket', 1),
+      snipeitAssetId: 111,
+    })
+  })
+
+  it('does not display if no assets are linked and agent does not have update permission', async () => {
+    const wrapper = renderSnipeitSidebar(false, [])
+    expect(wrapper.emitted('hide')).toHaveLength(1)
+  })
+
+  it('does not allow adding or removing assets if ticket is not editable', async () => {
+    const wrapper = renderSnipeitSidebar(false)
+
+    await waitForNextTick()
+
+    expect(wrapper.queryByRole('button', { name: 'Unlink asset' })).not.toBeInTheDocument()
+
+    expect(wrapper.queryByRole('button', { name: 'Action menu button' })).not.toBeInTheDocument()
+  })
+
+  it('updates to light logo if theme is dark', () => {
+    mockUserCurrent({
+      preferences: {
+        theme: 'dark',
+      },
+    })
+
+    const wrapper = renderSnipeitSidebar()
+
+    expect(wrapper.getAllByIconName('snipeit-logo-light')).toHaveLength(2)
+  })
+
+  it('updates to dark logo if theme is light', () => {
+    mockUserCurrent({
+      preferences: {
+        theme: 'light',
+      },
+    })
+
+    const wrapper = renderSnipeitSidebar()
+
+    expect(wrapper.getAllByIconName('snipeit-logo-dark')).toHaveLength(2)
+  })
+})
+
+describe('errors', () => {
+  it('shows a generic error message if query fails due to failure of Snipe-IT api', async () => {
+    mockApplicationConfig({
+      snipeit_integration: true,
+    })
+
+    mockTicketExternalReferencesSnipeitAssetListQueryError(
+      'Snipe-IT request failed. Please have a look at the log file for details',
+      { type: GraphQLErrorTypes.UnknownError },
+    )
+
+    const wrapper = renderComponent(TicketSidebarSnipeit, {
+      props: {
+        sidebar: 'snipeit',
+        sidebarPlugin: snipeitPlugin,
+        selected: true,
+        context: {
+          screenType: TicketSidebarScreenType.TicketDetailView,
+          formValues: {},
+          toggleCollapse: () => {},
+          isCollapsed: false,
+          ticket: ref(
+            createDummyTicket({
+              preferences: {
+                snipeit: {
+                  asset_ids: [111, 2222],
+                },
+              },
+            }),
+          ),
+          isTicketEditable: true,
+        },
+      },
+      global: {
+        stubs: {
+          teleport: true,
+        },
+      },
+      flyout: true,
+      form: true,
+      router: true,
+      store: true,
+    })
+
+    expect(await wrapper.findByRole('alert')).toHaveTextContent(
+      'Error fetching information from Snipe-IT. Please contact your administrator.',
+    )
+
+    expect(wrapper.queryByRole('button', { name: 'Action menu button' })).not.toBeInTheDocument()
+  })
+})

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/types.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/types.ts
@@ -1,0 +1,12 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import type { FormSubmitData } from '#shared/components/Form/types.ts'
+
+export type FormFieldRecords = {
+  category: string | undefined
+  model: string | undefined
+  filter: string | undefined
+  assetIds: number[]
+}
+
+export type FormDataRecords = FormSubmitData<FormFieldRecords>

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/useSnipeitCacheHandlers.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/useSnipeitCacheHandlers.ts
@@ -1,0 +1,115 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import { cloneDeep } from 'lodash-es'
+
+import type {
+  TicketExternalReferencesSnipeitAssetAddMutation,
+  TicketExternalReferencesSnipeitAssetListQuery,
+} from '#shared/graphql/types.ts'
+import { getApolloClient } from '#shared/server/apollo/client.ts'
+
+import { TicketExternalReferencesSnipeitAssetListDocument } from '#desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.api.ts'
+
+import type { ApolloCache, FetchResult } from '@apollo/client/core'
+import type { Ref } from 'vue'
+
+export const useSnipeitCacheHandlers = (assetIds: Ref<number[]>, ticketId: Ref<ID | undefined>) => {
+  const { cache } = getApolloClient()
+
+  const modifyAssetItemAddCache = (
+    cache: ApolloCache<TicketExternalReferencesSnipeitAssetListQuery>,
+    { data }: Omit<FetchResult<TicketExternalReferencesSnipeitAssetAddMutation>, 'context'>,
+  ) => {
+    if (!data) return
+
+    const { ticketExternalReferencesSnipeitAssetAdd } = data
+
+    if (!ticketExternalReferencesSnipeitAssetAdd?.snipeitAssets?.length) return
+
+    const queryOptions = {
+      query: TicketExternalReferencesSnipeitAssetListDocument,
+      variables: {
+        ticketId: ticketId.value,
+        snipeitAssetIds: ticketId.value ? undefined : assetIds.value,
+      },
+    }
+
+    let existingSnipeitAssets =
+      cache.readQuery<TicketExternalReferencesSnipeitAssetListQuery>(queryOptions)
+
+    const newIdPresent = existingSnipeitAssets?.ticketExternalReferencesSnipeitAssetList?.find(
+      (asset) => {
+        return ticketExternalReferencesSnipeitAssetAdd?.snipeitAssets?.some(
+          (snipeitAsset) => snipeitAsset.snipeitAssetId === asset.snipeitAssetId,
+        )
+      },
+    )
+
+    if (newIdPresent) return
+
+    existingSnipeitAssets = {
+      ...existingSnipeitAssets,
+      ticketExternalReferencesSnipeitAssetList: [
+        ...(existingSnipeitAssets?.ticketExternalReferencesSnipeitAssetList || []),
+        ...ticketExternalReferencesSnipeitAssetAdd.snipeitAssets!,
+      ],
+    }
+
+    if (!ticketId.value) {
+      queryOptions.variables.snipeitAssetIds = [
+        ...(assetIds.value || []),
+        ...ticketExternalReferencesSnipeitAssetAdd.snipeitAssets.map(
+          (asset) => asset.snipeitAssetId,
+        ),
+      ]
+    }
+
+    cache.writeQuery({
+      ...queryOptions,
+      data: {
+        ...existingSnipeitAssets,
+      },
+    })
+  }
+
+  const removeAssetListCacheUpdate = (id: number) => {
+    const queryOptions = {
+      query: TicketExternalReferencesSnipeitAssetListDocument,
+      variables: {
+        ticketId: ticketId.value,
+        snipeitAssetIds: ticketId.value ? undefined : assetIds.value,
+      },
+    }
+
+    const existingSnipeitAssets =
+      cache.readQuery<TicketExternalReferencesSnipeitAssetListQuery>(queryOptions)
+
+    if (!existingSnipeitAssets) return
+
+    const oldAssets = cloneDeep(existingSnipeitAssets)
+
+    if (!ticketId.value) {
+      queryOptions.variables.snipeitAssetIds = assetIds.value.filter(
+        (snipeitAssetId) => snipeitAssetId !== id,
+      )
+    }
+
+    cache.writeQuery({
+      ...queryOptions,
+      data: {
+        ticketExternalReferencesSnipeitAssetList:
+          existingSnipeitAssets.ticketExternalReferencesSnipeitAssetList.filter(
+            (asset) => asset.snipeitAssetId !== id,
+          ),
+      },
+    })
+
+    return () =>
+      cache.writeQuery({
+        ...queryOptions,
+        data: oldAssets,
+      })
+  }
+
+  return { removeAssetListCacheUpdate, modifyAssetItemAddCache }
+}

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/useSnipeitFormHelpers.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/useSnipeitFormHelpers.ts
@@ -1,0 +1,54 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import { cloneDeep } from 'lodash-es'
+
+import type { FormRef } from '#shared/components/Form/types.ts'
+import type { SnipeitAssetAttributesFragment } from '#shared/graphql/types.ts'
+
+import type { ExternalReferencesFormValues } from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/types.ts'
+
+import type { Ref } from 'vue'
+
+export const useSnipeitFormHelpers = (form: Ref<FormRef | undefined>) => {
+  const addAssetIdsToForm = (assets?: SnipeitAssetAttributesFragment[] | null) => {
+    if (!assets) return
+
+    const assetIds = assets.map((asset) => asset.snipeitAssetId)
+
+    const externalReferences = form.value?.findNodeByName('externalReferences')
+
+    if (!externalReferences) return
+
+    let existingReferences = cloneDeep(
+      externalReferences.value,
+    ) as ExternalReferencesFormValues['externalReferences']
+
+    existingReferences ||= {}
+    existingReferences.snipeit = [...(existingReferences.snipeit || []), ...assetIds]
+
+    externalReferences?.input(existingReferences, false)
+  }
+
+  const removeAssetFromForm = async (id: number) => {
+    const externalReferences = form.value?.findNodeByName('externalReferences')
+
+    const { values } = form.value as { values: ExternalReferencesFormValues }
+
+    if (!externalReferences?.value || !values.externalReferences?.snipeit) return
+
+    let existingReferences = cloneDeep(
+      externalReferences.value,
+    ) as ExternalReferencesFormValues['externalReferences']
+
+    existingReferences ||= {}
+
+    existingReferences.snipeit = existingReferences.snipeit!.filter((assetId) => assetId !== id)
+
+    return externalReferences?.input(existingReferences, false)
+  }
+
+  return {
+    addAssetIdsToForm,
+    removeAssetFromForm,
+  }
+}

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/types.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/types.ts
@@ -10,5 +10,6 @@ export interface ExternalReferencesFormValues {
     [EnumTicketExternalReferencesIssueTrackerType.Github]?: string[]
     [EnumTicketExternalReferencesIssueTrackerType.Gitlab]?: string[]
     idoit?: number[] // :TODO check for key type
+    snipeit?: number[]
   }
 }

--- a/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/snipeit.ts
+++ b/app/frontend/apps/desktop/pages/ticket/components/TicketSidebar/plugins/snipeit.ts
@@ -1,0 +1,19 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import { useApplicationStore } from '#shared/stores/application.ts'
+
+import TicketSidebarSnipeit from '#desktop/pages/ticket/components/TicketSidebar/TicketSidebarExternalReferences/TicketSidebarSnipeit/TicketSidebarSnipeit.vue'
+import { TicketSidebarScreenType } from '#desktop/pages/ticket/types/sidebar.ts'
+
+import type { TicketSidebarPlugin } from './types.ts'
+
+export default <TicketSidebarPlugin>{
+  title: __('Snipe-IT'),
+  component: TicketSidebarSnipeit,
+  permissions: ['ticket.agent'],
+  screens: [TicketSidebarScreenType.TicketDetailView, TicketSidebarScreenType.TicketCreate],
+  views: ['agent'],
+  icon: 'snipeit-logo', // icon does not exist underlying cmp will use it as a base to get light and dark icon name
+  order: 6100,
+  available: () => useApplicationStore().config.snipeit_integration,
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/fragments/SnipeitAssetAttributes.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/fragments/SnipeitAssetAttributes.api.ts
@@ -1,0 +1,16 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import gql from 'graphql-tag';
+export const SnipeitAssetAttributesFragmentDoc = gql`
+    fragment SnipeitAssetAttributes on TicketExternalReferencesSnipeitAsset {
+  snipeitAssetId
+  link
+  name
+  assetTag
+  serial
+  model
+  status
+  category
+  location
+}
+    `;

--- a/app/frontend/apps/desktop/pages/ticket/graphql/fragments/SnipeitAssetAttributes.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/fragments/SnipeitAssetAttributes.graphql
@@ -1,0 +1,11 @@
+fragment SnipeitAssetAttributes on TicketExternalReferencesSnipeitAsset {
+  snipeitAssetId
+  link
+  name
+  assetTag
+  serial
+  model
+  status
+  category
+  location
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetAdd.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetAdd.api.ts
@@ -1,0 +1,29 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import gql from 'graphql-tag';
+import { SnipeitAssetAttributesFragmentDoc } from '../fragments/SnipeitAssetAttributes.api';
+import { ErrorsFragmentDoc } from '../../../../../../shared/graphql/fragments/errors.api';
+import * as VueApolloComposable from '@vue/apollo-composable';
+import * as VueCompositionApi from 'vue';
+export type ReactiveFunction<TParam> = () => TParam;
+
+export const TicketExternalReferencesSnipeitAssetAddDocument = gql`
+    mutation ticketExternalReferencesSnipeitAssetAdd($snipeitAssetIds: [Int!]!, $ticketId: ID) {
+  ticketExternalReferencesSnipeitAssetAdd(
+    snipeitAssetIds: $snipeitAssetIds
+    ticketId: $ticketId
+  ) {
+    snipeitAssets {
+      ...SnipeitAssetAttributes
+    }
+    errors {
+      ...errors
+    }
+  }
+}
+    ${SnipeitAssetAttributesFragmentDoc}
+${ErrorsFragmentDoc}`;
+export function useTicketExternalReferencesSnipeitAssetAddMutation(options: VueApolloComposable.UseMutationOptions<Types.TicketExternalReferencesSnipeitAssetAddMutation, Types.TicketExternalReferencesSnipeitAssetAddMutationVariables> | ReactiveFunction<VueApolloComposable.UseMutationOptions<Types.TicketExternalReferencesSnipeitAssetAddMutation, Types.TicketExternalReferencesSnipeitAssetAddMutationVariables>> = {}) {
+  return VueApolloComposable.useMutation<Types.TicketExternalReferencesSnipeitAssetAddMutation, Types.TicketExternalReferencesSnipeitAssetAddMutationVariables>(TicketExternalReferencesSnipeitAssetAddDocument, options);
+}
+export type TicketExternalReferencesSnipeitAssetAddMutationCompositionFunctionResult = VueApolloComposable.UseMutationReturn<Types.TicketExternalReferencesSnipeitAssetAddMutation, Types.TicketExternalReferencesSnipeitAssetAddMutationVariables>;

--- a/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetAdd.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetAdd.graphql
@@ -1,0 +1,10 @@
+mutation ticketExternalReferencesSnipeitAssetAdd($snipeitAssetIds: [Int!]!, $ticketId: ID) {
+  ticketExternalReferencesSnipeitAssetAdd(snipeitAssetIds: $snipeitAssetIds, ticketId: $ticketId) {
+    snipeitAssets {
+      ...SnipeitAssetAttributes
+    }
+    errors {
+      ...errors
+    }
+  }
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetAdd.mocks.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetAdd.mocks.ts
@@ -1,0 +1,17 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import * as Mocks from '#tests/graphql/builders/mocks.ts'
+import * as Operations from './ticketExternalReferencesSnipeitAssetAdd.api.ts'
+import * as ErrorTypes from '#shared/types/error.ts'
+
+export function mockTicketExternalReferencesSnipeitAssetAddMutation(defaults: Mocks.MockDefaultsValue<Types.TicketExternalReferencesSnipeitAssetAddMutation, Types.TicketExternalReferencesSnipeitAssetAddMutationVariables>) {
+  return Mocks.mockGraphQLResult(Operations.TicketExternalReferencesSnipeitAssetAddDocument, defaults)
+}
+
+export function waitForTicketExternalReferencesSnipeitAssetAddMutationCalls() {
+  return Mocks.waitForGraphQLMockCalls<Types.TicketExternalReferencesSnipeitAssetAddMutation>(Operations.TicketExternalReferencesSnipeitAssetAddDocument)
+}
+
+export function mockTicketExternalReferencesSnipeitAssetAddMutationError(message: string, extensions: {type: ErrorTypes.GraphQLErrorTypes }) {
+  return Mocks.mockGraphQLResultWithError(Operations.TicketExternalReferencesSnipeitAssetAddDocument, message, extensions);
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.api.ts
@@ -1,0 +1,25 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import gql from 'graphql-tag';
+import { ErrorsFragmentDoc } from '../../../../../../shared/graphql/fragments/errors.api';
+import * as VueApolloComposable from '@vue/apollo-composable';
+import * as VueCompositionApi from 'vue';
+export type ReactiveFunction<TParam> = () => TParam;
+
+export const TicketExternalReferencesSnipeitAssetRemoveDocument = gql`
+    mutation ticketExternalReferencesSnipeitAssetRemove($ticketId: ID!, $snipeitAssetId: Int!) {
+  ticketExternalReferencesSnipeitAssetRemove(
+    ticketId: $ticketId
+    snipeitAssetId: $snipeitAssetId
+  ) {
+    success
+    errors {
+      ...errors
+    }
+  }
+}
+    ${ErrorsFragmentDoc}`;
+export function useTicketExternalReferencesSnipeitAssetRemoveMutation(options: VueApolloComposable.UseMutationOptions<Types.TicketExternalReferencesSnipeitAssetRemoveMutation, Types.TicketExternalReferencesSnipeitAssetRemoveMutationVariables> | ReactiveFunction<VueApolloComposable.UseMutationOptions<Types.TicketExternalReferencesSnipeitAssetRemoveMutation, Types.TicketExternalReferencesSnipeitAssetRemoveMutationVariables>> = {}) {
+  return VueApolloComposable.useMutation<Types.TicketExternalReferencesSnipeitAssetRemoveMutation, Types.TicketExternalReferencesSnipeitAssetRemoveMutationVariables>(TicketExternalReferencesSnipeitAssetRemoveDocument, options);
+}
+export type TicketExternalReferencesSnipeitAssetRemoveMutationCompositionFunctionResult = VueApolloComposable.UseMutationReturn<Types.TicketExternalReferencesSnipeitAssetRemoveMutation, Types.TicketExternalReferencesSnipeitAssetRemoveMutationVariables>;

--- a/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.graphql
@@ -1,0 +1,8 @@
+mutation ticketExternalReferencesSnipeitAssetRemove($ticketId: ID!, $snipeitAssetId: Int!) {
+  ticketExternalReferencesSnipeitAssetRemove(ticketId: $ticketId, snipeitAssetId: $snipeitAssetId) {
+    success
+    errors {
+      ...errors
+    }
+  }
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.mocks.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/mutations/ticketExternalReferencesSnipeitAssetRemove.mocks.ts
@@ -1,0 +1,17 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import * as Mocks from '#tests/graphql/builders/mocks.ts'
+import * as Operations from './ticketExternalReferencesSnipeitAssetRemove.api.ts'
+import * as ErrorTypes from '#shared/types/error.ts'
+
+export function mockTicketExternalReferencesSnipeitAssetRemoveMutation(defaults: Mocks.MockDefaultsValue<Types.TicketExternalReferencesSnipeitAssetRemoveMutation, Types.TicketExternalReferencesSnipeitAssetRemoveMutationVariables>) {
+  return Mocks.mockGraphQLResult(Operations.TicketExternalReferencesSnipeitAssetRemoveDocument, defaults)
+}
+
+export function waitForTicketExternalReferencesSnipeitAssetRemoveMutationCalls() {
+  return Mocks.waitForGraphQLMockCalls<Types.TicketExternalReferencesSnipeitAssetRemoveMutation>(Operations.TicketExternalReferencesSnipeitAssetRemoveDocument)
+}
+
+export function mockTicketExternalReferencesSnipeitAssetRemoveMutationError(message: string, extensions: {type: ErrorTypes.GraphQLErrorTypes }) {
+  return Mocks.mockGraphQLResultWithError(Operations.TicketExternalReferencesSnipeitAssetRemoveDocument, message, extensions);
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.api.ts
@@ -1,0 +1,22 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import gql from 'graphql-tag';
+import * as VueApolloComposable from '@vue/apollo-composable';
+import * as VueCompositionApi from 'vue';
+export type ReactiveFunction<TParam> = () => TParam;
+
+export const AutocompleteSearchSnipeitCategoriesDocument = gql`
+    query autocompleteSearchSnipeitCategories($input: AutocompleteSearchInput!) {
+  autocompleteSearchSnipeitCategories(input: $input) {
+    value
+    label
+  }
+}
+    `;
+export function useAutocompleteSearchSnipeitCategoriesQuery(variables: Types.AutocompleteSearchSnipeitCategoriesQueryVariables | VueCompositionApi.Ref<Types.AutocompleteSearchSnipeitCategoriesQueryVariables> | ReactiveFunction<Types.AutocompleteSearchSnipeitCategoriesQueryVariables>, options: VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>> = {}) {
+  return VueApolloComposable.useQuery<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>(AutocompleteSearchSnipeitCategoriesDocument, variables, options);
+}
+export function useAutocompleteSearchSnipeitCategoriesLazyQuery(variables?: Types.AutocompleteSearchSnipeitCategoriesQueryVariables | VueCompositionApi.Ref<Types.AutocompleteSearchSnipeitCategoriesQueryVariables> | ReactiveFunction<Types.AutocompleteSearchSnipeitCategoriesQueryVariables>, options: VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>(AutocompleteSearchSnipeitCategoriesDocument, variables, options);
+}
+export type AutocompleteSearchSnipeitCategoriesQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>;

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.graphql
@@ -1,0 +1,6 @@
+query autocompleteSearchSnipeitCategories($input: AutocompleteSearchInput!) {
+  autocompleteSearchSnipeitCategories(input: $input) {
+    value
+    label
+  }
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.mocks.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitCategories.mocks.ts
@@ -1,0 +1,17 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import * as Mocks from '#tests/graphql/builders/mocks.ts'
+import * as Operations from './autocompleteSearchSnipeitCategories.api.ts'
+import * as ErrorTypes from '#shared/types/error.ts'
+
+export function mockAutocompleteSearchSnipeitCategoriesQuery(defaults: Mocks.MockDefaultsValue<Types.AutocompleteSearchSnipeitCategoriesQuery, Types.AutocompleteSearchSnipeitCategoriesQueryVariables>) {
+  return Mocks.mockGraphQLResult(Operations.AutocompleteSearchSnipeitCategoriesDocument, defaults)
+}
+
+export function waitForAutocompleteSearchSnipeitCategoriesQueryCalls() {
+  return Mocks.waitForGraphQLMockCalls<Types.AutocompleteSearchSnipeitCategoriesQuery>(Operations.AutocompleteSearchSnipeitCategoriesDocument)
+}
+
+export function mockAutocompleteSearchSnipeitCategoriesQueryError(message: string, extensions: {type: ErrorTypes.GraphQLErrorTypes }) {
+  return Mocks.mockGraphQLResultWithError(Operations.AutocompleteSearchSnipeitCategoriesDocument, message, extensions);
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.api.ts
@@ -6,7 +6,7 @@ import * as VueCompositionApi from 'vue';
 export type ReactiveFunction<TParam> = () => TParam;
 
 export const AutocompleteSearchSnipeitModelsDocument = gql`
-    query autocompleteSearchSnipeitModels($input: AutocompleteSearchInput!) {
+    query autocompleteSearchSnipeitModels($input: AutocompleteSearchSnipeitModelsInput!) {
   autocompleteSearchSnipeitModels(input: $input) {
     value
     label

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.api.ts
@@ -1,0 +1,22 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import gql from 'graphql-tag';
+import * as VueApolloComposable from '@vue/apollo-composable';
+import * as VueCompositionApi from 'vue';
+export type ReactiveFunction<TParam> = () => TParam;
+
+export const AutocompleteSearchSnipeitModelsDocument = gql`
+    query autocompleteSearchSnipeitModels($input: AutocompleteSearchInput!) {
+  autocompleteSearchSnipeitModels(input: $input) {
+    value
+    label
+  }
+}
+    `;
+export function useAutocompleteSearchSnipeitModelsQuery(variables: Types.AutocompleteSearchSnipeitModelsQueryVariables | VueCompositionApi.Ref<Types.AutocompleteSearchSnipeitModelsQueryVariables> | ReactiveFunction<Types.AutocompleteSearchSnipeitModelsQueryVariables>, options: VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>> = {}) {
+  return VueApolloComposable.useQuery<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>(AutocompleteSearchSnipeitModelsDocument, variables, options);
+}
+export function useAutocompleteSearchSnipeitModelsLazyQuery(variables?: Types.AutocompleteSearchSnipeitModelsQueryVariables | VueCompositionApi.Ref<Types.AutocompleteSearchSnipeitModelsQueryVariables> | ReactiveFunction<Types.AutocompleteSearchSnipeitModelsQueryVariables>, options: VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>(AutocompleteSearchSnipeitModelsDocument, variables, options);
+}
+export type AutocompleteSearchSnipeitModelsQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>;

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.graphql
@@ -1,0 +1,6 @@
+query autocompleteSearchSnipeitModels($input: AutocompleteSearchInput!) {
+  autocompleteSearchSnipeitModels(input: $input) {
+    value
+    label
+  }
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.graphql
@@ -1,4 +1,4 @@
-query autocompleteSearchSnipeitModels($input: AutocompleteSearchInput!) {
+query autocompleteSearchSnipeitModels($input: AutocompleteSearchSnipeitModelsInput!) {
   autocompleteSearchSnipeitModels(input: $input) {
     value
     label

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.mocks.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/autocompleteSearchSnipeitModels.mocks.ts
@@ -1,0 +1,17 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import * as Mocks from '#tests/graphql/builders/mocks.ts'
+import * as Operations from './autocompleteSearchSnipeitModels.api.ts'
+import * as ErrorTypes from '#shared/types/error.ts'
+
+export function mockAutocompleteSearchSnipeitModelsQuery(defaults: Mocks.MockDefaultsValue<Types.AutocompleteSearchSnipeitModelsQuery, Types.AutocompleteSearchSnipeitModelsQueryVariables>) {
+  return Mocks.mockGraphQLResult(Operations.AutocompleteSearchSnipeitModelsDocument, defaults)
+}
+
+export function waitForAutocompleteSearchSnipeitModelsQueryCalls() {
+  return Mocks.waitForGraphQLMockCalls<Types.AutocompleteSearchSnipeitModelsQuery>(Operations.AutocompleteSearchSnipeitModelsDocument)
+}
+
+export function mockAutocompleteSearchSnipeitModelsQueryError(message: string, extensions: {type: ErrorTypes.GraphQLErrorTypes }) {
+  return Mocks.mockGraphQLResultWithError(Operations.AutocompleteSearchSnipeitModelsDocument, message, extensions);
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.api.ts
@@ -1,0 +1,24 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import gql from 'graphql-tag';
+import { SnipeitAssetAttributesFragmentDoc } from '../fragments/SnipeitAssetAttributes.api';
+import * as VueApolloComposable from '@vue/apollo-composable';
+import * as VueCompositionApi from 'vue';
+export type ReactiveFunction<TParam> = () => TParam;
+
+export const TicketExternalReferencesSnipeitAssetListDocument = gql`
+    query ticketExternalReferencesSnipeitAssetList($ticketId: ID, $snipeitAssetIds: [Int!]) {
+  ticketExternalReferencesSnipeitAssetList(
+    input: {ticketId: $ticketId, snipeitAssetIds: $snipeitAssetIds}
+  ) {
+    ...SnipeitAssetAttributes
+  }
+}
+    ${SnipeitAssetAttributesFragmentDoc}`;
+export function useTicketExternalReferencesSnipeitAssetListQuery(variables: Types.TicketExternalReferencesSnipeitAssetListQueryVariables | VueCompositionApi.Ref<Types.TicketExternalReferencesSnipeitAssetListQueryVariables> | ReactiveFunction<Types.TicketExternalReferencesSnipeitAssetListQueryVariables> = {}, options: VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>> = {}) {
+  return VueApolloComposable.useQuery<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>(TicketExternalReferencesSnipeitAssetListDocument, variables, options);
+}
+export function useTicketExternalReferencesSnipeitAssetListLazyQuery(variables: Types.TicketExternalReferencesSnipeitAssetListQueryVariables | VueCompositionApi.Ref<Types.TicketExternalReferencesSnipeitAssetListQueryVariables> | ReactiveFunction<Types.TicketExternalReferencesSnipeitAssetListQueryVariables> = {}, options: VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>(TicketExternalReferencesSnipeitAssetListDocument, variables, options);
+}
+export type TicketExternalReferencesSnipeitAssetListQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>;

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.graphql
@@ -1,0 +1,7 @@
+query ticketExternalReferencesSnipeitAssetList($ticketId: ID, $snipeitAssetIds: [Int!]) {
+  ticketExternalReferencesSnipeitAssetList(
+    input: { ticketId: $ticketId, snipeitAssetIds: $snipeitAssetIds }
+  ) {
+    ...SnipeitAssetAttributes
+  }
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.mocks.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetList.mocks.ts
@@ -1,0 +1,17 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import * as Mocks from '#tests/graphql/builders/mocks.ts'
+import * as Operations from './ticketExternalReferencesSnipeitAssetList.api.ts'
+import * as ErrorTypes from '#shared/types/error.ts'
+
+export function mockTicketExternalReferencesSnipeitAssetListQuery(defaults: Mocks.MockDefaultsValue<Types.TicketExternalReferencesSnipeitAssetListQuery, Types.TicketExternalReferencesSnipeitAssetListQueryVariables>) {
+  return Mocks.mockGraphQLResult(Operations.TicketExternalReferencesSnipeitAssetListDocument, defaults)
+}
+
+export function waitForTicketExternalReferencesSnipeitAssetListQueryCalls() {
+  return Mocks.waitForGraphQLMockCalls<Types.TicketExternalReferencesSnipeitAssetListQuery>(Operations.TicketExternalReferencesSnipeitAssetListDocument)
+}
+
+export function mockTicketExternalReferencesSnipeitAssetListQueryError(message: string, extensions: {type: ErrorTypes.GraphQLErrorTypes }) {
+  return Mocks.mockGraphQLResultWithError(Operations.TicketExternalReferencesSnipeitAssetListDocument, message, extensions);
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.api.ts
@@ -1,0 +1,27 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import gql from 'graphql-tag';
+import { SnipeitAssetAttributesFragmentDoc } from '../fragments/SnipeitAssetAttributes.api';
+import * as VueApolloComposable from '@vue/apollo-composable';
+import * as VueCompositionApi from 'vue';
+export type ReactiveFunction<TParam> = () => TParam;
+
+export const TicketExternalReferencesSnipeitAssetSearchDocument = gql`
+    query ticketExternalReferencesSnipeitAssetSearch($categoryId: String, $modelId: String, $limit: Int!, $query: String) {
+  ticketExternalReferencesSnipeitAssetSearch(
+    categoryId: $categoryId
+    modelId: $modelId
+    limit: $limit
+    query: $query
+  ) {
+    ...SnipeitAssetAttributes
+  }
+}
+    ${SnipeitAssetAttributesFragmentDoc}`;
+export function useTicketExternalReferencesSnipeitAssetSearchQuery(variables: Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables | VueCompositionApi.Ref<Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables> | ReactiveFunction<Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>, options: VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>> = {}) {
+  return VueApolloComposable.useQuery<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>(TicketExternalReferencesSnipeitAssetSearchDocument, variables, options);
+}
+export function useTicketExternalReferencesSnipeitAssetSearchLazyQuery(variables?: Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables | VueCompositionApi.Ref<Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables> | ReactiveFunction<Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>, options: VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables> | VueCompositionApi.Ref<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>> | ReactiveFunction<VueApolloComposable.UseQueryOptions<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>> = {}) {
+  return VueApolloComposable.useLazyQuery<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>(TicketExternalReferencesSnipeitAssetSearchDocument, variables, options);
+}
+export type TicketExternalReferencesSnipeitAssetSearchQueryCompositionFunctionResult = VueApolloComposable.UseQueryReturn<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>;

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.api.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.api.ts
@@ -7,12 +7,13 @@ import * as VueCompositionApi from 'vue';
 export type ReactiveFunction<TParam> = () => TParam;
 
 export const TicketExternalReferencesSnipeitAssetSearchDocument = gql`
-    query ticketExternalReferencesSnipeitAssetSearch($categoryId: String, $modelId: String, $limit: Int!, $query: String) {
+    query ticketExternalReferencesSnipeitAssetSearch($categoryId: String, $modelId: String, $limit: Int!, $query: String, $customerId: ID) {
   ticketExternalReferencesSnipeitAssetSearch(
     categoryId: $categoryId
     modelId: $modelId
     limit: $limit
     query: $query
+    customerId: $customerId
   ) {
     ...SnipeitAssetAttributes
   }

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.graphql
@@ -1,0 +1,15 @@
+query ticketExternalReferencesSnipeitAssetSearch(
+  $categoryId: String
+  $modelId: String
+  $limit: Int!
+  $query: String
+) {
+  ticketExternalReferencesSnipeitAssetSearch(
+    categoryId: $categoryId
+    modelId: $modelId
+    limit: $limit
+    query: $query
+  ) {
+    ...SnipeitAssetAttributes
+  }
+}

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.graphql
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.graphql
@@ -3,12 +3,14 @@ query ticketExternalReferencesSnipeitAssetSearch(
   $modelId: String
   $limit: Int!
   $query: String
+  $customerId: ID
 ) {
   ticketExternalReferencesSnipeitAssetSearch(
     categoryId: $categoryId
     modelId: $modelId
     limit: $limit
     query: $query
+    customerId: $customerId
   ) {
     ...SnipeitAssetAttributes
   }

--- a/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.mocks.ts
+++ b/app/frontend/apps/desktop/pages/ticket/graphql/queries/ticketExternalReferencesSnipeitAssetSearch.mocks.ts
@@ -1,0 +1,17 @@
+import * as Types from '#shared/graphql/types.ts';
+
+import * as Mocks from '#tests/graphql/builders/mocks.ts'
+import * as Operations from './ticketExternalReferencesSnipeitAssetSearch.api.ts'
+import * as ErrorTypes from '#shared/types/error.ts'
+
+export function mockTicketExternalReferencesSnipeitAssetSearchQuery(defaults: Mocks.MockDefaultsValue<Types.TicketExternalReferencesSnipeitAssetSearchQuery, Types.TicketExternalReferencesSnipeitAssetSearchQueryVariables>) {
+  return Mocks.mockGraphQLResult(Operations.TicketExternalReferencesSnipeitAssetSearchDocument, defaults)
+}
+
+export function waitForTicketExternalReferencesSnipeitAssetSearchQueryCalls() {
+  return Mocks.waitForGraphQLMockCalls<Types.TicketExternalReferencesSnipeitAssetSearchQuery>(Operations.TicketExternalReferencesSnipeitAssetSearchDocument)
+}
+
+export function mockTicketExternalReferencesSnipeitAssetSearchQueryError(message: string, extensions: {type: ErrorTypes.GraphQLErrorTypes }) {
+  return Mocks.mockGraphQLResultWithError(Operations.TicketExternalReferencesSnipeitAssetSearchDocument, message, extensions);
+}

--- a/app/frontend/shared/graphql/schema-types.ts
+++ b/app/frontend/shared/graphql/schema-types.ts
@@ -359,6 +359,16 @@ export type AutocompleteSearchRecipientInput = {
   query: Scalars['String']['input'];
 };
 
+/** Input fields for Snipe-IT model autocomplete searches. */
+export type AutocompleteSearchSnipeitModelsInput = {
+  /** Snipe-IT category id to restrict the models to */
+  categoryId?: InputMaybe<Scalars['String']['input']>;
+  /** Limit for the amount of entries */
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  /** Query from the autocomplete field */
+  query: Scalars['String']['input'];
+};
+
 /** Input fields for tag autocomplete searches. */
 export type AutocompleteSearchTagInput = {
   /** Optional tags to be filtered out from results */
@@ -3386,7 +3396,7 @@ export type QueriesAutocompleteSearchSnipeitCategoriesArgs = {
 
 /** All available queries */
 export type QueriesAutocompleteSearchSnipeitModelsArgs = {
-  input: AutocompleteSearchInput;
+  input: AutocompleteSearchSnipeitModelsInput;
 };
 
 

--- a/app/frontend/shared/graphql/schema-types.ts
+++ b/app/frontend/shared/graphql/schema-types.ts
@@ -1902,6 +1902,10 @@ export type Mutations = {
   ticketExternalReferencesIssueTrackerItemAdd?: Maybe<TicketExternalReferencesIssueTrackerItemAddPayload>;
   /** Removes an issue tracker link from an ticket. */
   ticketExternalReferencesIssueTrackerItemRemove?: Maybe<TicketExternalReferencesIssueTrackerItemRemovePayload>;
+  /** Add Snipe-IT assets to a ticket or just resolve them for ticket creation. */
+  ticketExternalReferencesSnipeitAssetAdd?: Maybe<TicketExternalReferencesSnipeitAssetAddPayload>;
+  /** Remove a Snipe-IT asset from a ticket. */
+  ticketExternalReferencesSnipeitAssetRemove?: Maybe<TicketExternalReferencesSnipeitAssetRemovePayload>;
   /** Deletes the desired live user entry. */
   ticketLiveUserDelete?: Maybe<TicketLiveUserDeletePayload>;
   /** Updates the current live user entry. If no matching live user entry is found, a new live user entry for the current user and ticket will be created. */
@@ -2359,6 +2363,20 @@ export type MutationsTicketExternalReferencesIssueTrackerItemAddArgs = {
 export type MutationsTicketExternalReferencesIssueTrackerItemRemoveArgs = {
   issueTrackerLink: Scalars['UriHttpString']['input'];
   issueTrackerType: EnumTicketExternalReferencesIssueTrackerType;
+  ticketId: Scalars['ID']['input'];
+};
+
+
+/** All available mutations */
+export type MutationsTicketExternalReferencesSnipeitAssetAddArgs = {
+  snipeitAssetIds: Array<Scalars['Int']['input']>;
+  ticketId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+
+/** All available mutations */
+export type MutationsTicketExternalReferencesSnipeitAssetRemoveArgs = {
+  snipeitAssetId: Scalars['Int']['input'];
   ticketId: Scalars['ID']['input'];
 };
 
@@ -3171,6 +3189,10 @@ export type Queries = {
   autocompleteSearchOrganization: Array<AutocompleteSearchOrganizationEntry>;
   /** Search for recipients */
   autocompleteSearchRecipient: Array<AutocompleteSearchRecipientEntry>;
+  /** Search for Snipe-IT categories */
+  autocompleteSearchSnipeitCategories: Array<AutocompleteSearchEntry>;
+  /** Search for Snipe-IT models */
+  autocompleteSearchSnipeitModels: Array<AutocompleteSearchEntry>;
   /** Search for tags */
   autocompleteSearchTag: Array<AutocompleteSearchEntry>;
   /** Search for tickets */
@@ -3245,6 +3267,10 @@ export type Queries = {
   ticketExternalReferencesIdoitObjectSearch: Array<TicketExternalReferencesIdoitObject>;
   /** Detailed issue tracker items for the given issue tracker links or the given ticket */
   ticketExternalReferencesIssueTrackerItemList: Array<TicketExternalReferencesIssueTrackerItem>;
+  /** Detailed Snipe-IT assets for the given asset ids or the given ticket */
+  ticketExternalReferencesSnipeitAssetList: Array<TicketExternalReferencesSnipeitAsset>;
+  /** Search for Snipe-IT assets */
+  ticketExternalReferencesSnipeitAssetSearch: Array<TicketExternalReferencesSnipeitAsset>;
   /** Fetch history of a ticket */
   ticketHistory: Array<HistoryGroup>;
   /** Ticket overviews available in the system */
@@ -3349,6 +3375,18 @@ export type QueriesAutocompleteSearchOrganizationArgs = {
 /** All available queries */
 export type QueriesAutocompleteSearchRecipientArgs = {
   input: AutocompleteSearchRecipientInput;
+};
+
+
+/** All available queries */
+export type QueriesAutocompleteSearchSnipeitCategoriesArgs = {
+  input: AutocompleteSearchInput;
+};
+
+
+/** All available queries */
+export type QueriesAutocompleteSearchSnipeitModelsArgs = {
+  input: AutocompleteSearchInput;
 };
 
 
@@ -3574,6 +3612,21 @@ export type QueriesTicketExternalReferencesIdoitObjectSearchArgs = {
 export type QueriesTicketExternalReferencesIssueTrackerItemListArgs = {
   input: TicketExternalReferencesIssueTrackerListInput;
   issueTrackerType: EnumTicketExternalReferencesIssueTrackerType;
+};
+
+
+/** All available queries */
+export type QueriesTicketExternalReferencesSnipeitAssetListArgs = {
+  input: TicketExternalReferencesSnipeitAssetListInput;
+};
+
+
+/** All available queries */
+export type QueriesTicketExternalReferencesSnipeitAssetSearchArgs = {
+  categoryId?: InputMaybe<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  modelId?: InputMaybe<Scalars['String']['input']>;
+  query?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4876,6 +4929,8 @@ export type TicketExternalReferences = {
   gitlab?: Maybe<Array<Scalars['UriHttpString']['output']>>;
   /** Returns exising object ids for the idoit integration */
   idoit?: Maybe<Array<Scalars['Int']['output']>>;
+  /** Returns existing asset ids for the Snipe-IT integration */
+  snipeit?: Maybe<Array<Scalars['Int']['output']>>;
 };
 
 /** Idoit object item for an external reference for a ticket */
@@ -4924,6 +4979,8 @@ export type TicketExternalReferencesInput = {
   gitlab?: InputMaybe<Array<Scalars['UriHttpString']['input']>>;
   /** Object ids for the Idoit integration */
   idoit?: InputMaybe<Array<Scalars['Int']['input']>>;
+  /** Asset ids for the Snipe-IT integration */
+  snipeit?: InputMaybe<Array<Scalars['Int']['input']>>;
 };
 
 /** Issue tracker item for an external reference for a ticket */
@@ -4991,6 +5048,54 @@ export type TicketExternalReferencesIssueTrackerListInput = {
   issueTrackerLinks?: InputMaybe<Array<Scalars['UriHttpString']['input']>>;
   /** The related ticket for the issue tracker items */
   ticketId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+/** Snipe-IT asset item for an external reference for a ticket */
+export type TicketExternalReferencesSnipeitAsset = {
+  __typename?: 'TicketExternalReferencesSnipeitAsset';
+  /** Asset tag */
+  assetTag?: Maybe<Scalars['String']['output']>;
+  /** Asset category */
+  category?: Maybe<Scalars['String']['output']>;
+  /** Link to the asset in the Snipe-IT GUI */
+  link?: Maybe<Scalars['UriHttpString']['output']>;
+  /** Asset location */
+  location?: Maybe<Scalars['String']['output']>;
+  /** Asset model name */
+  model?: Maybe<Scalars['String']['output']>;
+  name: Scalars['String']['output'];
+  /** Serial number */
+  serial?: Maybe<Scalars['String']['output']>;
+  /** Snipe-IT asset id */
+  snipeitAssetId: Scalars['Int']['output'];
+  /** Asset status */
+  status?: Maybe<Scalars['String']['output']>;
+};
+
+/** Autogenerated return type of TicketExternalReferencesSnipeitAssetAdd. */
+export type TicketExternalReferencesSnipeitAssetAddPayload = {
+  __typename?: 'TicketExternalReferencesSnipeitAssetAddPayload';
+  /** Errors encountered during execution of the mutation. */
+  errors?: Maybe<Array<UserError>>;
+  /** The added / resolved Snipe-IT assets */
+  snipeitAssets?: Maybe<Array<TicketExternalReferencesSnipeitAsset>>;
+};
+
+/** Input fields for retrieving Snipe-IT asset details */
+export type TicketExternalReferencesSnipeitAssetListInput = {
+  /** Snipe-IT asset IDs to fetch */
+  snipeitAssetIds?: InputMaybe<Array<Scalars['Int']['input']>>;
+  /** The related ticket for the Snipe-IT assets */
+  ticketId?: InputMaybe<Scalars['ID']['input']>;
+};
+
+/** Autogenerated return type of TicketExternalReferencesSnipeitAssetRemove. */
+export type TicketExternalReferencesSnipeitAssetRemovePayload = {
+  __typename?: 'TicketExternalReferencesSnipeitAssetRemovePayload';
+  /** Errors encountered during execution of the mutation. */
+  errors?: Maybe<Array<UserError>>;
+  /** Was the mutation successful? */
+  success?: Maybe<Scalars['Boolean']['output']>;
 };
 
 /** Represents a ticket link to another object. */

--- a/app/frontend/shared/graphql/schema-types.ts
+++ b/app/frontend/shared/graphql/schema-types.ts
@@ -3634,6 +3634,7 @@ export type QueriesTicketExternalReferencesSnipeitAssetListArgs = {
 /** All available queries */
 export type QueriesTicketExternalReferencesSnipeitAssetSearchArgs = {
   categoryId?: InputMaybe<Scalars['String']['input']>;
+  customerId?: InputMaybe<Scalars['ID']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   modelId?: InputMaybe<Scalars['String']['input']>;
   query?: InputMaybe<Scalars['String']['input']>;

--- a/app/frontend/shared/graphql/types.ts
+++ b/app/frontend/shared/graphql/types.ts
@@ -935,7 +935,7 @@ export type AutocompleteSearchSnipeitCategoriesQueryVariables = Exact<{
 export type AutocompleteSearchSnipeitCategoriesQuery = { autocompleteSearchSnipeitCategories: Array<{ __typename: 'AutocompleteSearchEntry', value: string, label: string }> };
 
 export type AutocompleteSearchSnipeitModelsQueryVariables = Exact<{
-  input: Types.AutocompleteSearchInput;
+  input: Types.AutocompleteSearchSnipeitModelsInput;
 }>;
 
 

--- a/app/frontend/shared/graphql/types.ts
+++ b/app/frontend/shared/graphql/types.ts
@@ -1026,6 +1026,7 @@ export type TicketExternalReferencesSnipeitAssetSearchQueryVariables = Exact<{
   modelId?: string | null | undefined;
   limit: number;
   query?: string | null | undefined;
+  customerId?: string | number | null | undefined;
 }>;
 
 

--- a/app/frontend/shared/graphql/types.ts
+++ b/app/frontend/shared/graphql/types.ts
@@ -779,6 +779,8 @@ export type AiAssistantAnalyticsMetaFragment = { __typename: 'AIAnalyticsMetadat
 
 export type IdoitObjectAttributesFragment = { __typename: 'TicketExternalReferencesIdoitObject', idoitObjectId: number, link: string | null | undefined, title: string, type: string, status: string };
 
+export type SnipeitAssetAttributesFragment = { __typename: 'TicketExternalReferencesSnipeitAsset', snipeitAssetId: number, link: string | null | undefined, name: string, assetTag: string | null | undefined, serial: string | null | undefined, model: string | null | undefined, status: string | null | undefined, category: string | null | undefined, location: string | null | undefined };
+
 export type LinkAddMutationVariables = Exact<{
   input: Types.LinkInput;
 }>;
@@ -902,12 +904,42 @@ export type TicketExternalReferencesIssueTrackerItemRemoveMutationVariables = Ex
 
 export type TicketExternalReferencesIssueTrackerItemRemoveMutation = { ticketExternalReferencesIssueTrackerItemRemove: { __typename: 'TicketExternalReferencesIssueTrackerItemRemovePayload', success: boolean | null | undefined, errors: Array<{ __typename: 'UserError', message: string, messagePlaceholder: Array<string> | null | undefined, field: string | null | undefined, exception: Types.EnumUserErrorException | null | undefined }> | null | undefined } | null | undefined };
 
+export type TicketExternalReferencesSnipeitAssetAddMutationVariables = Exact<{
+  snipeitAssetIds: Array<number> | number;
+  ticketId?: string | number | null | undefined;
+}>;
+
+
+export type TicketExternalReferencesSnipeitAssetAddMutation = { ticketExternalReferencesSnipeitAssetAdd: { __typename: 'TicketExternalReferencesSnipeitAssetAddPayload', snipeitAssets: Array<{ __typename: 'TicketExternalReferencesSnipeitAsset', snipeitAssetId: number, link: string | null | undefined, name: string, assetTag: string | null | undefined, serial: string | null | undefined, model: string | null | undefined, status: string | null | undefined, category: string | null | undefined, location: string | null | undefined }> | null | undefined, errors: Array<{ __typename: 'UserError', message: string, messagePlaceholder: Array<string> | null | undefined, field: string | null | undefined, exception: Types.EnumUserErrorException | null | undefined }> | null | undefined } | null | undefined };
+
+export type TicketExternalReferencesSnipeitAssetRemoveMutationVariables = Exact<{
+  ticketId: string | number;
+  snipeitAssetId: number;
+}>;
+
+
+export type TicketExternalReferencesSnipeitAssetRemoveMutation = { ticketExternalReferencesSnipeitAssetRemove: { __typename: 'TicketExternalReferencesSnipeitAssetRemovePayload', success: boolean | null | undefined, errors: Array<{ __typename: 'UserError', message: string, messagePlaceholder: Array<string> | null | undefined, field: string | null | undefined, exception: Types.EnumUserErrorException | null | undefined }> | null | undefined } | null | undefined };
+
 export type AutocompleteSearchIdoitObjectTypesQueryVariables = Exact<{
   input: Types.AutocompleteSearchInput;
 }>;
 
 
 export type AutocompleteSearchIdoitObjectTypesQuery = { autocompleteSearchIdoitObjectTypes: Array<{ __typename: 'AutocompleteSearchEntry', value: string, label: string }> };
+
+export type AutocompleteSearchSnipeitCategoriesQueryVariables = Exact<{
+  input: Types.AutocompleteSearchInput;
+}>;
+
+
+export type AutocompleteSearchSnipeitCategoriesQuery = { autocompleteSearchSnipeitCategories: Array<{ __typename: 'AutocompleteSearchEntry', value: string, label: string }> };
+
+export type AutocompleteSearchSnipeitModelsQueryVariables = Exact<{
+  input: Types.AutocompleteSearchInput;
+}>;
+
+
+export type AutocompleteSearchSnipeitModelsQuery = { autocompleteSearchSnipeitModels: Array<{ __typename: 'AutocompleteSearchEntry', value: string, label: string }> };
 
 export type ChecklistTemplatesQueryVariables = Exact<{
   onlyActive?: boolean | null | undefined;
@@ -980,6 +1012,24 @@ export type TicketExternalReferencesIssueTrackerItemListQueryVariables = Exact<{
 
 
 export type TicketExternalReferencesIssueTrackerItemListQuery = { ticketExternalReferencesIssueTrackerItemList: Array<{ __typename: 'TicketExternalReferencesIssueTrackerItem', assignees: Array<string> | null | undefined, issueId: number, milestone: string | null | undefined, state: Types.EnumTicketExternalReferencesIssueTrackerItemState, title: string, url: string, issueType: { __typename: 'TicketExternalReferencesIssueTrackerItemIssueType', color: string | null | undefined, name: string } | null | undefined, labels: Array<{ __typename: 'TicketExternalReferencesIssueTrackerItemLabel', color: string, textColor: string, title: string }> | null | undefined }> };
+
+export type TicketExternalReferencesSnipeitAssetListQueryVariables = Exact<{
+  ticketId?: string | number | null | undefined;
+  snipeitAssetIds?: Array<number> | number | null | undefined;
+}>;
+
+
+export type TicketExternalReferencesSnipeitAssetListQuery = { ticketExternalReferencesSnipeitAssetList: Array<{ __typename: 'TicketExternalReferencesSnipeitAsset', snipeitAssetId: number, link: string | null | undefined, name: string, assetTag: string | null | undefined, serial: string | null | undefined, model: string | null | undefined, status: string | null | undefined, category: string | null | undefined, location: string | null | undefined }> };
+
+export type TicketExternalReferencesSnipeitAssetSearchQueryVariables = Exact<{
+  categoryId?: string | null | undefined;
+  modelId?: string | null | undefined;
+  limit: number;
+  query?: string | null | undefined;
+}>;
+
+
+export type TicketExternalReferencesSnipeitAssetSearchQuery = { ticketExternalReferencesSnipeitAssetSearch: Array<{ __typename: 'TicketExternalReferencesSnipeitAsset', snipeitAssetId: number, link: string | null | undefined, name: string, assetTag: string | null | undefined, serial: string | null | undefined, model: string | null | undefined, status: string | null | undefined, category: string | null | undefined, location: string | null | undefined }> };
 
 export type TicketHistoryQueryVariables = Exact<{
   ticketId: string | number;

--- a/app/frontend/shared/types/config.ts
+++ b/app/frontend/shared/types/config.ts
@@ -40,6 +40,7 @@ export interface ConfigList {
   gitlab_integration?: boolean | null
   http_type?: 'https' | 'http' | null
   idoit_integration?: boolean | null
+  snipeit_integration?: boolean | null
   import_backend: string
   import_mode?: boolean | null
   kb_active: boolean

--- a/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_add.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_add.rb
@@ -38,9 +38,9 @@ module Gql::Mutations
       end
 
       if ticket.present?
-        ticket.preferences[:snipeit] ||= {}
-        ticket.preferences[:snipeit][:asset_ids] = seen_ids
-        ticket.save!
+        Service::Ticket::ExternalReferences::Snipeit::LinkAssets
+          .with_current_user(context.current_user)
+          .execute(ticket: ticket, asset_ids: seen_ids)
       end
 
       { snipeit_assets: results }

--- a/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_add.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_add.rb
@@ -1,0 +1,49 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Mutations
+  class Ticket::ExternalReferences::SnipeitAssetAdd < BaseMutation
+    description 'Add Snipe-IT assets to a ticket or just resolve them for ticket creation.'
+
+    argument :ticket_id,         GraphQL::Types::ID, required: false, loads: Gql::Types::TicketType, loads_pundit_method: :agent_update_access?, description: 'The related ticket for the Snipe-IT assets'
+    argument :snipeit_asset_ids, [Integer], description: 'The Snipe-IT assets to add'
+
+    field :snipeit_assets, [Gql::Types::Ticket::ExternalReferences::SnipeitAssetType], description: 'The added / resolved Snipe-IT assets'
+
+    requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
+
+    def authorized?(snipeit_asset_ids:, ticket: nil)
+      ticket.present? || context.current_user.permissions?('ticket.agent')
+    end
+
+    def resolve(snipeit_asset_ids:, ticket: nil)
+      results = []
+      existing_ids = Array(ticket&.preferences&.dig(:snipeit, :asset_ids)).map(&:to_i)
+      seen_ids = existing_ids.dup
+
+      snipeit_asset_ids.each do |snipeit_asset_id|
+        snipeit_asset_id = snipeit_asset_id.to_i
+
+        if seen_ids.include?(snipeit_asset_id)
+          return error_response({ field: :snipeit_asset_ids, message: __('The Snipe-IT asset is already present on the ticket.') })
+        end
+
+        api_asset = Snipeit.asset(snipeit_asset_id)
+
+        if api_asset.blank?
+          return error_response({ field: :snipeit_asset_ids, message: __('The Snipe-IT asset could not be found.') })
+        end
+
+        seen_ids << snipeit_asset_id
+        results.push Snipeit.normalize_asset(api_asset)
+      end
+
+      if ticket.present?
+        ticket.preferences[:snipeit] ||= {}
+        ticket.preferences[:snipeit][:asset_ids] = seen_ids
+        ticket.save!
+      end
+
+      { snipeit_assets: results }
+    end
+  end
+end

--- a/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_remove.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_remove.rb
@@ -12,8 +12,11 @@ module Gql::Mutations
     requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
 
     def resolve(snipeit_asset_id:, ticket: nil)
-      ticket.preferences.dig(:snipeit, :asset_ids)&.map!(&:to_i)&.delete(snipeit_asset_id)
-      ticket.save!
+      remaining_asset_ids = Array(ticket.preferences.dig(:snipeit, :asset_ids)).map(&:to_i) - [snipeit_asset_id]
+
+      Service::Ticket::ExternalReferences::Snipeit::LinkAssets
+        .with_current_user(context.current_user)
+        .execute(ticket: ticket, asset_ids: remaining_asset_ids)
 
       { success: true }
     end

--- a/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_remove.rb
+++ b/app/graphql/gql/mutations/ticket/external_references/snipeit_asset_remove.rb
@@ -1,0 +1,21 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Mutations
+  class Ticket::ExternalReferences::SnipeitAssetRemove < BaseMutation
+    description 'Remove a Snipe-IT asset from a ticket.'
+
+    argument :ticket_id, GraphQL::Types::ID, loads: Gql::Types::TicketType, loads_pundit_method: :agent_update_access?, description: 'The related ticket for the Snipe-IT assets'
+    argument :snipeit_asset_id, Integer, description: 'The Snipe-IT asset to remove'
+
+    field :success, Boolean, description: 'Was the mutation successful?'
+
+    requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
+
+    def resolve(snipeit_asset_id:, ticket: nil)
+      ticket.preferences.dig(:snipeit, :asset_ids)&.map!(&:to_i)&.delete(snipeit_asset_id)
+      ticket.save!
+
+      { success: true }
+    end
+  end
+end

--- a/app/graphql/gql/queries/autocomplete_search/snipeit_categories.rb
+++ b/app/graphql/gql/queries/autocomplete_search/snipeit_categories.rb
@@ -1,0 +1,52 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Queries
+  class AutocompleteSearch::SnipeitCategories < BaseQuery
+
+    description 'Search for Snipe-IT categories'
+
+    argument :input, Gql::Types::Input::AutocompleteSearch::InputType, required: true, description: 'The input object for the autocomplete search'
+
+    type [Gql::Types::AutocompleteSearch::EntryType], null: false
+
+    requires_permission 'ticket.agent'
+    requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
+
+    def resolve(input:)
+      api_call(input).map do |category|
+        { value: category['id'].to_s, label: category['name'] }
+      end
+    end
+
+    private
+
+    # Snipe-IT filters server-side, so the search term must be passed on instead of
+    # fetching a page of categories and filtering it in Ruby, which would make
+    # categories beyond the fetched page unreachable.
+    def api_call(input)
+      response = Snipeit.query('categories', build_params(input))
+      response.is_a?(Hash) && response['rows'].is_a?(Array) ? response['rows'] : []
+    rescue => e
+      Rails.logger.error "Failed to fetch Snipe-IT categories: #{e.message}"
+      []
+    end
+
+    def build_params(input)
+      # Only asset categories can ever contain hardware; accessory, consumable, component
+      # and license categories would always yield an empty asset list.
+      params = { 'limit' => input.limit || 10, 'category_type' => 'asset' }
+
+      search = normalize_query(input.query)
+      params['search'] = search if search.present?
+
+      params
+    end
+
+    def normalize_query(query)
+      query = query.strip
+      return '' if query.blank? || query == '*'
+
+      query.delete_prefix('*').delete_suffix('*')
+    end
+  end
+end

--- a/app/graphql/gql/queries/autocomplete_search/snipeit_models.rb
+++ b/app/graphql/gql/queries/autocomplete_search/snipeit_models.rb
@@ -1,0 +1,50 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Queries
+  class AutocompleteSearch::SnipeitModels < BaseQuery
+
+    description 'Search for Snipe-IT models'
+
+    argument :input, Gql::Types::Input::AutocompleteSearch::InputType, required: true, description: 'The input object for the autocomplete search'
+
+    type [Gql::Types::AutocompleteSearch::EntryType], null: false
+
+    requires_permission 'ticket.agent'
+    requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
+
+    def resolve(input:)
+      api_call(input).map do |model|
+        { value: model['id'].to_s, label: model['name'] }
+      end
+    end
+
+    private
+
+    # Snipe-IT filters server-side, so the search term must be passed on instead of
+    # fetching a page of models and filtering it in Ruby, which would make models
+    # beyond the fetched page unreachable.
+    def api_call(input)
+      response = Snipeit.query('models', build_params(input))
+      response.is_a?(Hash) && response['rows'].is_a?(Array) ? response['rows'] : []
+    rescue => e
+      Rails.logger.error "Failed to fetch Snipe-IT models: #{e.message}"
+      []
+    end
+
+    def build_params(input)
+      params = { 'limit' => input.limit || 10 }
+
+      search = normalize_query(input.query)
+      params['search'] = search if search.present?
+
+      params
+    end
+
+    def normalize_query(query)
+      query = query.strip
+      return '' if query.blank? || query == '*'
+
+      query.delete_prefix('*').delete_suffix('*')
+    end
+  end
+end

--- a/app/graphql/gql/queries/autocomplete_search/snipeit_models.rb
+++ b/app/graphql/gql/queries/autocomplete_search/snipeit_models.rb
@@ -5,7 +5,7 @@ module Gql::Queries
 
     description 'Search for Snipe-IT models'
 
-    argument :input, Gql::Types::Input::AutocompleteSearch::InputType, required: true, description: 'The input object for the autocomplete search'
+    argument :input, Gql::Types::Input::AutocompleteSearch::SnipeitModelsInputType, required: true, description: 'The input object for the autocomplete search'
 
     type [Gql::Types::AutocompleteSearch::EntryType], null: false
 
@@ -33,6 +33,10 @@ module Gql::Queries
 
     def build_params(input)
       params = { 'limit' => input.limit || 10 }
+
+      # Snipe-IT models belong to a category, so a selected category can narrow the list
+      # down instead of offering models which cannot hold the wanted assets.
+      params['category_id'] = input.category_id if input.category_id.present?
 
       search = normalize_query(input.query)
       params['search'] = search if search.present?

--- a/app/graphql/gql/queries/ticket/external_references/snipeit_asset_list.rb
+++ b/app/graphql/gql/queries/ticket/external_references/snipeit_asset_list.rb
@@ -1,0 +1,41 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Queries
+  class Ticket::ExternalReferences::SnipeitAssetList < BaseQuery
+
+    description 'Detailed Snipe-IT assets for the given asset ids or the given ticket'
+
+    argument :input, Gql::Types::Input::Ticket::ExternalReferences::SnipeitAssetListInputType, description: 'The input to fetch detailed Snipe-IT assets for the given asset ids or the given ticket'
+
+    type [Gql::Types::Ticket::ExternalReferences::SnipeitAssetType], null: false
+
+    requires_permission 'ticket.agent'
+    requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
+
+    def resolve(input:)
+      snipeit_asset_ids = if input.ticket.present?
+                            input.ticket.preferences.dig(:snipeit, :asset_ids) || []
+                          else
+                            input.snipeit_asset_ids
+                          end
+
+      return [] if snipeit_asset_ids.blank?
+
+      # Snipe-IT offers no bulk lookup by id, so assets are fetched one by one.
+      # Like the i-doit integration, items which are not found are silently skipped.
+      snipeit_asset_ids.filter_map { |asset_id| fetch_asset(asset_id) }
+    end
+
+    private
+
+    def fetch_asset(asset_id)
+      response = Snipeit.asset(asset_id)
+      return if response.blank?
+
+      Snipeit.normalize_asset(response)
+    rescue => e
+      Rails.logger.error "Failed to fetch Snipe-IT asset #{asset_id}: #{e.message}"
+      nil
+    end
+  end
+end

--- a/app/graphql/gql/queries/ticket/external_references/snipeit_asset_search.rb
+++ b/app/graphql/gql/queries/ticket/external_references/snipeit_asset_search.rb
@@ -9,22 +9,43 @@ module Gql::Queries
     argument :model_id, String, required: false, description: 'Selected Snipe-IT model id to search in'
     argument :query, String, required: false, description: 'Query for searching the Snipe-IT assets'
     argument :limit, Integer, required: false, description: 'Limit for the amount of entries'
+    argument :customer_id, GraphQL::Types::ID, required: false, loads: Gql::Types::UserType, description: 'Ticket customer whose assigned assets are suggested while no filter is set'
 
     type [Gql::Types::Ticket::ExternalReferences::SnipeitAssetType], null: false
 
     requires_permission 'ticket.agent'
     requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
 
-    def resolve(query: '', limit: 10, category_id: nil, model_id: nil)
-      params = build_params(category_id:, model_id:, query:, limit:)
-      response = Snipeit.query('hardware', params)
+    def resolve(query: '', limit: 10, category_id: nil, model_id: nil, customer: nil)
+      rows   = customer_assets(customer, limit:) if suggest_customer_assets?(customer, query:, category_id:, model_id:)
+      rows ||= search_assets(category_id:, model_id:, query:, limit:)
 
-      return [] if !response.is_a?(Hash) || !response['rows'].is_a?(Array)
-
-      response['rows'].map { |asset| Snipeit.normalize_asset(asset) }
+      rows.map { |asset| Snipeit.normalize_asset(asset) }
     end
 
     private
+
+    def search_assets(category_id:, model_id:, query:, limit:)
+      response = Snipeit.query('hardware', build_params(category_id:, model_id:, query:, limit:))
+
+      return [] if !response.is_a?(Hash) || !response['rows'].is_a?(Array)
+
+      response['rows']
+    end
+
+    # With no filter applied, the assets already assigned to the ticket customer are the
+    # most likely candidates - the same suggestion the legacy sidebar makes. As soon as
+    # anything is typed or selected, the regular search takes over again.
+    def suggest_customer_assets?(customer, query:, category_id:, model_id:)
+      customer.present? && category_id.blank? && model_id.blank? && normalize_query(query).blank?
+    end
+
+    def customer_assets(customer, limit:)
+      Snipeit.assets_assigned_to_email(customer.email, limit: limit)
+    rescue => e
+      Rails.logger.error "Failed to fetch Snipe-IT assets for customer #{customer.id}: #{e.message}"
+      nil
+    end
 
     def build_params(category_id:, model_id:, query:, limit:)
       {}.tap do |params|

--- a/app/graphql/gql/queries/ticket/external_references/snipeit_asset_search.rb
+++ b/app/graphql/gql/queries/ticket/external_references/snipeit_asset_search.rb
@@ -1,0 +1,47 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Queries
+  class Ticket::ExternalReferences::SnipeitAssetSearch < BaseQuery
+
+    description 'Search for Snipe-IT assets'
+
+    argument :category_id, String, required: false, description: 'Selected Snipe-IT category id to search in'
+    argument :model_id, String, required: false, description: 'Selected Snipe-IT model id to search in'
+    argument :query, String, required: false, description: 'Query for searching the Snipe-IT assets'
+    argument :limit, Integer, required: false, description: 'Limit for the amount of entries'
+
+    type [Gql::Types::Ticket::ExternalReferences::SnipeitAssetType], null: false
+
+    requires_permission 'ticket.agent'
+    requires_enabled_setting 'snipeit_integration', error_message: __('Snipe-IT integration is not enabled')
+
+    def resolve(query: '', limit: 10, category_id: nil, model_id: nil)
+      params = build_params(category_id:, model_id:, query:, limit:)
+      response = Snipeit.query('hardware', params)
+
+      return [] if !response.is_a?(Hash) || !response['rows'].is_a?(Array)
+
+      response['rows'].map { |asset| Snipeit.normalize_asset(asset) }
+    end
+
+    private
+
+    def build_params(category_id:, model_id:, query:, limit:)
+      {}.tap do |params|
+        params['limit'] = limit if limit
+        params['category_id'] = category_id if category_id.present?
+        params['model_id'] = model_id if model_id.present?
+
+        search_query = normalize_query(query)
+        params['search'] = search_query if search_query.present?
+      end
+    end
+
+    def normalize_query(query)
+      query = query.strip
+      return '' if query.blank? || query == '*'
+
+      query.delete_prefix('*').delete_suffix('*')
+    end
+  end
+end

--- a/app/graphql/gql/types/input/autocomplete_search/snipeit_models_input_type.rb
+++ b/app/graphql/gql/types/input/autocomplete_search/snipeit_models_input_type.rb
@@ -1,0 +1,10 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Types::Input::AutocompleteSearch
+  class SnipeitModelsInputType < InputType
+
+    description 'Input fields for Snipe-IT model autocomplete searches.'
+
+    argument :category_id, String, required: false, description: 'Snipe-IT category id to restrict the models to'
+  end
+end

--- a/app/graphql/gql/types/input/ticket/external_references/snipeit_asset_list_input_type.rb
+++ b/app/graphql/gql/types/input/ticket/external_references/snipeit_asset_list_input_type.rb
@@ -1,0 +1,12 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Types::Input::Ticket::ExternalReferences
+  class SnipeitAssetListInputType < Gql::Types::BaseInputObject
+    description 'Input fields for retrieving Snipe-IT asset details'
+
+    argument :ticket_id, GraphQL::Types::ID, required: false, loads: Gql::Types::TicketType, description: 'The related ticket for the Snipe-IT assets'
+    argument :snipeit_asset_ids, [Integer], required: false, description: 'Snipe-IT asset IDs to fetch'
+
+    validates required: { one_of: %i[ticket snipeit_asset_ids] }
+  end
+end

--- a/app/graphql/gql/types/input/ticket/external_references_input_type.rb
+++ b/app/graphql/gql/types/input/ticket/external_references_input_type.rb
@@ -18,5 +18,10 @@ module Gql::Types::Input::Ticket
              [Integer],
              required:    false,
              description: 'Object ids for the Idoit integration'
+
+    argument :snipeit,
+             [Integer],
+             required:    false,
+             description: 'Asset ids for the Snipe-IT integration'
   end
 end

--- a/app/graphql/gql/types/ticket/external_references/snipeit_asset_type.rb
+++ b/app/graphql/gql/types/ticket/external_references/snipeit_asset_type.rb
@@ -1,0 +1,17 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Gql::Types::Ticket::ExternalReferences
+  class SnipeitAssetType < Gql::Types::BaseObject
+    description 'Snipe-IT asset item for an external reference for a ticket'
+
+    field :snipeit_asset_id, Integer, null: false, method: :id, description: 'Snipe-IT asset id'
+    field :name, String, null: false
+    field :asset_tag, String, description: 'Asset tag'
+    field :serial, String, description: 'Serial number'
+    field :link, Gql::Types::UriHttpStringType, description: 'Link to the asset in the Snipe-IT GUI'
+    field :model, String, description: 'Asset model name', method: :model_name
+    field :status, String, description: 'Asset status', method: :status_name
+    field :category, String, description: 'Asset category', method: :category_name
+    field :location, String, description: 'Asset location', method: :location_name
+  end
+end

--- a/app/graphql/gql/types/ticket_external_references_type.rb
+++ b/app/graphql/gql/types/ticket_external_references_type.rb
@@ -4,8 +4,9 @@ module Gql::Types
   class TicketExternalReferencesType < BaseObject
     description 'Links attached to a ticket and pointing to external services'
 
-    field :github, [Gql::Types::UriHttpStringType], description: 'Returns exising links for the github integration'
-    field :gitlab, [Gql::Types::UriHttpStringType], description: 'Returns exising links for the gitlab integration'
-    field :idoit,  [Integer], description: 'Returns exising object ids for the idoit integration'
+    field :github,  [Gql::Types::UriHttpStringType], description: 'Returns exising links for the github integration'
+    field :gitlab,  [Gql::Types::UriHttpStringType], description: 'Returns exising links for the gitlab integration'
+    field :idoit,   [Integer], description: 'Returns exising object ids for the idoit integration'
+    field :snipeit, [Integer], description: 'Returns existing asset ids for the Snipe-IT integration'
   end
 end

--- a/app/graphql/gql/types/ticket_type.rb
+++ b/app/graphql/gql/types/ticket_type.rb
@@ -151,6 +151,10 @@ module Gql::Types
         output[:idoit] = @object.preferences.dig('idoit', 'object_ids')&.map(&:to_i)
       end
 
+      if Setting.get('snipeit_integration')
+        output[:snipeit] = @object.preferences.dig('snipeit', 'asset_ids')&.map(&:to_i)
+      end
+
       output.compact_blank.presence
     end
 

--- a/app/graphql/graphql_introspection.json
+++ b/app/graphql/graphql_introspection.json
@@ -12633,6 +12633,92 @@
               "deprecationReason": null
             },
             {
+              "name": "ticketExternalReferencesSnipeitAssetAdd",
+              "description": "Add Snipe-IT assets to a ticket or just resolve them for ticket creation.",
+              "args": [
+                {
+                  "name": "ticketId",
+                  "description": "The related ticket for the Snipe-IT assets",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "snipeitAssetIds",
+                  "description": "The Snipe-IT assets to add",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "Int",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TicketExternalReferencesSnipeitAssetAddPayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ticketExternalReferencesSnipeitAssetRemove",
+              "description": "Remove a Snipe-IT asset from a ticket.",
+              "args": [
+                {
+                  "name": "ticketId",
+                  "description": "The related ticket for the Snipe-IT assets",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "snipeitAssetId",
+                  "description": "The Snipe-IT asset to remove",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Int",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TicketExternalReferencesSnipeitAssetRemovePayload",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "ticketLiveUserDelete",
               "description": "Deletes the desired live user entry.",
               "args": [
@@ -17631,6 +17717,84 @@
               "deprecationReason": null
             },
             {
+              "name": "autocompleteSearchSnipeitCategories",
+              "description": "Search for Snipe-IT categories",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The input object for the autocomplete search",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AutocompleteSearchInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AutocompleteSearchEntry",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "autocompleteSearchSnipeitModels",
+              "description": "Search for Snipe-IT models",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The input object for the autocomplete search",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "AutocompleteSearchInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AutocompleteSearchEntry",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "autocompleteSearchTag",
               "description": "Search for tags",
               "args": [
@@ -19164,6 +19328,110 @@
                     "ofType": {
                       "kind": "OBJECT",
                       "name": "TicketExternalReferencesIssueTrackerItem",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ticketExternalReferencesSnipeitAssetList",
+              "description": "Detailed Snipe-IT assets for the given asset ids or the given ticket",
+              "args": [
+                {
+                  "name": "input",
+                  "description": "The input to fetch detailed Snipe-IT assets for the given asset ids or the given ticket",
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "TicketExternalReferencesSnipeitAssetListInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "TicketExternalReferencesSnipeitAsset",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ticketExternalReferencesSnipeitAssetSearch",
+              "description": "Search for Snipe-IT assets",
+              "args": [
+                {
+                  "name": "categoryId",
+                  "description": "Selected Snipe-IT category id to search in",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "modelId",
+                  "description": "Selected Snipe-IT model id to search in",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "query",
+                  "description": "Query for searching the Snipe-IT assets",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": "Limit for the amount of entries",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "TicketExternalReferencesSnipeitAsset",
                       "ofType": null
                     }
                   }
@@ -26800,6 +27068,26 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "snipeit",
+              "description": "Returns existing asset ids for the Snipe-IT integration",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -27072,6 +27360,24 @@
             {
               "name": "idoit",
               "description": "Object ids for the Idoit integration",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "snipeit",
+              "description": "Asset ids for the Snipe-IT integration",
               "type": {
                 "kind": "LIST",
                 "name": null,
@@ -27451,6 +27757,266 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TicketExternalReferencesSnipeitAsset",
+          "description": "Snipe-IT asset item for an external reference for a ticket",
+          "fields": [
+            {
+              "name": "assetTag",
+              "description": "Asset tag",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "category",
+              "description": "Asset category",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "link",
+              "description": "Link to the asset in the Snipe-IT GUI",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "UriHttpString",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "location",
+              "description": "Asset location",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "model",
+              "description": "Asset model name",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "serial",
+              "description": "Serial number",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snipeitAssetId",
+              "description": "Snipe-IT asset id",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "status",
+              "description": "Asset status",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TicketExternalReferencesSnipeitAssetAddPayload",
+          "description": "Autogenerated return type of TicketExternalReferencesSnipeitAssetAdd.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": "Errors encountered during execution of the mutation.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UserError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "snipeitAssets",
+              "description": "The added / resolved Snipe-IT assets",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TicketExternalReferencesSnipeitAsset",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TicketExternalReferencesSnipeitAssetListInput",
+          "description": "Input fields for retrieving Snipe-IT asset details",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "ticketId",
+              "description": "The related ticket for the Snipe-IT assets",
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "snipeitAssetIds",
+              "description": "Snipe-IT asset IDs to fetch",
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TicketExternalReferencesSnipeitAssetRemovePayload",
+          "description": "Autogenerated return type of TicketExternalReferencesSnipeitAssetRemove.",
+          "fields": [
+            {
+              "name": "errors",
+              "description": "Errors encountered during execution of the mutation.",
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UserError",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "success",
+              "description": "Was the mutation successful?",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
           "enumValues": null,
           "possibleTypes": null
         },

--- a/app/graphql/graphql_introspection.json
+++ b/app/graphql/graphql_introspection.json
@@ -19463,6 +19463,16 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "customerId",
+                  "description": "Ticket customer whose assigned assets are suggested while no filter is set",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {

--- a/app/graphql/graphql_introspection.json
+++ b/app/graphql/graphql_introspection.json
@@ -2304,6 +2304,51 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "AutocompleteSearchSnipeitModelsInput",
+          "description": "Input fields for Snipe-IT model autocomplete searches.",
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "query",
+              "description": "Query from the autocomplete field",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "limit",
+              "description": "Limit for the amount of entries",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "categoryId",
+              "description": "Snipe-IT category id to restrict the models to",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "AutocompleteSearchTagInput",
           "description": "Input fields for tag autocomplete searches.",
           "fields": null,
@@ -17767,7 +17812,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
-                      "name": "AutocompleteSearchInput",
+                      "name": "AutocompleteSearchSnipeitModelsInput",
                       "ofType": null
                     }
                   },

--- a/app/models/http_log.rb
+++ b/app/models/http_log.rb
@@ -57,6 +57,7 @@ optional you can put the max oldest chat entries as argument
       'SAML'               => 'admin.security',
       'sipagte.io'         => 'admin.integration', # typo in facility name, keep for backward compatibility
       'sipgate.io'         => 'admin.integration',
+      'snipeit'            => 'admin.integration',
       'webhook'            => 'admin.webhook',
       'WhatsApp::Business' => 'admin.channel_whatsapp',
     }

--- a/app/policies/controllers/integration/snipeit_controller_policy.rb
+++ b/app/policies/controllers/integration/snipeit_controller_policy.rb
@@ -1,0 +1,7 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Controllers::Integration::SnipeitControllerPolicy < Controllers::ApplicationControllerPolicy
+  permit! %i[query update], to: 'ticket.agent'
+  permit! :verify, to: 'admin.integration.snipeit'
+  default_permit!(['agent.integration.snipeit', 'admin.integration.snipeit'])
+end

--- a/app/services/service/ticket/create.rb
+++ b/app/services/service/ticket/create.rb
@@ -135,21 +135,27 @@ class Service::Ticket::Create < Service::Base
     return if external_references.blank?
 
     %i[github gitlab].each do |key|
-      input = external_references[key]
+      next if !external_reference_enabled?(external_references, key)
 
-      next if input.blank? || !Setting.get("#{key}_integration")
-
-      ticket_data[:preferences] ||= {}
-      ticket_data[:preferences][key] = { issue_links: input.map(&:to_s) }
+      add_external_reference_preference(ticket_data, key, { issue_links: external_references[key].map(&:to_s) })
     end
 
-    # idoit
-    idoit_object_ids = external_references[:idoit]
+    if external_reference_enabled?(external_references, :idoit)
+      add_external_reference_preference(ticket_data, :idoit, { object_ids: external_references[:idoit] })
+    end
 
-    return if idoit_object_ids.blank? || !Setting.get('idoit_integration')
+    return if !external_reference_enabled?(external_references, :snipeit)
 
+    add_external_reference_preference(ticket_data, :snipeit, { asset_ids: external_references[:snipeit] })
+  end
+
+  def external_reference_enabled?(external_references, key)
+    external_references[key].present? && Setting.get("#{key}_integration")
+  end
+
+  def add_external_reference_preference(ticket_data, key, value)
     ticket_data[:preferences] ||= {}
-    ticket_data[:preferences][:idoit] = { object_ids: idoit_object_ids }
+    ticket_data[:preferences][key] = value
   end
 
   def customer?(group_id)

--- a/app/services/service/ticket/create.rb
+++ b/app/services/service/ticket/create.rb
@@ -31,6 +31,7 @@ class Service::Ticket::Create < Service::Base
         create_article(ticket, article_data)
         assign_tags(ticket, tag_data)
         add_links(ticket, link_data)
+        log_snipeit_asset_links(ticket)
       end
     end
   end
@@ -45,6 +46,25 @@ class Service::Ticket::Create < Service::Base
     Service::Ticket::Article::Create
       .with_current_user(current_user)
       .execute(article_data: article_data, ticket: ticket)
+  end
+
+  # Assets selected while creating a ticket are stored as part of the ticket itself, not as
+  # a later change, so Service::Ticket::ExternalReferences::Snipeit::LinkAssets never sees a
+  # diff to derive the history from. Without this, unlinking such an asset would leave a
+  # 'removed' entry with no matching 'added' one.
+  #
+  # Reads the ids off the saved ticket rather than the input, so it covers both the
+  # externalReferences input used by the Vue create screen and the raw preferences the
+  # legacy sidebar appends to the create request.
+  def log_snipeit_asset_links(ticket)
+    return if !Setting.get('snipeit_integration')
+
+    asset_ids = Array(ticket.preferences.dig(:snipeit, :asset_ids)).map(&:to_i).uniq
+    return if asset_ids.blank?
+
+    asset_ids.each do |asset_id|
+      ticket.history_log('added', current_user.id, { history_attribute: 'snipeit', value_to: Snipeit.asset_label(asset_id) })
+    end
   end
 
   def assign_tags(ticket, tag_data)

--- a/app/services/service/ticket/external_references/snipeit/link_assets.rb
+++ b/app/services/service/ticket/external_references/snipeit/link_assets.rb
@@ -1,0 +1,49 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+# Sets the Snipe-IT assets linked to a ticket and records the change in the ticket history.
+#
+# Ticket historization ignores the preferences column (see Ticket.history_attributes_ignored),
+# so linking and unlinking assets would otherwise leave no trace at all. Every caller which
+# writes preferences[:snipeit][:asset_ids] has to go through here.
+class Service::Ticket::ExternalReferences::Snipeit::LinkAssets < Service::Base
+  requires_current_user!
+
+  attr_reader :ticket, :asset_ids
+
+  def initialize(ticket:, asset_ids:)
+    @ticket = ticket
+    @asset_ids = Array(asset_ids).map(&:to_i).uniq
+  end
+
+  def execute
+    ticket.with_lock do
+      previous_asset_ids = current_asset_ids
+
+      ticket.preferences[:snipeit] ||= {}
+      ticket.preferences[:snipeit][:asset_ids] = asset_ids
+      ticket.save!
+
+      # Inside the lock and after the save, so a concurrent update cannot produce history
+      # which does not match the stored asset ids.
+      log_history(previous_asset_ids)
+    end
+
+    ticket
+  end
+
+  private
+
+  def current_asset_ids
+    Array(ticket.preferences.dig(:snipeit, :asset_ids)).map(&:to_i)
+  end
+
+  def log_history(previous_asset_ids)
+    (asset_ids - previous_asset_ids).each do |asset_id|
+      ticket.history_log('added', current_user.id, { history_attribute: 'snipeit', value_to: Snipeit.asset_label(asset_id) })
+    end
+
+    (previous_asset_ids - asset_ids).each do |asset_id|
+      ticket.history_log('removed', current_user.id, { history_attribute: 'snipeit', value_to: Snipeit.asset_label(asset_id) })
+    end
+  end
+end

--- a/config/routes/integration_snipeit.rb
+++ b/config/routes/integration_snipeit.rb
@@ -1,0 +1,11 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+Zammad::Application.routes.draw do
+  api_path = Rails.configuration.api_path
+
+  match api_path + '/integration/snipeit',                to: 'integration/snipeit#query',   via: :post
+  match api_path + '/integration/snipeit',                to: 'integration/snipeit#query',   via: :get
+  match api_path + '/integration/snipeit/verify',         to: 'integration/snipeit#verify',  via: :post
+  match api_path + '/integration/snipeit_ticket_update',  to: 'integration/snipeit#update',  via: :post
+
+end

--- a/db/migrate/20260725000000_add_snipeit_integration.rb
+++ b/db/migrate/20260725000000_add_snipeit_integration.rb
@@ -1,0 +1,54 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class AddSnipeitIntegration < ActiveRecord::Migration[8.0]
+  def up
+    return if !Setting.exists?(name: 'system_init_done')
+
+    Setting.create_if_not_exists(
+      title:       'Snipe-IT integration',
+      name:        'snipeit_integration',
+      area:        'Integration::Switch',
+      description: 'Defines if the Snipe-IT (https://snipeitapp.com/) integration is enabled or not.',
+      options:     {
+        form: [
+          {
+            display: '',
+            null:    true,
+            name:    'snipeit_integration',
+            tag:     'boolean',
+            options: {
+              true  => 'yes',
+              false => 'no',
+            },
+          },
+        ],
+      },
+      state:       false,
+      preferences: {
+        prio:           1,
+        authentication: true,
+        permission:     ['admin.integration'],
+      },
+      frontend:    true
+    )
+
+    Setting.create_if_not_exists(
+      title:       'Snipe-IT config',
+      name:        'snipeit_config',
+      area:        'Integration::Snipeit',
+      description: 'Defines the Snipe-IT config.',
+      options:     {},
+      state:       {},
+      preferences: {
+        prio:       2,
+        permission: ['admin.integration'],
+      },
+      frontend:    false,
+    )
+  end
+
+  def down
+    Setting.find_by(name: 'snipeit_integration')&.destroy
+    Setting.find_by(name: 'snipeit_config')&.destroy
+  end
+end

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -5110,6 +5110,46 @@ Setting.create_if_not_exists(
   frontend:    false,
 )
 Setting.create_if_not_exists(
+  title:       __('Snipe-IT integration'),
+  name:        'snipeit_integration',
+  area:        'Integration::Switch',
+  description: __('Defines if the Snipe-IT (https://snipeitapp.com/) integration is enabled or not.'),
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    true,
+        name:    'snipeit_integration',
+        tag:     'boolean',
+        options: {
+          true  => 'yes',
+          false => 'no',
+        },
+      },
+    ],
+  },
+  state:       false,
+  preferences: {
+    prio:           1,
+    authentication: true,
+    permission:     ['admin.integration'],
+  },
+  frontend:    true
+)
+Setting.create_if_not_exists(
+  title:       __('Snipe-IT config'),
+  name:        'snipeit_config',
+  area:        'Integration::Snipeit',
+  description: __('Defines the Snipe-IT config.'),
+  options:     {},
+  state:       {},
+  preferences: {
+    prio:       2,
+    permission: ['admin.integration'],
+  },
+  frontend:    false,
+)
+Setting.create_if_not_exists(
   title:       __('GitLab integration'),
   name:        'gitlab_integration',
   area:        'Integration::Switch',

--- a/lib/snipeit.rb
+++ b/lib/snipeit.rb
@@ -118,6 +118,28 @@ away instead of reporting 'not found' until the entry expires.
 
 =begin
 
+readable label for a hardware asset, for use in the ticket history
+
+  label = Snipeit.asset_label(42)
+
+Assets live in Snipe-IT, so a history entry has to carry a label of its own - the bare id
+would be meaningless once the link is gone. Falls back to the id if the asset can no longer
+be fetched, because a broken Snipe-IT connection must not stop a ticket from being saved.
+
+=end
+
+  def self.asset_label(asset_id)
+    api_asset = asset(asset_id)
+    return asset_id.to_s if api_asset.blank?
+
+    api_asset['asset_tag'].presence || api_asset['name'].presence || asset_id.to_s
+  rescue => e
+    Rails.logger.error "Failed to fetch Snipe-IT asset #{asset_id} for the ticket history: #{e.message}"
+    asset_id.to_s
+  end
+
+=begin
+
 normalize a raw Snipe-IT hardware asset into the flat structure used by the GraphQL types
 
   asset = Snipeit.normalize_asset(api_asset)

--- a/lib/snipeit.rb
+++ b/lib/snipeit.rb
@@ -140,6 +140,50 @@ be fetched, because a broken Snipe-IT connection must not stop a ticket from bei
 
 =begin
 
+look up a Snipe-IT user by email address
+
+  user = Snipeit.user_by_email('nicole.braun@zammad.org')
+
+Snipe-IT matches 'email' exactly, unlike 'search', which would return a fuzzy page the
+wanted user may not even be part of. The find below stays as a defensive re-check.
+
+returns the raw user hash, or nil if no user has that address.
+
+=end
+
+  def self.user_by_email(email)
+    return if email.blank?
+
+    response = query('users', { email: email })
+    return if response.blank? || response['rows'].blank?
+
+    response['rows'].find { |user| user['email']&.downcase == email.downcase }
+  end
+
+=begin
+
+hardware assets currently assigned to the Snipe-IT user with the given email address
+
+  assets = Snipeit.assets_assigned_to_email('nicole.braun@zammad.org')
+
+returns an array of raw assets, or nil if no Snipe-IT user has that address - so callers
+can tell 'unknown customer' apart from 'customer without assets'.
+
+=end
+
+  def self.assets_assigned_to_email(email, limit: nil)
+    user = user_by_email(email)
+    return if user.blank?
+
+    params = { assigned_to: user['id'], assigned_type: 'App\\Models\\User' }
+    params[:limit] = limit if limit
+
+    response = query('hardware', params)
+    response.is_a?(Hash) && response['rows'].is_a?(Array) ? response['rows'] : []
+  end
+
+=begin
+
 normalize a raw Snipe-IT hardware asset into the flat structure used by the GraphQL types
 
   asset = Snipeit.normalize_asset(api_asset)

--- a/lib/snipeit.rb
+++ b/lib/snipeit.rb
@@ -1,0 +1,199 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'cgi'
+
+class Snipeit
+
+=begin
+
+verify Snipe-IT configuration
+
+  result = Snipeit.verify(api_token, endpoint, verify_ssl: false)
+
+returns
+
+  array with hardware assets or an exception if no data was able to be retrieved
+
+=end
+
+  def self.verify(api_token, endpoint, verify_ssl: false)
+    raise __('Invalid Snipe-IT configuration (missing endpoint or api_token).') if api_token.blank? || endpoint.blank?
+
+    _query('hardware', {}, _url_cleanup(endpoint), api_token, verify_ssl: verify_ssl)
+  end
+
+=begin
+
+query Snipe-IT API
+
+  result = Snipeit.query(method, params)
+
+  result = Snipeit.query('hardware', { search: 'laptop' })
+
+returns for hardware:
+
+  {
+    "total": 2,
+    "rows": [
+      {
+        "id": 1,
+        "name": "Laptop-001",
+        "asset_tag": "LAP001",
+        "serial": "ABC123",
+        "model": {
+          "id": 1,
+          "name": "MacBook Pro"
+        },
+        "status_label": {
+          "id": 2,
+          "name": "Ready to Deploy",
+          "status_type": "deployable",
+          "status_meta": "deployed"
+        },
+        "category": {
+          "id": 1,
+          "name": "Laptops"
+        },
+        "manufacturer": {
+          "id": 1,
+          "name": "Apple"
+        },
+        "location": {
+          "id": 1,
+          "name": "HQ"
+        },
+        "assigned_to": {
+          "id": 1,
+          "name": "John Doe",
+          "type": "user"
+        },
+        "notes": "Some notes",
+        "created_at": {
+          "datetime": "2024-01-01 10:00:00",
+          "formatted": "Mon Jan 01, 2024 10:00 AM"
+        },
+        "updated_at": {
+          "datetime": "2024-01-15 14:30:00",
+          "formatted": "Mon Jan 15, 2024 02:30 PM"
+        }
+      }
+    ]
+  }
+
+=end
+
+  def self.query(method, params = {})
+    setting = Setting.get('snipeit_config')
+    raise __("The required field 'api_token' is missing from the config.") if setting[:api_token].blank?
+    raise __("The required field 'endpoint' is missing from the config.") if setting[:endpoint].blank?
+
+    _query(method, params, _url_cleanup(setting[:endpoint]), setting[:api_token], verify_ssl: setting[:verify_ssl])
+  end
+
+=begin
+
+fetch a single hardware asset by id
+
+  asset = Snipeit.asset(42)
+
+Snipe-IT offers no bulk lookup by id, so linked assets have to be fetched one by one.
+The short-lived cache keeps the repeated lookups of the same ids (sidebar badge, sidebar
+list, re-render after every add / remove) from turning into individual HTTP requests.
+
+returns the raw API hash, or nil if the asset does not exist. Callers which need the flat
+structure used by the GraphQL types have to apply .normalize_asset themselves, because the
+legacy sidebar renders the nested Snipe-IT keys directly.
+
+Misses are not cached, so an asset which was just created in Snipe-IT is linkable right
+away instead of reporting 'not found' until the entry expires.
+
+=end
+
+  def self.asset(asset_id)
+    Rails.cache.fetch("Snipeit/hardware/#{asset_id.to_i}", expires_in: 1.minute, skip_nil: true) do
+      response = query("hardware/#{asset_id.to_i}")
+      response.is_a?(Hash) && response['id'] ? response : nil
+    end
+  end
+
+=begin
+
+normalize a raw Snipe-IT hardware asset into the flat structure used by the GraphQL types
+
+  asset = Snipeit.normalize_asset(api_asset)
+
+=end
+
+  def self.normalize_asset(asset)
+    {
+      'id'            => asset['id'],
+      'name'          => asset['name'] || asset['asset_tag'],
+      'asset_tag'     => asset['asset_tag'],
+      'serial'        => asset['serial'],
+      'link'          => asset['link'],
+      'model_name'    => asset.dig('model', 'name'),
+      'status_name'   => asset.dig('status_label', 'name'),
+      'category_name' => asset.dig('category', 'name'),
+      'location_name' => asset.dig('location', 'name'),
+    }
+  end
+
+  def self._query(method, params, url, api_token, verify_ssl: false)
+    # Build query parameters
+    query_params = params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join('&')
+    full_url = query_params.present? ? "#{url}/#{method}?#{query_params}" : "#{url}/#{method}"
+
+    result = UserAgent.get(
+      full_url,
+      {},
+      {
+        verify_ssl:   verify_ssl,
+        json:         true,
+        open_timeout: 6,
+        read_timeout: 16,
+        headers:      {
+          'Authorization' => "Bearer #{api_token}",
+          'Accept'        => 'application/json',
+        },
+        log:          {
+          facility: 'snipeit',
+        },
+      },
+    )
+
+    raise format(__("Can't fetch data from %s: %s"), url, result.error) if !result.success?
+
+    data = result.data
+
+    # add link to assets
+    if data['rows'].is_a?(Array)
+      data['rows'].each do |item|
+        next if !item['id']
+
+        item['link'] = "#{_url_cleanup_baseurl(url)}/hardware/#{item['id']}"
+      end
+    elsif data['id'].present?
+      # Single asset response
+      data['link'] = "#{_url_cleanup_baseurl(url)}/hardware/#{data['id']}"
+    end
+
+    data
+  end
+
+  def self._url_cleanup(url)
+    url = url.strip.gsub(%r{/+$}, '')
+    raise format(__("Invalid endpoint '%s', need to start with http:// or https://"), url) if !url.match?(%r{^https?://}i)
+
+    url = _url_cleanup_baseurl(url)
+    url = "#{url}/api/v1"
+    url.gsub(%r{([^:])//+}, '\\1/')
+  end
+
+  def self._url_cleanup_baseurl(url)
+    url = url.strip.gsub(%r{/+$}, '')
+    raise format(__("Invalid endpoint '%s', need to start with http:// or https://"), url) if !url.match?(%r{^https?://}i)
+
+    url.gsub!(%r{/api/v1.*$}, '')
+    url.gsub(%r{([^:])//+}, '\\1/')
+  end
+end

--- a/spec/graphql/gql/mutations/ticket/external_references/snipeit_asset_add_spec.rb
+++ b/spec/graphql/gql/mutations/ticket/external_references/snipeit_asset_add_spec.rb
@@ -1,0 +1,164 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Gql::Mutations::Ticket::ExternalReferences::SnipeitAssetAdd, type: :graphql do
+  let(:variables)                  { { ticketId: gql.id(ticket), snipeitAssetIds: snipeit_asset_ids } }
+  let(:ticket)                     { create(:ticket, preferences: { snipeit: { asset_ids: [42] } }) }
+  let(:snipeit_asset_ids)          { [26] }
+  let(:snipeit_api_asset) do
+    {
+      'id'           => 26,
+      'name'         => 'Laptop-001',
+      'asset_tag'    => 'LAP001',
+      'serial'       => 'ABC123',
+      'link'         => 'http://snipeit.example/hardware/26',
+      'model'        => { 'name' => 'MacBook Pro' },
+      'status_label' => { 'name' => 'Ready to Deploy' },
+      'category'     => { 'name' => 'Laptops' },
+      'location'     => { 'name' => 'HQ' },
+    }
+  end
+  let(:snipeit_asset) do
+    {
+      'snipeitAssetId' => 26,
+      'name'           => 'Laptop-001',
+      'assetTag'       => 'LAP001',
+      'serial'         => 'ABC123',
+      'link'           => 'http://snipeit.example/hardware/26',
+      'model'          => 'MacBook Pro',
+      'status'         => 'Ready to Deploy',
+      'category'       => 'Laptops',
+      'location'       => 'HQ',
+    }
+  end
+  let(:snipeit_integration_active) { true }
+
+  let(:mutation) do
+    <<~MUTATION
+      mutation ticketExternalReferencesSnipeitAssetAdd(
+        $ticketId: ID
+        $snipeitAssetIds: [Int!]!
+      ) {
+        ticketExternalReferencesSnipeitAssetAdd(
+          ticketId: $ticketId
+          snipeitAssetIds: $snipeitAssetIds
+        ) {
+          snipeitAssets {
+            snipeitAssetId
+            name
+            assetTag
+            serial
+            model
+            status
+            category
+            location
+            link
+          }
+          errors {
+            message
+            field
+          }
+        }
+      }
+    MUTATION
+  end
+
+  before do
+    Setting.set('snipeit_integration', snipeit_integration_active)
+    allow(Snipeit).to receive(:query).with('hardware/26').and_return(snipeit_api_asset)
+  end
+
+  context 'with an agent', authenticated_as: :agent do
+    let(:agent) { create(:agent) }
+
+    context 'when snipeit integration is inactive' do
+      let(:snipeit_integration_active) { false }
+
+      it 'raises an error' do
+        gql.execute(mutation, variables: variables)
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
+    context 'when ticket is used' do
+      context 'when an agent has access to the ticket' do
+        let(:agent) { create(:agent, groups: [ticket.group]) }
+
+        context 'when the snipeit asset id already exists' do
+          before do
+            ticket.preferences[:snipeit] = { asset_ids: [26] }
+            ticket.save!
+          end
+
+          it 'returns a user error' do
+            gql.execute(mutation, variables: variables)
+
+            expect(gql.result.data[:errors].first).to include('field' => 'snipeit_asset_ids', 'message' => 'The Snipe-IT asset is already present on the ticket.')
+          end
+        end
+
+        context 'when the snipeit asset id already exists as a string' do
+          before do
+            ticket.preferences[:snipeit] = { asset_ids: %w[26] }
+            ticket.save!
+          end
+
+          it 'returns a user error' do
+            gql.execute(mutation, variables: variables)
+
+            expect(gql.result.data[:errors].first).to include('field' => 'snipeit_asset_ids', 'message' => 'The Snipe-IT asset is already present on the ticket.')
+          end
+        end
+
+        context 'when the same snipeit asset id is submitted twice' do
+          let(:snipeit_asset_ids) { [26, 26] }
+
+          it 'returns a user error', aggregate_failures: true do
+            gql.execute(mutation, variables: variables)
+
+            expect(gql.result.data[:errors].first).to include('field' => 'snipeit_asset_ids', 'message' => 'The Snipe-IT asset is already present on the ticket.')
+            expect(ticket.reload.preferences).to include(snipeit: { asset_ids: [42] })
+          end
+        end
+
+        context 'when new snipeit asset should be added' do
+
+          it 'returns the snipeit asset', aggregate_failures: true do
+            gql.execute(mutation, variables: variables)
+
+            expect(gql.result.data[:snipeitAssets]).to contain_exactly(snipeit_asset)
+
+            expect(ticket.reload.preferences)
+              .to include(snipeit: { asset_ids: [42, 26] })
+          end
+        end
+      end
+
+      context 'when an agent has no access to the ticket' do
+        before { gql.execute(mutation, variables:) }
+
+        it_behaves_like 'graphql responds with error if unauthenticated'
+      end
+    end
+
+    context 'without a ticket' do
+      let(:variables) { { snipeitAssetIds: [26] } }
+
+      context 'when new snipeit asset should be added' do
+
+        it 'returns snipeit asset', aggregate_failures: true do
+          gql.execute(mutation, variables: variables)
+
+          expect(gql.result.data[:snipeitAssets]).to contain_exactly(snipeit_asset)
+        end
+      end
+    end
+  end
+
+  context 'when unauthenticated' do
+    before { gql.execute(mutation, variables:) }
+
+    it_behaves_like 'graphql responds with error if unauthenticated'
+  end
+end

--- a/spec/graphql/gql/mutations/ticket/external_references/snipeit_asset_remove_spec.rb
+++ b/spec/graphql/gql/mutations/ticket/external_references/snipeit_asset_remove_spec.rb
@@ -1,0 +1,81 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Gql::Mutations::Ticket::ExternalReferences::SnipeitAssetRemove, type: :graphql do
+  let(:variables)                  { { ticketId: gql.id(ticket), snipeitAssetId: snipeit_asset_id } }
+  let(:ticket)                     { create(:ticket, preferences: { 'snipeit' => { 'asset_ids' => [42, 26] } }) }
+  let(:snipeit_asset_id)           { 26 }
+  let(:snipeit_integration_active) { true }
+
+  let(:mutation) do
+    <<~MUTATION
+      mutation ticketExternalReferencesSnipeitAssetRemove(
+        $ticketId: ID!
+        $snipeitAssetId: Int!
+      ) {
+        ticketExternalReferencesSnipeitAssetRemove(
+          ticketId: $ticketId
+          snipeitAssetId: $snipeitAssetId
+        ) {
+          success
+          errors {
+            message
+            field
+          }
+        }
+      }
+    MUTATION
+  end
+
+  before do
+    Setting.set('snipeit_integration', snipeit_integration_active)
+  end
+
+  context 'with an agent', authenticated_as: :agent do
+    let(:agent) { create(:agent) }
+
+    context 'when snipeit integration is inactive' do
+      let(:snipeit_integration_active) { false }
+
+      it 'raises an error' do
+        gql.execute(mutation, variables: variables)
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
+    context 'when ticket is used' do
+      context 'when an agent has access to the ticket' do
+        let(:agent) { create(:agent, groups: [ticket.group]) }
+
+        it 'removes the snipeit asset' do
+          gql.execute(mutation, variables: variables)
+
+          expect(ticket.reload.preferences).to include(snipeit: { asset_ids: [42] })
+        end
+
+        context 'when snipeit assets are stored as strings (legacy app)' do
+          let(:ticket) { create(:ticket, preferences: { 'snipeit' => { 'asset_ids' => %w[42 26] } }) }
+
+          it 'removes the snipeit asset' do
+            gql.execute(mutation, variables: variables)
+
+            expect(ticket.reload.preferences).to include(snipeit: { asset_ids: [42] })
+          end
+        end
+      end
+
+      context 'when an agent has no access to the ticket' do
+        before { gql.execute(mutation, variables:) }
+
+        it_behaves_like 'graphql responds with error if unauthenticated'
+      end
+    end
+  end
+
+  context 'when unauthenticated' do
+    before { gql.execute(mutation, variables:) }
+
+    it_behaves_like 'graphql responds with error if unauthenticated'
+  end
+end

--- a/spec/graphql/gql/queries/autocomplete_search/snipeit_categories_spec.rb
+++ b/spec/graphql/gql/queries/autocomplete_search/snipeit_categories_spec.rb
@@ -1,0 +1,96 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Gql::Queries::AutocompleteSearch::SnipeitCategories, authenticated_as: :agent, type: :graphql do
+
+  let(:available_categories) { %w[Laptops Monitors Desktops Printers Phones] }
+  let(:categories_api_result) do
+    {
+      'rows' => available_categories.each_with_index.map { |category, index| { 'id' => index + 1, 'name' => category } }
+    }
+  end
+
+  context 'when searching for snipeit categories' do
+    let(:agent) { create(:agent) }
+    let(:query) do
+      <<~QUERY
+        query autocompleteSearchSnipeitCategories($input: AutocompleteSearchInput!)  {
+          autocompleteSearchSnipeitCategories(input: $input) {
+            value
+            label
+          }
+        }
+      QUERY
+    end
+    let(:variables)                  { { input: { query: query_string, limit: limit } } }
+    let(:query_string)               { '' }
+    let(:limit)                      { nil }
+    let(:snipeit_integration_active) { true }
+
+    before do
+      Setting.set('snipeit_integration', snipeit_integration_active)
+      allow(Snipeit).to receive(:query).and_return(categories_api_result)
+      gql.execute(query, variables: variables)
+    end
+
+    context 'when snipeit integration is disabled' do
+      let(:snipeit_integration_active) { false }
+
+      it 'raises an error' do
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
+    context 'without limit' do
+      it 'returns all categories the API sent' do
+        expect(gql.result.data.length).to eq(available_categories.length)
+      end
+
+      it 'asks the API for asset categories with the default limit' do
+        expect(Snipeit).to have_received(:query).with('categories', { 'limit' => 10, 'category_type' => 'asset' })
+      end
+    end
+
+    context 'with limit' do
+      let(:limit) { 1 }
+
+      it 'passes the limit on to the API' do
+        expect(Snipeit).to have_received(:query).with('categories', hash_including('limit' => limit))
+      end
+    end
+
+    context 'with search' do
+      let(:query_string) { 'Laptops' }
+
+      it 'lets the API filter instead of filtering the fetched page in Ruby' do
+        expect(Snipeit).to have_received(:query).with('categories', hash_including('search' => 'Laptops'))
+      end
+
+      it 'maps the API rows to autocomplete entries' do
+        expect(gql.result.data.first).to eq({ 'value' => '1', 'label' => 'Laptops' })
+      end
+    end
+
+    context 'with a wildcard search' do
+      let(:query_string) { '*' }
+
+      it 'sends no search term' do
+        expect(Snipeit).to have_received(:query).with('categories', { 'limit' => 10, 'category_type' => 'asset' })
+      end
+    end
+
+    context 'when the API fails' do
+      before do
+        allow(Snipeit).to receive(:query).and_raise('API down')
+        gql.execute(query, variables: variables)
+      end
+
+      it 'returns no entries instead of an error' do
+        expect(gql.result.data).to eq([])
+      end
+    end
+
+    it_behaves_like 'graphql responds with error if unauthenticated'
+  end
+end

--- a/spec/graphql/gql/queries/autocomplete_search/snipeit_models_spec.rb
+++ b/spec/graphql/gql/queries/autocomplete_search/snipeit_models_spec.rb
@@ -1,0 +1,96 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Gql::Queries::AutocompleteSearch::SnipeitModels, authenticated_as: :agent, type: :graphql do
+
+  let(:available_models) { ['MacBook Pro', 'ThinkPad', 'UltraSharp', 'DeskJet', 'iPhone'] }
+  let(:models_api_result) do
+    {
+      'rows' => available_models.each_with_index.map { |model, index| { 'id' => index + 1, 'name' => model } }
+    }
+  end
+
+  context 'when searching for snipeit models' do
+    let(:agent) { create(:agent) }
+    let(:query) do
+      <<~QUERY
+        query autocompleteSearchSnipeitModels($input: AutocompleteSearchInput!)  {
+          autocompleteSearchSnipeitModels(input: $input) {
+            value
+            label
+          }
+        }
+      QUERY
+    end
+    let(:variables)                  { { input: { query: query_string, limit: limit } } }
+    let(:query_string)               { '' }
+    let(:limit)                      { nil }
+    let(:snipeit_integration_active) { true }
+
+    before do
+      Setting.set('snipeit_integration', snipeit_integration_active)
+      allow(Snipeit).to receive(:query).and_return(models_api_result)
+      gql.execute(query, variables: variables)
+    end
+
+    context 'when snipeit integration is disabled' do
+      let(:snipeit_integration_active) { false }
+
+      it 'raises an error' do
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
+    context 'without limit' do
+      it 'returns all models the API sent' do
+        expect(gql.result.data.length).to eq(available_models.length)
+      end
+
+      it 'asks the API with the default limit' do
+        expect(Snipeit).to have_received(:query).with('models', { 'limit' => 10 })
+      end
+    end
+
+    context 'with limit' do
+      let(:limit) { 1 }
+
+      it 'passes the limit on to the API' do
+        expect(Snipeit).to have_received(:query).with('models', hash_including('limit' => limit))
+      end
+    end
+
+    context 'with search' do
+      let(:query_string) { 'ThinkPad' }
+
+      it 'lets the API filter instead of filtering the fetched page in Ruby' do
+        expect(Snipeit).to have_received(:query).with('models', hash_including('search' => 'ThinkPad'))
+      end
+
+      it 'maps the API rows to autocomplete entries' do
+        expect(gql.result.data.first).to eq({ 'value' => '1', 'label' => 'MacBook Pro' })
+      end
+    end
+
+    context 'with a wildcard search' do
+      let(:query_string) { '*' }
+
+      it 'sends no search term' do
+        expect(Snipeit).to have_received(:query).with('models', { 'limit' => 10 })
+      end
+    end
+
+    context 'when the API fails' do
+      before do
+        allow(Snipeit).to receive(:query).and_raise('API down')
+        gql.execute(query, variables: variables)
+      end
+
+      it 'returns no entries instead of an error' do
+        expect(gql.result.data).to eq([])
+      end
+    end
+
+    it_behaves_like 'graphql responds with error if unauthenticated'
+  end
+end

--- a/spec/graphql/gql/queries/autocomplete_search/snipeit_models_spec.rb
+++ b/spec/graphql/gql/queries/autocomplete_search/snipeit_models_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Gql::Queries::AutocompleteSearch::SnipeitModels, authenticated_as
     let(:agent) { create(:agent) }
     let(:query) do
       <<~QUERY
-        query autocompleteSearchSnipeitModels($input: AutocompleteSearchInput!)  {
+        query autocompleteSearchSnipeitModels($input: AutocompleteSearchSnipeitModelsInput!)  {
           autocompleteSearchSnipeitModels(input: $input) {
             value
             label
@@ -77,6 +77,14 @@ RSpec.describe Gql::Queries::AutocompleteSearch::SnipeitModels, authenticated_as
 
       it 'sends no search term' do
         expect(Snipeit).to have_received(:query).with('models', { 'limit' => 10 })
+      end
+    end
+
+    context 'with a selected category' do
+      let(:variables) { { input: { query: query_string, limit: limit, categoryId: '3' } } }
+
+      it 'restricts the models to that category' do
+        expect(Snipeit).to have_received(:query).with('models', hash_including('category_id' => '3'))
       end
     end
 

--- a/spec/graphql/gql/queries/ticket/external_references/snipeit_asset_list_spec.rb
+++ b/spec/graphql/gql/queries/ticket/external_references/snipeit_asset_list_spec.rb
@@ -1,0 +1,111 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Gql::Queries::Ticket::ExternalReferences::SnipeitAssetList, type: :graphql do
+  let(:variables) { { ticketId: gql.id(ticket) } }
+  let(:ticket)    { create(:ticket, preferences: { snipeit: { asset_ids: [26] } }) }
+
+  let(:query) do
+    <<~QUERY
+      query ticketExternalReferencesSnipeitAssetList(
+        $ticketId: ID
+        $snipeitAssetIds: [Int!]
+      ) {
+        ticketExternalReferencesSnipeitAssetList(
+          input: {
+            ticketId: $ticketId
+            snipeitAssetIds: $snipeitAssetIds
+          }
+        ) {
+          snipeitAssetId
+          name
+          link
+          model
+          status
+          category
+          location
+          assetTag
+          serial
+        }
+      }
+    QUERY
+  end
+
+  let(:snipeit_api_asset) do
+    {
+      'id'           => 26,
+      'name'         => 'Laptop-001',
+      'asset_tag'    => 'LAP001',
+      'serial'       => 'ABC123',
+      'link'         => 'http://snipeit.example/hardware/26',
+      'model'        => { 'name' => 'MacBook Pro' },
+      'status_label' => { 'name' => 'Ready to Deploy' },
+      'category'     => { 'name' => 'Laptops' },
+      'location'     => { 'name' => 'HQ' },
+    }
+  end
+  let(:snipeit_asset) do
+    {
+      'snipeitAssetId' => 26,
+      'name'           => 'Laptop-001',
+      'assetTag'       => 'LAP001',
+      'serial'         => 'ABC123',
+      'link'           => 'http://snipeit.example/hardware/26',
+      'model'          => 'MacBook Pro',
+      'status'         => 'Ready to Deploy',
+      'category'       => 'Laptops',
+      'location'       => 'HQ',
+    }
+  end
+  let(:snipeit_integration_active) { true }
+
+  context 'with an agent', authenticated_as: :agent do
+    let(:agent) { create(:agent, groups: [ticket.group]) }
+
+    before do
+      Setting.set('snipeit_integration', snipeit_integration_active)
+      allow(Snipeit).to receive(:query).with('hardware/26').and_return(snipeit_api_asset)
+      gql.execute(query, variables: variables)
+    end
+
+    context 'when snipeit integration is inactive' do
+      let(:snipeit_integration_active) { false }
+
+      it 'raises an error' do
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
+    context 'when ticket is used' do
+      it 'returns snipeit assets', aggregate_failures: true do
+        expect(gql.result.data).to eq([snipeit_asset])
+      end
+    end
+
+    context 'when snipeit asset ids are used' do
+      let(:variables) { { snipeitAssetIds: [26] } }
+
+      it 'returns snipeit assets', aggregate_failures: true do
+        expect(gql.result.data).to eq([snipeit_asset])
+      end
+    end
+
+    context 'when no input is provided' do
+      let(:variables) { {} }
+
+      it 'returns a validation error', aggregate_failures: true do
+        expect(gql.result.error_type).to eq(GraphQL::Schema::Validator::ValidationFailedError)
+      end
+    end
+  end
+
+  context 'when unauthenticated' do
+    before do
+      Setting.set('snipeit_integration', true)
+      gql.execute(query, variables: variables)
+    end
+
+    it_behaves_like 'graphql responds with error if unauthenticated'
+  end
+end

--- a/spec/graphql/gql/queries/ticket/external_references/snipeit_asset_search_spec.rb
+++ b/spec/graphql/gql/queries/ticket/external_references/snipeit_asset_search_spec.rb
@@ -1,0 +1,138 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Gql::Queries::Ticket::ExternalReferences::SnipeitAssetSearch, type: :graphql do
+  let(:category_id)  { '3' }
+  let(:search_query) { '' }
+  let(:limit)        { 3 }
+  let(:variables)    { { categoryId: category_id, query: search_query, limit: } }
+
+  let(:query) do
+    <<~QUERY
+      query ticketExternalReferencesSnipeitAssetSearch(
+        $categoryId: String
+        $modelId: String
+        $query: String
+        $limit: Int
+      ) {
+        ticketExternalReferencesSnipeitAssetSearch(
+          categoryId: $categoryId
+          modelId: $modelId
+          query: $query
+          limit: $limit
+        ) {
+          snipeitAssetId
+          name
+          link
+          model
+          status
+          category
+          location
+          assetTag
+          serial
+        }
+      }
+    QUERY
+  end
+
+  let(:snipeit_api_asset) do
+    {
+      'id'           => 26,
+      'name'         => 'Laptop-001',
+      'asset_tag'    => 'LAP001',
+      'serial'       => 'ABC123',
+      'link'         => 'http://snipeit.example/hardware/26',
+      'model'        => { 'name' => 'MacBook Pro' },
+      'status_label' => { 'name' => 'Ready to Deploy' },
+      'category'     => { 'name' => 'Laptops' },
+      'location'     => { 'name' => 'HQ' },
+    }
+  end
+  let(:snipeit_asset) do
+    {
+      'snipeitAssetId' => 26,
+      'name'           => 'Laptop-001',
+      'assetTag'       => 'LAP001',
+      'serial'         => 'ABC123',
+      'link'           => 'http://snipeit.example/hardware/26',
+      'model'          => 'MacBook Pro',
+      'status'         => 'Ready to Deploy',
+      'category'       => 'Laptops',
+      'location'       => 'HQ',
+    }
+  end
+  let(:snipeit_integration_active) { true }
+
+  context 'with an agent', authenticated_as: :agent do
+    let(:agent) { create(:agent) }
+
+    before do
+      setup if defined? setup
+      Setting.set('snipeit_integration', snipeit_integration_active)
+      gql.execute(query, variables: variables)
+    end
+
+    context 'when snipeit integration is inactive' do
+      let(:snipeit_integration_active) { false }
+
+      it 'raises an error' do
+        expect(gql.result.error_type).to eq(Exceptions::Forbidden)
+      end
+    end
+
+    context 'without category and search query' do
+      let(:variables) { {} }
+      let(:setup) do
+        allow(Snipeit).to receive(:query).with('hardware', { 'limit' => 10 }).and_return({ 'rows' => [snipeit_api_asset] })
+      end
+
+      it 'returns snipeit assets', aggregate_failures: true do
+        expect(gql.result.data).to eq([snipeit_asset])
+      end
+    end
+
+    context 'without search query' do
+      let(:setup) do
+        allow(Snipeit).to receive(:query).with('hardware', { 'limit' => 3, 'category_id' => '3' }).and_return({ 'rows' => [snipeit_api_asset] })
+      end
+
+      it 'returns snipeit assets', aggregate_failures: true do
+        expect(gql.result.data).to eq([snipeit_asset])
+      end
+    end
+
+    context 'with matching search query' do
+      let(:search_query) { 'Laptop' }
+
+      let(:setup) do
+        allow(Snipeit).to receive(:query).with('hardware', { 'limit' => 3, 'category_id' => '3', 'search' => 'Laptop' }).and_return({ 'rows' => [snipeit_api_asset] })
+      end
+
+      it 'returns snipeit assets', aggregate_failures: true do
+        expect(gql.result.data).to eq([snipeit_asset])
+      end
+    end
+
+    context 'with nonmatching search query' do
+      let(:search_query) { 'nonexisting' }
+
+      let(:setup) do
+        allow(Snipeit).to receive(:query).with('hardware', { 'limit' => 3, 'category_id' => '3', 'search' => 'nonexisting' }).and_return({ 'rows' => [] })
+      end
+
+      it 'returns no assets', aggregate_failures: true do
+        expect(gql.result.data).to eq([])
+      end
+    end
+  end
+
+  context 'when unauthenticated' do
+    before do
+      Setting.set('snipeit_integration', true)
+      gql.execute(query, variables: variables)
+    end
+
+    it_behaves_like 'graphql responds with error if unauthenticated'
+  end
+end

--- a/spec/graphql/gql/queries/ticket/external_references/snipeit_asset_search_spec.rb
+++ b/spec/graphql/gql/queries/ticket/external_references/snipeit_asset_search_spec.rb
@@ -15,12 +15,14 @@ RSpec.describe Gql::Queries::Ticket::ExternalReferences::SnipeitAssetSearch, typ
         $modelId: String
         $query: String
         $limit: Int
+        $customerId: ID
       ) {
         ticketExternalReferencesSnipeitAssetSearch(
           categoryId: $categoryId
           modelId: $modelId
           query: $query
           limit: $limit
+          customerId: $customerId
         ) {
           snipeitAssetId
           name
@@ -63,6 +65,8 @@ RSpec.describe Gql::Queries::Ticket::ExternalReferences::SnipeitAssetSearch, typ
     }
   end
   let(:snipeit_integration_active) { true }
+  let(:customer)                   { create(:customer) }
+  let(:customer_variables)         { { customerId: Gql::ZammadSchema.id_from_object(customer), limit: } }
 
   context 'with an agent', authenticated_as: :agent do
     let(:agent) { create(:agent) }
@@ -123,6 +127,46 @@ RSpec.describe Gql::Queries::Ticket::ExternalReferences::SnipeitAssetSearch, typ
 
       it 'returns no assets', aggregate_failures: true do
         expect(gql.result.data).to eq([])
+      end
+    end
+
+    context 'with a customer and no filter' do
+      let(:variables) { customer_variables }
+
+      let(:setup) do
+        allow(Snipeit).to receive(:assets_assigned_to_email)
+          .with(customer.email, limit: 3).and_return([snipeit_api_asset])
+      end
+
+      it 'suggests the assets assigned to the customer' do
+        expect(gql.result.data).to eq([snipeit_asset])
+      end
+    end
+
+    context 'with a customer who is unknown to Snipe-IT' do
+      let(:variables) { customer_variables }
+
+      let(:setup) do
+        allow(Snipeit).to receive(:assets_assigned_to_email).and_return(nil)
+        allow(Snipeit).to receive(:query).with('hardware', { 'limit' => 3 }).and_return({ 'rows' => [snipeit_api_asset] })
+      end
+
+      it 'falls back to the regular search' do
+        expect(gql.result.data).to eq([snipeit_asset])
+      end
+    end
+
+    context 'with a customer and an active search query' do
+      let(:variables) { customer_variables.merge(query: 'Laptop') }
+
+      let(:setup) do
+        allow(Snipeit).to receive(:assets_assigned_to_email)
+        allow(Snipeit).to receive(:query).with('hardware', { 'limit' => 3, 'search' => 'Laptop' }).and_return({ 'rows' => [snipeit_api_asset] })
+      end
+
+      it 'searches instead of suggesting', aggregate_failures: true do
+        expect(gql.result.data).to eq([snipeit_asset])
+        expect(Snipeit).not_to have_received(:assets_assigned_to_email)
       end
     end
   end

--- a/spec/lib/snipeit_spec.rb
+++ b/spec/lib/snipeit_spec.rb
@@ -1,0 +1,68 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Snipeit do
+  let(:token)    { 'some_token' }
+  let(:endpoint) { 'https://snipeit.example.com/' }
+
+  let(:hardware_response) do
+    {
+      id:           26,
+      name:         'Laptop-001',
+      asset_tag:    'LAP001',
+      model:        { id: 1, name: 'MacBook Pro' },
+      status_label: { id: 2, name: 'Ready to Deploy' },
+    }.to_json
+  end
+
+  before do
+    Setting.set('snipeit_integration', true)
+    Setting.set('snipeit_config', { api_token: token, endpoint: endpoint, verify_ssl: false })
+  end
+
+  describe '.asset' do
+    let!(:request_stub) do
+      stub_request(:get, "#{endpoint}api/v1/hardware/26")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_response, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'returns the raw asset with its nested attributes intact', aggregate_failures: true do
+      asset = described_class.asset(26)
+
+      expect(asset['id']).to eq(26)
+      expect(asset.dig('model', 'name')).to eq('MacBook Pro')
+    end
+
+    it 'coerces the given id' do
+      described_class.asset('26')
+
+      expect(request_stub).to have_been_requested
+    end
+
+    # Snipe-IT has no bulk lookup by id, so the same ids get fetched over and over while a
+    # ticket sidebar is open. Only the first lookup may hit the API.
+    it 'issues a single request for repeated lookups of the same asset' do
+      3.times { described_class.asset(26) }
+
+      expect(request_stub).to have_been_requested.once
+    end
+
+    context 'when the asset does not exist' do
+      let(:hardware_response) { { status: 'error', messages: 'Asset not found' }.to_json }
+
+      it 'returns nil' do
+        expect(described_class.asset(26)).to be_nil
+      end
+
+      # Otherwise an asset which was just created in Snipe-IT would keep reporting
+      # 'not found' until the cache entry expires.
+      it 'does not cache the miss' do
+        2.times { described_class.asset(26) }
+
+        expect(request_stub).to have_been_requested.twice
+      end
+    end
+  end
+end

--- a/spec/lib/snipeit_spec.rb
+++ b/spec/lib/snipeit_spec.rb
@@ -65,4 +65,43 @@ RSpec.describe Snipeit do
       end
     end
   end
+
+  describe '.asset_label' do
+    before do
+      stub_request(:get, "#{endpoint}api/v1/hardware/26")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_response, headers: { 'Content-Type' => 'application/json' })
+    end
+
+    it 'prefers the asset tag' do
+      expect(described_class.asset_label(26)).to eq('LAP001')
+    end
+
+    context 'without an asset tag' do
+      let(:hardware_response) { { id: 26, name: 'Laptop-001' }.to_json }
+
+      it 'falls back to the name' do
+        expect(described_class.asset_label(26)).to eq('Laptop-001')
+      end
+    end
+
+    context 'when the asset cannot be fetched' do
+      before do
+        stub_request(:get, "#{endpoint}api/v1/hardware/26").to_return(status: 500)
+      end
+
+      # A broken Snipe-IT connection must not stop the ticket from being saved.
+      it 'falls back to the bare id' do
+        expect(described_class.asset_label(26)).to eq('26')
+      end
+    end
+
+    context 'when the asset does not exist' do
+      let(:hardware_response) { { status: 'error', messages: 'Asset not found' }.to_json }
+
+      it 'falls back to the bare id' do
+        expect(described_class.asset_label(26)).to eq('26')
+      end
+    end
+  end
 end

--- a/spec/models/system_report_spec.rb
+++ b/spec/models/system_report_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe SystemReport, current_user_id: 1, type: :model do
           'exchange_oauth',
           'exchange_integration',
           'idoit_integration',
+          'snipeit_integration',
           'gitlab_integration',
           'github_integration',
           '0100_trigger',

--- a/spec/requests/integration/snipeit_spec.rb
+++ b/spec/requests/integration/snipeit_spec.rb
@@ -1,0 +1,290 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe 'Snipeit', type: :request do
+  let!(:admin) do
+    create(:admin, groups: Group.all)
+  end
+  let!(:agent) do
+    create(:agent, groups: Group.all)
+  end
+  let!(:token) do
+    'some_token'
+  end
+  let!(:endpoint) do
+    'https://snipeit.example.com/'
+  end
+
+  let(:hardware_list_response) do
+    {
+      total: 1,
+      rows:  [
+        {
+          id:           1,
+          name:         'Laptop-001',
+          asset_tag:    'LAP001',
+          serial:       'ABC123',
+          model:        { id: 1, name: 'MacBook Pro' },
+          status_label: { id: 2, name: 'Ready to Deploy' },
+          category:     { id: 1, name: 'Laptops' },
+          location:     { id: 1, name: 'HQ' },
+        }
+      ]
+    }.to_json
+  end
+
+  let(:hardware_response) do
+    {
+      id:           1,
+      name:         'Laptop-001',
+      asset_tag:    'LAP001',
+      serial:       'ABC123',
+      model:        { id: 1, name: 'MacBook Pro' },
+      status_label: { id: 2, name: 'Ready to Deploy' },
+      category:     { id: 1, name: 'Laptops' },
+      location:     { id: 1, name: 'HQ' },
+    }.to_json
+  end
+
+  let(:users_response) do
+    {
+      total: 1,
+      rows:  [
+        { id: 7, username: 'nicole', email: 'nicole.braun@zammad.org' }
+      ]
+    }.to_json
+  end
+
+  before do
+    Setting.set('snipeit_integration', true)
+    Setting.set('snipeit_config', {
+                  api_token:  token,
+                  endpoint:   endpoint,
+                  verify_ssl: false,
+                })
+  end
+
+  describe 'request handling' do
+
+    it 'forbids verify for agents', aggregate_failures: true do
+      params = {
+        api_token: token,
+        endpoint:  endpoint,
+      }
+      authenticated_as(agent)
+      post '/api/v1/integration/snipeit/verify', params: params, as: :json
+      expect(response).to have_http_status(:forbidden)
+      expect(json_response['error']).to eq('User authorization failed.')
+    end
+
+    it 'verifies configuration for admins with a masked token', aggregate_failures: true do
+      stub_request(:get, "#{endpoint}api/v1/hardware")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+      params = {
+        api_token: SensitiveParamsHelper::SENSITIVE_MASK,
+        endpoint:  endpoint,
+      }
+      authenticated_as(admin)
+      post '/api/v1/integration/snipeit/verify', params: params, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']).to eq('ok')
+      expect(json_response['response']['rows'][0]['id']).to eq(1)
+    end
+
+    it 'verifies configuration for admins', aggregate_failures: true do
+      stub_request(:get, "#{endpoint}api/v1/hardware")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+      params = {
+        api_token: token,
+        endpoint:  endpoint,
+      }
+      authenticated_as(admin)
+      post '/api/v1/integration/snipeit/verify', params: params, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']).to eq('ok')
+      expect(json_response['response']['rows'][0]['id']).to eq(1)
+      expect(json_response['response']['rows'][0]['link']).to eq("#{endpoint}hardware/1")
+    end
+
+    it 'cleans up endpoint urls on verify', aggregate_failures: true do
+      stub_request(:get, "#{endpoint}api/v1/hardware")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+      params = {
+        api_token: token,
+        endpoint:  " #{endpoint}/",
+      }
+      authenticated_as(admin)
+      post '/api/v1/integration/snipeit/verify', params: params, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']).to eq('ok')
+    end
+
+    it 'queries hardware for agents', aggregate_failures: true do
+      stub_request(:get, "#{endpoint}api/v1/hardware?search=laptop")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+      params = {
+        method: 'hardware',
+        search: 'laptop',
+      }
+      authenticated_as(agent)
+      post '/api/v1/integration/snipeit', params: params, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']['rows'][0]['name']).to eq('Laptop-001')
+      expect(json_response['result']['rows'][0]['link']).to eq("#{endpoint}hardware/1")
+    end
+
+    it 'defaults method to hardware when searching', aggregate_failures: true do
+      stub_request(:get, "#{endpoint}api/v1/hardware?search=laptop")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+      params = {
+        search: 'laptop',
+      }
+      authenticated_as(agent)
+      post '/api/v1/integration/snipeit', params: params, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']['rows'][0]['id']).to eq(1)
+    end
+
+    it 'fetches linked assets by id and keeps the raw nested attributes', aggregate_failures: true do
+      stub_request(:get, "#{endpoint}api/v1/hardware/1")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_response, headers: { 'Content-Type' => 'application/json' })
+
+      authenticated_as(agent)
+      post '/api/v1/integration/snipeit', params: { ids: [1] }, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']['rows'][0]['id']).to eq(1)
+
+      # The legacy sidebar template renders these nested keys directly, so they must not be
+      # flattened away on the way out.
+      expect(json_response['result']['rows'][0]['model']['name']).to eq('MacBook Pro')
+      expect(json_response['result']['rows'][0]['status_label']['name']).to eq('Ready to Deploy')
+    end
+
+    it 'suggests assets assigned to the customer using an exact email lookup', aggregate_failures: true do
+      users_stub = stub_request(:get, "#{endpoint}api/v1/users?email=nicole.braun%40zammad.org")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: users_response, headers: { 'Content-Type' => 'application/json' })
+
+      stub_request(:get, "#{endpoint}api/v1/hardware?assigned_to=7&assigned_type=App%5CModels%5CUser")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+      authenticated_as(agent)
+      post '/api/v1/integration/snipeit', params: { search: 'nicole.braun@zammad.org' }, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']['rows'][0]['id']).to eq(1)
+      expect(users_stub).to have_been_requested
+    end
+
+    it 'falls back to a regular search when the customer is unknown to Snipe-IT', aggregate_failures: true do
+      stub_request(:get, "#{endpoint}api/v1/users?email=unknown%40zammad.org")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: { total: 0, rows: [] }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+      stub_request(:get, "#{endpoint}api/v1/hardware?search=unknown%40zammad.org")
+        .with(headers: { 'Authorization' => "Bearer #{token}" })
+        .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+      authenticated_as(agent)
+      post '/api/v1/integration/snipeit', params: { search: 'unknown@zammad.org' }, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(json_response['result']['rows'][0]['id']).to eq(1)
+    end
+
+    context 'when the integration is disabled' do
+      before do
+        Setting.set('snipeit_integration', false)
+      end
+
+      it 'refuses to query', aggregate_failures: true do
+        authenticated_as(agent)
+        post '/api/v1/integration/snipeit', params: { search: 'laptop' }, as: :json
+        expect(response).to have_http_status(:forbidden)
+        expect(json_response['error']).to eq('Snipe-IT integration is not enabled')
+      end
+
+      it 'refuses to update linked assets' do
+        ticket = create(:ticket, group: Group.first)
+
+        authenticated_as(agent)
+        post '/api/v1/integration/snipeit_ticket_update', params: { ticket_id: ticket.id, asset_ids: [1] }, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      # Admins have to be able to test a configuration before switching the integration on.
+      it 'still allows admins to verify the configuration', aggregate_failures: true do
+        stub_request(:get, "#{endpoint}api/v1/hardware")
+          .with(headers: { 'Authorization' => "Bearer #{token}" })
+          .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+        authenticated_as(admin)
+        post '/api/v1/integration/snipeit/verify', params: { api_token: token, endpoint: endpoint }, as: :json
+        expect(response).to have_http_status(:ok)
+        expect(json_response['result']).to eq('ok')
+      end
+    end
+
+    it 'updates linked assets for agents with change access', aggregate_failures: true do
+      ticket = create(:ticket, group: Group.first)
+
+      authenticated_as(agent)
+      post '/api/v1/integration/snipeit_ticket_update', params: { ticket_id: ticket.id, asset_ids: [1, '1', 2] }, as: :json
+      expect(response).to have_http_status(:ok)
+      expect(ticket.reload.preferences).to include(snipeit: { asset_ids: [1, 2] })
+    end
+
+    it 'forbids updating linked assets for agents with read-only access', aggregate_failures: true do
+      group = create(:group)
+      ticket = create(:ticket, group: group)
+      read_only_agent = create(:agent)
+      read_only_agent.user_groups.create!(group: group, access: 'read')
+
+      authenticated_as(read_only_agent)
+      post '/api/v1/integration/snipeit_ticket_update', params: { ticket_id: ticket.id, asset_ids: [1] }, as: :json
+      expect(response).to have_http_status(:forbidden)
+      expect(ticket.reload.preferences[:snipeit]).to be_blank
+    end
+  end
+
+  describe 'SSL verification' do
+    describe '.verify' do
+      def request(verify: false)
+        stub_request(:get, "#{endpoint}api/v1/hardware")
+          .to_return(status: 200, body: hardware_list_response, headers: { 'Content-Type' => 'application/json' })
+
+        params = {
+          api_token:  token,
+          endpoint:   endpoint,
+          verify_ssl: verify
+        }
+        authenticated_as(admin)
+        post '/api/v1/integration/snipeit/verify', params: params, as: :json
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does verify SSL' do
+        allow(UserAgent).to receive(:get_http)
+        request(verify: true)
+        expect(UserAgent).to have_received(:get_http).with(URI::HTTPS, hash_including(verify_ssl: true)).once
+      end
+
+      it 'does not verify SSL' do
+        allow(UserAgent).to receive(:get_http)
+        request
+        expect(UserAgent).to have_received(:get_http).with(URI::HTTPS, hash_including(verify_ssl: false)).once
+      end
+    end
+  end
+end

--- a/spec/services/service/ticket/create_spec.rb
+++ b/spec/services/service/ticket/create_spec.rb
@@ -297,10 +297,52 @@ RSpec.describe Service::Ticket::Create, current_user_id: -> { user.id } do
       context 'when snipeit is enabled' do
         before do
           Setting.set('snipeit_integration', true)
+          allow(Snipeit).to receive(:asset_label).with(26).and_return('LAP001')
         end
 
         it 'adds snipeit asset ids' do
           expect(service_result.preferences).to eq({ 'snipeit' => { 'asset_ids' => [26] } })
+        end
+
+        # Assets picked while creating the ticket are part of the ticket itself, so there is
+        # no diff for LinkAssets to work from. Without an explicit entry here, unlinking such
+        # an asset later would leave a 'removed' with no matching 'added'.
+        it 'records the initial links in the ticket history', aggregate_failures: true do
+          entries = service_result.history_get.select { |entry| entry['attribute'] == 'snipeit' }
+
+          expect(entries.length).to eq(1)
+          expect(entries.first).to include('type' => 'added', 'value_to' => 'LAP001')
+        end
+      end
+
+      context 'when snipeit assets arrive as raw preferences' do
+        before do
+          Setting.set('snipeit_integration', true)
+          allow(Snipeit).to receive(:asset_label).with(99).and_return('MON002')
+          ticket_data[:external_references] = {}
+          ticket_data[:preferences] = { snipeit: { asset_ids: [99] } }
+        end
+
+        # The legacy sidebar appends the ids to the create request instead of going through
+        # the externalReferences input, so the history has to be derived from the ticket.
+        it 'records the initial links in the ticket history' do
+          entries = service_result.history_get.select { |entry| entry['attribute'] == 'snipeit' }
+
+          expect(entries.first).to include('type' => 'added', 'value_to' => 'MON002')
+        end
+      end
+
+      context 'when snipeit is disabled but assets are passed as raw preferences' do
+        before do
+          ticket_data[:external_references] = {}
+          ticket_data[:preferences] = { snipeit: { asset_ids: [99] } }
+        end
+
+        it 'does not talk to Snipe-IT', aggregate_failures: true do
+          allow(Snipeit).to receive(:asset_label)
+
+          expect(service_result.history_get.select { |entry| entry['attribute'] == 'snipeit' }).to be_empty
+          expect(Snipeit).not_to have_received(:asset_label)
         end
       end
 

--- a/spec/services/service/ticket/create_spec.rb
+++ b/spec/services/service/ticket/create_spec.rb
@@ -251,9 +251,10 @@ RSpec.describe Service::Ticket::Create, current_user_id: -> { user.id } do
 
       before do
         ticket_data[:external_references] = {
-          gitlab: [gitlab_link],
-          github: [github_link],
-          idoit:  [42],
+          gitlab:  [gitlab_link],
+          github:  [github_link],
+          idoit:   [42],
+          snipeit: [26],
         }
       end
 
@@ -290,6 +291,27 @@ RSpec.describe Service::Ticket::Create, current_user_id: -> { user.id } do
 
         it 'adds github links' do
           expect(service_result.preferences).to eq({ 'idoit' => { 'object_ids' => [42] } })
+        end
+      end
+
+      context 'when snipeit is enabled' do
+        before do
+          Setting.set('snipeit_integration', true)
+        end
+
+        it 'adds snipeit asset ids' do
+          expect(service_result.preferences).to eq({ 'snipeit' => { 'asset_ids' => [26] } })
+        end
+      end
+
+      context 'when idoit and snipeit are enabled' do
+        before do
+          Setting.set('idoit_integration', true)
+          Setting.set('snipeit_integration', true)
+        end
+
+        it 'adds both external references' do
+          expect(service_result.preferences).to eq({ 'idoit' => { 'object_ids' => [42] }, 'snipeit' => { 'asset_ids' => [26] } })
         end
       end
     end

--- a/spec/services/service/ticket/external_references/snipeit/link_assets_spec.rb
+++ b/spec/services/service/ticket/external_references/snipeit/link_assets_spec.rb
@@ -1,0 +1,96 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Service::Ticket::ExternalReferences::Snipeit::LinkAssets do
+  subject(:service) { described_class.with_current_user(agent) }
+
+  let(:agent)  { create(:agent, groups: [ticket.group]) }
+  let(:ticket) { create(:ticket) }
+
+  let(:asset_26) { { 'id' => 26, 'name' => 'Laptop-001', 'asset_tag' => 'LAP001' } }
+  let(:asset_27) { { 'id' => 27, 'name' => 'Monitor-002', 'asset_tag' => 'MON002' } }
+
+  before do
+    Setting.set('snipeit_integration', true)
+    allow(Snipeit).to receive(:asset).with(26).and_return(asset_26)
+    allow(Snipeit).to receive(:asset).with(27).and_return(asset_27)
+  end
+
+  def snipeit_history
+    ticket.reload.history_get.select { |entry| entry['attribute'] == 'snipeit' }
+  end
+
+  it 'stores the asset ids on the ticket' do
+    service.execute(ticket: ticket, asset_ids: [26, 27])
+
+    expect(ticket.reload.preferences[:snipeit][:asset_ids]).to eq([26, 27])
+  end
+
+  it 'normalizes and deduplicates the given ids' do
+    service.execute(ticket: ticket, asset_ids: [26, '26', 27])
+
+    expect(ticket.reload.preferences[:snipeit][:asset_ids]).to eq([26, 27])
+  end
+
+  it 'records an added history entry per newly linked asset', aggregate_failures: true do
+    service.execute(ticket: ticket, asset_ids: [26])
+
+    expect(snipeit_history.length).to eq(1)
+    expect(snipeit_history.first).to include('type' => 'added', 'value_to' => 'LAP001')
+  end
+
+  it 'attributes the history entry to the acting user' do
+    service.execute(ticket: ticket, asset_ids: [26])
+
+    expect(snipeit_history.first['created_by_id']).to eq(agent.id)
+  end
+
+  context 'when assets are already linked' do
+    before do
+      service.execute(ticket: ticket, asset_ids: [26, 27])
+    end
+
+    it 'records only the removal when an asset is unlinked', aggregate_failures: true do
+      service.execute(ticket: ticket.reload, asset_ids: [26])
+
+      removals = snipeit_history.select { |entry| entry['type'] == 'removed' }
+      expect(removals.length).to eq(1)
+      expect(removals.first['value_to']).to eq('MON002')
+    end
+
+    it 'records nothing when the asset ids are unchanged' do
+      entries_before = snipeit_history.length
+
+      service.execute(ticket: ticket.reload, asset_ids: [26, 27])
+
+      expect(snipeit_history.length).to eq(entries_before)
+    end
+
+    it 'records both sides when an asset is swapped', aggregate_failures: true do
+      service.execute(ticket: ticket.reload, asset_ids: [27])
+
+      expect(snipeit_history.pluck('type')).to include('added', 'removed')
+      expect(ticket.reload.preferences[:snipeit][:asset_ids]).to eq([27])
+    end
+  end
+
+  context 'when the asset can no longer be fetched from Snipe-IT' do
+    before do
+      allow(Snipeit).to receive(:asset).with(26).and_raise('API down')
+    end
+
+    # A broken Snipe-IT connection must not stop the ticket from being saved.
+    it 'falls back to the bare id and still stores the link', aggregate_failures: true do
+      service.execute(ticket: ticket, asset_ids: [26])
+
+      expect(ticket.reload.preferences[:snipeit][:asset_ids]).to eq([26])
+      expect(snipeit_history.first['value_to']).to eq('26')
+    end
+  end
+
+  it 'requires a current user' do
+    expect { described_class.execute(ticket: ticket, asset_ids: [26]) }
+      .to raise_error(%r{Current user is required})
+  end
+end

--- a/spec/system/ticket/snipeit_spec.rb
+++ b/spec/system/ticket/snipeit_spec.rb
@@ -1,0 +1,89 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe 'Ticket Handling with Snipe-IT', integration: true, required_envs: %w[SNIPEIT_API_TOKEN SNIPEIT_API_ENDPOINT SNIPEIT_API_SEARCH], type: :system do
+
+  let(:api_endpoint) { ENV['SNIPEIT_API_ENDPOINT'] }
+  let(:api_search)   { ENV['SNIPEIT_API_SEARCH'] }
+
+  before do
+    Setting.set('snipeit_integration', true)
+    Setting.set('snipeit_config', { api_token: ENV['SNIPEIT_API_TOKEN'], endpoint: api_endpoint, verify_ssl: false })
+
+    # Wait up to 2 minutes for the Snipe-IT container to become fully responsive.
+    # The container may need extra time to initialize its database on first run.
+    wait(120).until do
+      Snipeit.verify(ENV['SNIPEIT_API_TOKEN'], api_endpoint)
+      true
+    rescue
+      false
+    end
+  end
+
+  def open_snipeit_sidebar
+    find('.tabsSidebar svg.icon-printer').click
+  end
+
+  def select_asset_in_sidebar
+    find('.sidebar[data-tab="snipeit"] .js-headline').click
+    find('.sidebar[data-tab="snipeit"] .dropdown-menu').click
+    asset_id = nil
+
+    in_modal do
+      find('form.js-search input.js-searchField').fill_in with: api_search
+      asset_id = find('form.js-result tbody tr:first-child input[name=asset_id]').tap(&:click).value
+      # submit the Snipe-IT asset selections
+      find('button.js-submit').click
+    end
+
+    asset_id
+  end
+
+  context 'when using the Snipe-IT integration' do
+    let(:agent) { create(:agent, groups: [Group.find_by(name: 'Users')]) }
+
+    before do
+      visit 'ticket/create'
+      find('[name=customer_id_completion]').fill_in with: 'nico'
+      page.find('li.recipientList-entry.js-object.is-active').click
+      fill_in 'Title', with: 'subject - Snipe-IT integration'
+      set_editor_field_value('body', 'body - Snipe-IT integration')
+    end
+
+    it 'does process Snipe-IT information correctly', authenticated_as: :agent do
+
+      within :active_content do
+        # Select an asset initially.
+        open_snipeit_sidebar
+        asset_id = select_asset_in_sidebar
+        item_link = ".sidebar[data-tab='snipeit'] a[href='#{api_endpoint}/hardware/#{asset_id}']"
+        expect(page).to have_css(item_link)
+
+        # Reselect the customer and verify the asset is still shown in the sidebar.
+        find('[name=customer_id_completion]').fill_in with: 'admin'
+        page.find('li.recipientList-entry.js-object.is-active').click
+        expect(page).to have_css(item_link)
+
+        # Submit the ticket.
+        find('.newTicket button.js-submit').click
+        open_snipeit_sidebar
+        expect(page).to have_css(item_link)
+
+        # Check it's still there after reload.
+        page.refresh
+        open_snipeit_sidebar
+        expect(page).to have_css(item_link)
+
+        # Delete the asset.
+        find(".sidebar[data-tab='snipeit'] .js-delete[data-asset-id=\"#{asset_id}\"]").click
+        expect(find(".sidebar[data-tab='snipeit']")).to have_text('none')
+
+        # Check if the asset is still gone after reload.
+        page.refresh
+        open_snipeit_sidebar
+        expect(find(".sidebar[data-tab='snipeit']")).to have_text('none')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a Snipe-IT integration, modelled closely on the existing i-doit integration.

I am opening this as a basis for discussion rather than a finished proposal — see
[Open questions](#open-questions) at the end. If the answer is "not in core", that is a
useful outcome too, and I would rather hear it now than after review rounds.

## Why

There is no GitHub issue for this because feature requests belong on the community board, and
one has been there since February 2023: [Integrate Zammad into SnipeIT][forum]. Eight posts,
several people asking for it, one community member building a Python middleware bridge as a
workaround. No maintainer has weighed in either way.

Snipe-IT is one of the more widely used open-source asset management systems. Without an
integration, agents keep a second browser tab open and paste asset tags into tickets as free
text, where the information is neither linked nor searchable and goes stale as soon as the
asset is reassigned.

[forum]: https://community.zammad.org/t/integrate-zammad-into-snipeit/10986

## What it does

- **Admin**: a `Snipe-IT` entry under System → Integrations (endpoint, API token, SSL
  verification), backed by the `snipeit_integration` / `snipeit_config` settings, with HTTP
  logging under a `snipeit` facility.
- **API client**: `lib/snipeit.rb`, wrapping the Snipe-IT REST API v1 through `UserAgent`.
- **Legacy frontend**: ticket create and zoom sidebar with asset search, link and unlink.
- **GraphQL**: asset search and list queries, category and model autocompletes, add and
  remove mutations, and a `snipeit` field on `TicketExternalReferences`.
- **Desktop view**: `TicketSidebarSnipeit` under `TicketSidebarExternalReferences`, on the
  ticket create and detail screens for agents.
- Assets assigned to the ticket customer in Snipe-IT are suggested while no filter is set, so
  the common case needs no searching.
- Linking and unlinking is recorded in the ticket history.

Linked assets are stored on `ticket.preferences.snipeit.asset_ids`, mirroring how i-doit
stores its object ids. The ticket create path accepts them through `externalReferences.snipeit`.

## Commits

Four, each self-contained and individually revertable:

1. `Feature: Add Snipe-IT integration for linking assets to tickets.` — the integration
2. `Maintenance: Record Snipe-IT asset links in the ticket history.` — audit trail
3. `Feature: Scope the Snipe-IT model filter to the selected category.`
4. `Feature: Suggest the ticket customer's Snipe-IT assets in the desktop flyout.`

## Size

The diff is large, but most of it is not hand-written product code:

| | lines |
|---|---|
| Vue desktop | 1,823 |
| Tests | 1,388 |
| Backend (Ruby) | 915 |
| Generated GraphQL artifacts | 819 |
| Legacy CoffeeScript | 476 |

## Notes for reviewers

- Authorization follows the i-doit pattern: `requires_permission 'ticket.agent'` plus
  `requires_enabled_setting 'snipeit_integration'` on the GraphQL operations. The legacy
  `update` endpoint authorizes with `:update?` so read-only agents cannot relink assets —
  note that `Integration::IdoitController` uses `:show?` there, which looks like a gap on
  that side, but I did not want to change i-doit behaviour in this PR.
- The admin API token is masked in the settings payload and unmasked server-side via
  `SENSITIVE_FIELDS`, so re-saving the form without retyping the token works.
- The legacy `query` action allow-lists the reachable Snipe-IT endpoints rather than passing
  `params[:method]` through unchecked.
- Snipe-IT has **no bulk lookup by id**, unlike i-doit's `cmdb.objects`, so linked assets are
  fetched one at a time. `Snipeit.asset` caches hits for a minute to keep repeated sidebar
  renders from turning into one HTTP request each; misses are deliberately not cached, so a
  freshly created asset is linkable right away.
- Category and model autocompletes filter server-side (`search`, `category_type=asset`,
  `category_id`) rather than fetching a page and filtering in Ruby, so entries beyond the
  first page stay reachable.
- All three write paths for the asset ids go through
  `Service::Ticket::ExternalReferences::Snipeit::LinkAssets`, which diffs and writes the
  history. Ticket creation is handled separately, because assets picked in the create form
  are part of the ticket rather than a later change — without that, unlinking such an asset
  would leave a `removed` entry with no matching `added`.

## Testing

RSpec 134 examples, 0 failures. Vitest 20/20. Rubocop clean, full `pnpm lint` clean. GraphQL
artifacts regenerated with `pnpm generate-graphql-api`.

Also verified manually against a live Snipe-IT instance. If trying it out is easier than
reading the diff, there is a [single-file demo runner][demo] that brings up a throwaway
Zammad + Snipe-IT stack via compose, seeded with realistic assets, tickets and a matching
customer on both sides:

```
curl -fsSL https://gist.githubusercontent.com/kiliant/fcb8141e662b091d603e94afd80fe412/raw/demo.sh -o demo.sh
chmod +x demo.sh
./demo.sh
```

It prompts before every write, and `./demo.sh down` removes the containers and the temporary
workdir again.

[demo]: https://gist.github.com/kiliant/fcb8141e662b091d603e94afd80fe412

`spec/system/ticket/snipeit_spec.rb` mirrors `spec/system/ticket/idoit_spec.rb` and is tagged
`integration: true`. It **cannot run in CI yet** — that needs a `zammad-snipeit` service image
plus `.variables_snipeit` / `.services.snipeit` entries. I left the CI configuration untouched
on purpose, so the `capybara:integration` job does not break on a missing image.

## Open questions

1. **Is a Snipe-IT integration wanted in core at all?** If it belongs in an addon instead,
   that changes the shape of this entirely and is worth knowing before any review effort.
2. **Is the CoffeeScript side wanted?** I implemented both frontends because i-doit has both,
   but the developer docs say new features target Vue 3 + GraphQL. Dropping it removes ~476
   lines and the legacy REST controller with it.
3. **Is a mobile sidebar expected?** i-doit has none, so I did not build one.
4. **Would you want the CI wiring**, if the service image gets published? Happy to add it.

Happy to adjust scope in either direction.
