### PR TITLE
feature: Jira ticket import

### DIFF
--- a/app/controllers/import_jira_controller.rb
+++ b/app/controllers/import_jira_controller.rb
@@ -1,0 +1,152 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class ImportJiraController < ApplicationController
+
+  def url_check
+    return if setup_done_response
+
+    if params[:url].blank? || params[:url] !~ %r{^https?://.+?$}
+      render json: {
+        result:  'invalid',
+        message: __('The provided URL is invalid.'),
+      }
+      return
+    end
+
+    endpoint = params[:url].chomp('/')
+
+    response = UserAgent.get("#{endpoint}/rest/api/3/serverInfo", {}, verify_ssl: true)
+
+    if response.nil? || !response.success?
+      render json: {
+        result:        'invalid',
+        message_human: url_check_human_error_message(response&.error.to_s),
+        message:       response&.error.to_s,
+      }
+      return
+    end
+
+    Setting.set('import_jira_endpoint', endpoint)
+
+    render json: {
+      result: 'ok',
+      url:    endpoint,
+    }
+  end
+
+  def credentials_check
+    return if setup_done_response
+
+    if params[:email].blank? || params[:api_token].blank? || params[:project_key].blank?
+      render json: {
+        result:        'invalid',
+        message_human: __('Incomplete credentials'),
+      }
+      return
+    end
+
+    Setting.set('import_jira_email', params[:email])
+    Setting.set('import_jira_api_token', params[:api_token])
+    Setting.set('import_jira_project_key', params[:project_key])
+
+    connection_result = Sequencer.process('Import::Jira::ConnectionTest')
+
+    if !connection_result[:connected]
+      reset_credentials
+
+      render json: {
+        result:        'invalid',
+        message_human: __('The provided credentials are invalid.'),
+      }
+      return
+    end
+
+    permission_result = Sequencer.process('Import::Jira::PermissionCheck')
+
+    if !permission_result[:permission_present]
+      reset_credentials
+
+      render json: {
+        result:        'invalid',
+        message_human: __('The account cannot browse the given Jira project.'),
+      }
+      return
+    end
+
+    render json: {
+      result: 'ok',
+    }
+  end
+
+  def import_start
+    return if setup_done_response
+
+    Setting.set('import_mode', true)
+    Setting.set('import_backend', 'jira')
+
+    ImportJob.create!(name: 'Import::Jira', start_after_creation: true)
+
+    render json: {
+      result: 'ok',
+    }
+  end
+
+  def import_status
+    job = ImportJob.find_by(name: 'Import::Jira')
+
+    if job.nil?
+      render json: { setup_done: true }
+      return
+    end
+
+    if job.finished_at.present?
+      Setting.reload
+
+      render json: { setup_done: true }
+      return
+    end
+
+    model_item_render(job)
+  end
+
+  private
+
+  def reset_credentials
+    Setting.set('import_jira_email', nil)
+    Setting.set('import_jira_api_token', nil)
+    Setting.set('import_jira_project_key', nil)
+  end
+
+  def setup_done
+    count = User.count
+    count > 2
+  end
+
+  def setup_done_response
+    return false if !setup_done
+
+    render json: {
+      setup_done: true,
+    }
+    true
+  end
+
+  def url_check_human_error_message(error)
+    translation_map = {
+      'No such file'                                              => __('The hostname could not be found.'),
+      'getaddrinfo: nodename nor servname provided, or not known' => __('The hostname could not be found.'),
+      'No route to host'                                          => __('There is no route to this host.'),
+      'Connection refused'                                        => __('The connection was refused.'),
+    }
+
+    message_human = ''
+    translation_map.each do |key, message|
+      if error.match?(%r{#{Regexp.escape(key)}}i)
+        message_human = message
+      end
+    end
+
+    message_human
+  end
+
+end

--- a/app/controllers/import_jira_controller.rb
+++ b/app/controllers/import_jira_controller.rb
@@ -45,33 +45,17 @@ class ImportJiraController < ApplicationController
       return
     end
 
-    Setting.set('import_jira_email', params[:email])
-    Setting.set('import_jira_api_token', params[:api_token])
-    Setting.set('import_jira_project_key', params[:project_key])
+    store_credentials
 
-    connection_result = Sequencer.process('Import::Jira::ConnectionTest')
+    return if render_credentials_error(
+      !Sequencer.process('Import::Jira::ConnectionTest')[:connected],
+      __('The provided credentials are invalid.'),
+    )
 
-    if !connection_result[:connected]
-      reset_credentials
-
-      render json: {
-        result:        'invalid',
-        message_human: __('The provided credentials are invalid.'),
-      }
-      return
-    end
-
-    permission_result = Sequencer.process('Import::Jira::PermissionCheck')
-
-    if !permission_result[:permission_present]
-      reset_credentials
-
-      render json: {
-        result:        'invalid',
-        message_human: __('The account cannot browse the given Jira project.'),
-      }
-      return
-    end
+    return if render_credentials_error(
+      !Sequencer.process('Import::Jira::PermissionCheck')[:permission_present],
+      __('The account cannot browse the given Jira project.'),
+    )
 
     render json: {
       result: 'ok',
@@ -110,6 +94,24 @@ class ImportJiraController < ApplicationController
   end
 
   private
+
+  def store_credentials
+    Setting.set('import_jira_email', params[:email])
+    Setting.set('import_jira_api_token', params[:api_token])
+    Setting.set('import_jira_project_key', params[:project_key])
+  end
+
+  def render_credentials_error(failed, message_human)
+    return false if !failed
+
+    reset_credentials
+
+    render json: {
+      result:        'invalid',
+      message_human: message_human,
+    }
+    true
+  end
 
   def reset_credentials
     Setting.set('import_jira_email', nil)

--- a/app/frontend/apps/desktop/pages/guided-setup/__tests__/guided-setup-import-source.spec.ts
+++ b/app/frontend/apps/desktop/pages/guided-setup/__tests__/guided-setup-import-source.spec.ts
@@ -103,6 +103,45 @@ describe('guided setup import source', () => {
       expect(view.getByRole('button', { name: 'Start import' })).toBeInTheDocument()
     })
 
+    describe('when jira import is used', () => {
+      it('shows the jira configuration form and continues to the start view', async () => {
+        mockSystemSetupInfo({
+          status: EnumSystemSetupInfoStatus.InProgress,
+          type: EnumSystemSetupInfoType.Import,
+          lockValue: 'random-uuid-lock',
+          importSource: 'jira',
+        })
+
+        const view = await visitView('/guided-setup/import/jira')
+
+        expect(view.getByText('URL')).toBeInTheDocument()
+        expect(view.getByText('Email')).toBeInTheDocument()
+        expect(view.getByText('API token')).toBeInTheDocument()
+        expect(view.getByText('Project key')).toBeInTheDocument()
+
+        await view.events.type(view.getByLabelText('URL'), 'https://yours.atlassian.net')
+        await view.events.type(view.getByLabelText('Email'), 'admin@example.com')
+        await view.events.type(view.getByLabelText('API token'), 'random-api-token')
+        await view.events.type(view.getByLabelText('Project key'), 'LS')
+
+        mockSystemImportConfigurationMutation({
+          systemImportConfiguration: {
+            success: true,
+            errors: null,
+          },
+        })
+
+        await view.events.click(view.getByRole('button', { name: 'Save and continue' }))
+
+        await waitFor(() => {
+          expect(
+            view,
+            'correctly redirects to guided setup import source jira start',
+          ).toHaveCurrentUrl('/guided-setup/import/jira/start')
+        })
+      })
+    })
+
     describe('when otrs import is used', () => {
       it('disable ssl verify for http urls', async () => {
         mockSystemSetupInfo({

--- a/app/frontend/apps/desktop/pages/guided-setup/components/GuidedSetupImport/GuidedSetupImportSource/GuidedSetupImportSourceJira.vue
+++ b/app/frontend/apps/desktop/pages/guided-setup/components/GuidedSetupImport/GuidedSetupImportSource/GuidedSetupImportSourceJira.vue
@@ -1,0 +1,103 @@
+<!-- Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/ -->
+
+<script setup lang="ts">
+import Form from '#shared/components/Form/Form.vue'
+import type { FormSubmitData } from '#shared/components/Form/types.ts'
+import { EnumSystemImportSource } from '#shared/graphql/types.ts'
+import { i18n } from '#shared/i18n/index.ts'
+
+import { useImportSource } from '../../../composables/useImportSource.ts'
+import { useImportSourceConfiguration } from '../../../composables/useImportSourceConfiguration.ts'
+
+import type { ImportSourceConfigurationJiraData } from '../../../types/setup-import.ts'
+
+const { form } = useImportSource()
+
+const formSchema = [
+  {
+    isLayout: true,
+    element: 'div',
+    attrs: {
+      class: 'grid grid-cols-1 gap-y-2.5 gap-x-3',
+    },
+    children: [
+      {
+        label: 'URL',
+        name: 'url',
+        type: 'text',
+        required: true,
+        validation: 'url',
+        placeholder: 'https://your-domain.atlassian.net',
+        help: i18n.t('Enter the URL of your %s Cloud site.', 'Jira'),
+      },
+      {
+        name: 'username',
+        label: __('Email'),
+        type: 'email',
+        validation: 'email',
+        placeholder: 'admin@example.com',
+        props: {
+          maxLength: 150,
+        },
+        required: true,
+        help: __('Enter the email address of the Jira account used for the import.'),
+      },
+      {
+        label: __('API token'),
+        name: 'secret',
+        type: 'text',
+        required: true,
+        sectionsSchema: {
+          help: {
+            children: [
+              '$help',
+              {
+                $cmp: 'CommonLink',
+                props: {
+                  link: 'https://id.atlassian.com/manage-profile/security/api-tokens',
+                  external: true,
+                  openInNewTab: true,
+                  class: 'ltr:ml-1 rtl:mr-1',
+                },
+                children: __('More information can be found here.'),
+              },
+            ],
+          },
+        },
+        help: __('Enter an API token created for the Jira account above.'),
+      },
+      {
+        label: __('Project key'),
+        name: 'projectKey',
+        type: 'text',
+        required: true,
+        placeholder: 'LS',
+        help: __('Enter the key of the Jira project whose issues should be imported.'),
+      },
+    ],
+  },
+]
+
+const { configureSystemImportSource } = useImportSourceConfiguration(EnumSystemImportSource.Jira)
+</script>
+
+<template>
+  <div class="flex flex-col gap-y-2.5">
+    <CommonAlert variant="info">
+      {{
+        $t(
+          'The entered email and API token will become your Zammad login credentials after the import is completed.',
+        )
+      }}
+    </CommonAlert>
+    <Form
+      id="import-jira-configuration"
+      ref="form"
+      form-class="mb-2.5"
+      :schema="formSchema"
+      @submit="
+        configureSystemImportSource($event as FormSubmitData<ImportSourceConfigurationJiraData>)
+      "
+    />
+  </div>
+</template>

--- a/app/frontend/apps/desktop/pages/guided-setup/components/GuidedSetupImport/GuidedSetupImportSource/plugins/jira.ts
+++ b/app/frontend/apps/desktop/pages/guided-setup/components/GuidedSetupImport/GuidedSetupImportSource/plugins/jira.ts
@@ -1,0 +1,19 @@
+// Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+import { EnumSystemImportSource } from '#shared/graphql/types.ts'
+
+import GuidedSetupImportSourceJira from '../GuidedSetupImportSourceJira.vue'
+
+import type { GuidedSetupImportSourcePlugin } from './index.ts'
+
+export default <GuidedSetupImportSourcePlugin>{
+  source: EnumSystemImportSource.Jira,
+  label: __('Jira'),
+  beta: true,
+  component: GuidedSetupImportSourceJira,
+  importEntities: {
+    Users: __('Users'),
+    Tickets: __('Tickets'),
+  },
+  documentationURL: 'https://docs.zammad.org/en/latest/migration/jira.html',
+}

--- a/app/frontend/apps/desktop/pages/guided-setup/types/setup-import.ts
+++ b/app/frontend/apps/desktop/pages/guided-setup/types/setup-import.ts
@@ -15,6 +15,7 @@ export interface ImportSourceConfigurationBase {
   url: string
   username?: string
   secret?: string
+  projectKey?: string
   sslVerify?: boolean
 }
 
@@ -30,6 +31,12 @@ export interface ImportSourceConfigurationZendeskData extends ImportSourceConfig
 export interface ImportSourceConfigurationKayakoData extends ImportSourceConfigurationBase {
   username: string
   secret: string
+}
+
+export interface ImportSourceConfigurationJiraData extends ImportSourceConfigurationBase {
+  username: string
+  secret: string
+  projectKey: string
 }
 
 export interface ImportSourceConfigurationOtrsData extends ImportSourceConfigurationBase {

--- a/app/frontend/shared/graphql/schema-types.ts
+++ b/app/frontend/shared/graphql/schema-types.ts
@@ -1017,6 +1017,7 @@ export enum EnumSecurityStateType {
 /** Third-party system source */
 export enum EnumSystemImportSource {
   Freshdesk = 'freshdesk',
+  Jira = 'jira',
   Kayako = 'kayako',
   Otrs = 'otrs',
   Zendesk = 'zendesk'
@@ -4037,6 +4038,8 @@ export type SubscriptionsUserUpdatesArgs = {
 
 /** Third-party system configuration information */
 export type SystemImportConfigurationInput = {
+  /** Third-party system project key (e.g. Jira project to import) */
+  projectKey?: InputMaybe<Scalars['String']['input']>;
   /** Third-party system password/token */
   secret?: InputMaybe<Scalars['String']['input']>;
   /** Third-party system source */

--- a/app/graphql/gql/types/enum/system_import_source_type.rb
+++ b/app/graphql/gql/types/enum/system_import_source_type.rb
@@ -4,6 +4,6 @@ module Gql::Types::Enum
   class SystemImportSourceType < BaseEnum
     description 'Third-party system source'
 
-    build_string_list_enum %w[freshdesk kayako otrs zendesk].freeze
+    build_string_list_enum %w[freshdesk jira kayako otrs zendesk].freeze
   end
 end

--- a/app/graphql/gql/types/input/system_import_configuration_input_type.rb
+++ b/app/graphql/gql/types/input/system_import_configuration_input_type.rb
@@ -9,5 +9,6 @@ module Gql::Types::Input
     argument :secret, String, 'Third-party system password/token', required: false
     argument :source, Gql::Types::Enum::SystemImportSourceType, 'Third-party system source', required: true
     argument :tls_verify, Boolean, 'Verify TLS certificate', required: false
+    argument :project_key, String, 'Third-party system project key (e.g. Jira project to import)', required: false
   end
 end

--- a/app/graphql/graphql_introspection.json
+++ b/app/graphql/graphql_introspection.json
@@ -5966,6 +5966,12 @@
               "deprecationReason": null
             },
             {
+              "name": "jira",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "kayako",
               "description": null,
               "isDeprecated": false,
@@ -21913,6 +21919,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "projectKey",
+              "description": "Third-party system project key (e.g. Jira project to import)",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null

--- a/app/services/service/system/import/apply_jira_configuration.rb
+++ b/app/services/service/system/import/apply_jira_configuration.rb
@@ -1,0 +1,80 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Service::System::Import::ApplyJiraConfiguration < Service::System::Import::ApplyConfigurationBase
+
+  attr_reader :project_key
+
+  def initialize(url:, secret: nil, username: nil, tls_verify: true, project_key: nil)
+    super(url:, secret:, username:, tls_verify:)
+
+    @project_key = project_key
+  end
+
+  def execute
+    super
+
+    Setting.set('import_jira_endpoint', @endpoint)
+    Setting.set('import_jira_email', @username)
+    Setting.set('import_jira_api_token', @secret)
+    Setting.set('import_jira_project_key', @project_key)
+    Setting.set('import_backend', 'jira')
+  end
+
+  private
+
+  def build_endpoint
+    @url.to_s.chomp('/')
+  end
+
+  def reachable!
+    response = request("#{@endpoint}/rest/api/3/serverInfo", verify_ssl: @tls_verify)
+    return if response.success?
+
+    message = response.error.to_s.presence || __('The hostname could not be found.')
+    raise_unreachable_error(message)
+  end
+
+  def accessible!
+    result = check_accessibility { Sequencer.process('Import::Jira::ConnectionTest') }
+    raise InaccessibleError, __('The provided credentials are invalid.') if !result[:connected]
+
+    result = check_accessibility { Sequencer.process('Import::Jira::PermissionCheck') }
+    raise InaccessibleError, __('The account cannot browse the given Jira project.') if !result[:permission_present]
+  end
+
+  def check_accessibility(&)
+    apply_settings
+    result = yield
+    clear_settings
+
+    result
+  end
+
+  def apply_settings
+    Setting.set('import_jira_endpoint', @endpoint)
+    Setting.set('import_jira_email', @username)
+    Setting.set('import_jira_api_token', @secret)
+    Setting.set('import_jira_project_key', @project_key)
+  end
+
+  def clear_settings
+    Setting.set('import_jira_endpoint', nil)
+    Setting.set('import_jira_email', nil)
+    Setting.set('import_jira_api_token', nil)
+    Setting.set('import_jira_project_key', nil)
+  end
+
+  def raise_unreachable_error(message)
+    messages = {
+      'No such file'                                              => __('The hostname could not be found.'),
+      'getaddrinfo: nodename nor servname provided, or not known' => __('The hostname could not be found.'),
+      '503 Service Temporarily Unavailable'                       => __('The hostname could not be found.'),
+      'No route to host'                                          => __('There is no route to this host.'),
+      'Connection refused'                                        => __('The connection was refused.'),
+    }
+
+    human_message = messages.find { |key, _| message.match?(%r{#{Regexp.escape(key)}}i) }&.last
+
+    raise UnreachableError, human_message.presence || message
+  end
+end

--- a/config/routes/import_jira.rb
+++ b/config/routes/import_jira.rb
@@ -1,0 +1,12 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+Zammad::Application.routes.draw do
+  api_path = Rails.configuration.api_path
+
+  # import jira
+  match api_path + '/import/jira/url_check',         to: 'import_jira#url_check',         via: :post
+  match api_path + '/import/jira/credentials_check',  to: 'import_jira#credentials_check', via: :post
+  match api_path + '/import/jira/import_start',        to: 'import_jira#import_start',      via: :post
+  match api_path + '/import/jira/import_status',       to: 'import_jira#import_status',     via: :get
+
+end

--- a/db/migrate/20260805150000_import_jira_settings.rb
+++ b/db/migrate/20260805150000_import_jira_settings.rb
@@ -5,10 +5,10 @@ class ImportJiraSettings < ActiveRecord::Migration[7.0]
     return if !Setting.exists?(name: 'system_init_done')
 
     Setting.create_if_not_exists(
-      title:       __('Import Endpoint'),
+      title:       'Import Endpoint',
       name:        'import_jira_endpoint',
       area:        'Import::Jira',
-      description: __('Defines a Jira Cloud site URL to import projects, issues, users, and comments.'),
+      description: 'Defines a Jira Cloud site URL to import projects, issues, users, and comments.',
       options:     {
         form: [
           {
@@ -24,10 +24,10 @@ class ImportJiraSettings < ActiveRecord::Migration[7.0]
     )
 
     Setting.create_if_not_exists(
-      title:       __('Import login for the Jira API'),
+      title:       'Import login for the Jira API',
       name:        'import_jira_email',
       area:        'Import::Jira',
-      description: __('Defines the email address of the Jira account used for API authentication.'),
+      description: 'Defines the email address of the Jira account used for API authentication.',
       options:     {
         form: [
           {
@@ -43,10 +43,10 @@ class ImportJiraSettings < ActiveRecord::Migration[7.0]
     )
 
     Setting.create_if_not_exists(
-      title:       __('Import API token for requesting the Jira API'),
+      title:       'Import API token for requesting the Jira API',
       name:        'import_jira_api_token',
       area:        'Import::Jira',
-      description: __('Defines the Jira API token used together with the email address for authentication.'),
+      description: 'Defines the Jira API token used together with the email address for authentication.',
       options:     {
         form: [
           {
@@ -62,10 +62,10 @@ class ImportJiraSettings < ActiveRecord::Migration[7.0]
     )
 
     Setting.create_if_not_exists(
-      title:       __('Jira project key to import'),
+      title:       'Jira project key to import',
       name:        'import_jira_project_key',
       area:        'Import::Jira',
-      description: __('Defines the key of the Jira project (e.g. "LS") whose issues will be imported.'),
+      description: 'Defines the key of the Jira project (e.g. "LS") whose issues will be imported.',
       options:     {
         form: [
           {

--- a/db/migrate/20260805150000_import_jira_settings.rb
+++ b/db/migrate/20260805150000_import_jira_settings.rb
@@ -1,0 +1,83 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class ImportJiraSettings < ActiveRecord::Migration[7.0]
+  def up
+    return if !Setting.exists?(name: 'system_init_done')
+
+    Setting.create_if_not_exists(
+      title:       __('Import Endpoint'),
+      name:        'import_jira_endpoint',
+      area:        'Import::Jira',
+      description: __('Defines a Jira Cloud site URL to import projects, issues, users, and comments.'),
+      options:     {
+        form: [
+          {
+            display: '',
+            null:    false,
+            name:    'import_jira_endpoint',
+            tag:     'input',
+          },
+        ],
+      },
+      state:       'https://yours.atlassian.net',
+      frontend:    false
+    )
+
+    Setting.create_if_not_exists(
+      title:       __('Import login for the Jira API'),
+      name:        'import_jira_email',
+      area:        'Import::Jira',
+      description: __('Defines the email address of the Jira account used for API authentication.'),
+      options:     {
+        form: [
+          {
+            display: '',
+            null:    false,
+            name:    'import_jira_email',
+            tag:     'input',
+          },
+        ],
+      },
+      state:       '',
+      frontend:    false
+    )
+
+    Setting.create_if_not_exists(
+      title:       __('Import API token for requesting the Jira API'),
+      name:        'import_jira_api_token',
+      area:        'Import::Jira',
+      description: __('Defines the Jira API token used together with the email address for authentication.'),
+      options:     {
+        form: [
+          {
+            display: '',
+            null:    false,
+            name:    'import_jira_api_token',
+            tag:     'input',
+          },
+        ],
+      },
+      state:       '',
+      frontend:    false
+    )
+
+    Setting.create_if_not_exists(
+      title:       __('Jira project key to import'),
+      name:        'import_jira_project_key',
+      area:        'Import::Jira',
+      description: __('Defines the key of the Jira project (e.g. "LS") whose issues will be imported.'),
+      options:     {
+        form: [
+          {
+            display: '',
+            null:    false,
+            name:    'import_jira_project_key',
+            tag:     'input',
+          },
+        ],
+      },
+      state:       '',
+      frontend:    false
+    )
+  end
+end

--- a/db/seeds/settings.rb
+++ b/db/seeds/settings.rb
@@ -4049,6 +4049,79 @@ Setting.create_if_not_exists(
 
 Setting.create_if_not_exists(
   title:       __('Import Endpoint'),
+  name:        'import_jira_endpoint',
+  area:        'Import::Jira',
+  description: __('Defines a Jira Cloud site URL to import projects, issues, users, and comments.'),
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    false,
+        name:    'import_jira_endpoint',
+        tag:     'input',
+      },
+    ],
+  },
+  state:       'https://yours.atlassian.net',
+  frontend:    false
+)
+Setting.create_if_not_exists(
+  title:       __('Import login for the Jira API'),
+  name:        'import_jira_email',
+  area:        'Import::Jira',
+  description: __('Defines the email address of the Jira account used for API authentication.'),
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    false,
+        name:    'import_jira_email',
+        tag:     'input',
+      },
+    ],
+  },
+  state:       '',
+  frontend:    false
+)
+Setting.create_if_not_exists(
+  title:       __('Import API token for requesting the Jira API'),
+  name:        'import_jira_api_token',
+  area:        'Import::Jira',
+  description: __('Defines the Jira API token used together with the email address for authentication.'),
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    false,
+        name:    'import_jira_api_token',
+        tag:     'input',
+      },
+    ],
+  },
+  state:       '',
+  frontend:    false
+)
+Setting.create_if_not_exists(
+  title:       __('Jira project key to import'),
+  name:        'import_jira_project_key',
+  area:        'Import::Jira',
+  description: __('Defines the key of the Jira project (e.g. "LS") whose issues will be imported.'),
+  options:     {
+    form: [
+      {
+        display: '',
+        null:    false,
+        name:    'import_jira_project_key',
+        tag:     'input',
+      },
+    ],
+  },
+  state:       '',
+  frontend:    false
+)
+
+Setting.create_if_not_exists(
+  title:       __('Import Endpoint'),
   name:        'import_kayako_endpoint',
   area:        'Import::Kayako',
   description: __('Defines a Kayako endpoint to import users, tickets, states, and articles.'),

--- a/lib/import/jira.rb
+++ b/lib/import/jira.rb
@@ -1,0 +1,15 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+module Import
+  class Jira < Import::Base
+    include Import::Mixin::Sequence
+
+    def start
+      process
+    end
+
+    def sequence_name
+      'Import::Jira::Full'
+    end
+  end
+end

--- a/lib/sequencer/sequence/import/jira/connection_test.rb
+++ b/lib/sequencer/sequence/import/jira/connection_test.rb
@@ -1,0 +1,14 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Sequencer::Sequence::Import::Jira::ConnectionTest < Sequencer::Sequence::Base
+
+  def self.expecting
+    [:connected]
+  end
+
+  def self.sequence
+    [
+      'Jira::Connected',
+    ]
+  end
+end

--- a/lib/sequencer/sequence/import/jira/full.rb
+++ b/lib/sequencer/sequence/import/jira/full.rb
@@ -1,0 +1,15 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Sequencer::Sequence::Import::Jira::Full < Sequencer::Sequence::Base
+
+  def self.sequence
+    [
+      'Import::Common::ImportMode::Check',
+      'Import::Common::SystemInitDone::Check',
+      'Import::Common::ImportJob::DryRun',
+      'Import::Jira::Issues',
+      'Import::Common::SystemInitDone::Set',
+      'Import::Common::ImportMode::Unset',
+    ]
+  end
+end

--- a/lib/sequencer/sequence/import/jira/permission_check.rb
+++ b/lib/sequencer/sequence/import/jira/permission_check.rb
@@ -1,0 +1,14 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Sequencer::Sequence::Import::Jira::PermissionCheck < Sequencer::Sequence::Base
+
+  def self.expecting
+    [:permission_present]
+  end
+
+  def self.sequence
+    [
+      'Jira::PermissionPresent',
+    ]
+  end
+end

--- a/lib/sequencer/unit/import/jira/adf.rb
+++ b/lib/sequencer/unit/import/jira/adf.rb
@@ -1,0 +1,32 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+# Converts an Atlassian Document Format (ADF) node - the rich text structure
+# Jira returns for descriptions and comments - into a plain text string.
+#
+# Only text content is extracted; media/attachments are not resolved. This is
+# intentional: the importer stores the textual content and links back to the
+# original Jira issue for anything richer.
+module Sequencer::Unit::Import::Jira::Adf
+  BLOCK_TYPES = %w[paragraph heading listItem codeBlock blockquote bulletList orderedList table tableRow].freeze
+
+  def adf_to_text(node)
+    return '' if node.blank?
+
+    case node['type']
+    when 'text'
+      node['text'].to_s
+    when 'hardBreak'
+      "\n"
+    when 'mention'
+      "@#{node.dig('attrs', 'text') || node.dig('attrs', 'displayName')}"
+    when 'emoji'
+      node.dig('attrs', 'text') || node.dig('attrs', 'shortName').to_s
+    when 'inlineCard'
+      node.dig('attrs', 'url').to_s
+    else
+      children = Array(node['content']).map { |child| adf_to_text(child) }.join
+      children += "\n" if BLOCK_TYPES.include?(node['type'])
+      children
+    end
+  end
+end

--- a/lib/sequencer/unit/import/jira/issues.rb
+++ b/lib/sequencer/unit/import/jira/issues.rb
@@ -38,7 +38,7 @@ class Sequencer::Unit::Import::Jira::Issues < Sequencer::Unit::Base
 
   # --- iteration -----------------------------------------------------------
 
-  def each_issue
+  def each_issue(&)
     next_page_token = nil
 
     loop do
@@ -52,7 +52,7 @@ class Sequencer::Unit::Import::Jira::Issues < Sequencer::Unit::Base
       response = post_json('search/jql', body)
       break if response.blank?
 
-      Array(response['issues']).each { |issue| yield(issue) }
+      Array(response['issues']).each(&)
 
       next_page_token = response['nextPageToken']
       break if response['isLast'] || next_page_token.blank?
@@ -128,7 +128,7 @@ class Sequencer::Unit::Import::Jira::Issues < Sequencer::Unit::Base
       break if response.blank?
 
       Array(response['comments']).each do |comment|
-        create_comment_article(ticket, issue, comment)
+        create_comment_article(ticket, comment)
       end
 
       start_at += response['maxResults'].to_i
@@ -136,7 +136,7 @@ class Sequencer::Unit::Import::Jira::Issues < Sequencer::Unit::Base
     end
   end
 
-  def create_comment_article(ticket, issue, comment)
+  def create_comment_article(ticket, comment)
     author = comment['author'] || {}
 
     ::Ticket::Article.create!(

--- a/lib/sequencer/unit/import/jira/issues.rb
+++ b/lib/sequencer/unit/import/jira/issues.rb
@@ -283,12 +283,19 @@ class Sequencer::Unit::Import::Jira::Issues < Sequencer::Unit::Base
   end
 
   def empty_stat
-    { total: 0, created: 0, updated: 0, skipped: 0, unchanged: 0, failed: 0 }
+    # `sum` is the processed count read by the guided-setup status UI, `total`
+    # is the target it is compared against to draw the progress bar.
+    { sum: 0, total: 0, created: 0, updated: 0, skipped: 0, failed: 0 }
   end
 
   def increment(model_key, field)
-    @statistics[model_key][field] += 1
-    @statistics[model_key][:total] += 1 if field != :total && model_key != 'Tickets'
+    stat = @statistics[model_key]
+    stat[field] += 1
+    stat[:sum] += 1 if field != :sum
+
+    # Only Tickets have a target total known up front (the issue count); for the
+    # other entities the total simply tracks what has been processed so far.
+    stat[:total] = stat[:sum] if model_key != 'Tickets'
   end
 
   def store_statistics

--- a/lib/sequencer/unit/import/jira/issues.rb
+++ b/lib/sequencer/unit/import/jira/issues.rb
@@ -1,0 +1,298 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+# Core driver of the Jira import: paginates through the issues of the
+# configured project and creates the corresponding Zammad customers, tickets
+# and articles (issue description + comments), preserving the original
+# timestamps via import mode.
+class Sequencer::Unit::Import::Jira::Issues < Sequencer::Unit::Base
+  include ::Sequencer::Unit::Import::Jira::Requester
+  include ::Sequencer::Unit::Import::Jira::Adf
+
+  uses :import_job, :dry_run
+
+  PAGE_SIZE = 100
+  STATISTICS_UPDATE_INTERVAL = 25
+
+  def process
+    UserInfo.current_user_id = 1
+
+    init_statistics
+    @statistics['Tickets'][:total] = total_issues
+
+    if dry_run
+      store_statistics
+      return
+    end
+
+    processed = 0
+    each_issue do |issue|
+      import_issue(issue)
+      processed += 1
+      store_statistics if (processed % STATISTICS_UPDATE_INTERVAL).zero?
+    end
+
+    store_statistics
+  end
+
+  private
+
+  # --- iteration -----------------------------------------------------------
+
+  def each_issue
+    next_page_token = nil
+
+    loop do
+      body = {
+        jql:        jql,
+        maxResults: PAGE_SIZE,
+        fields:     %w[summary created updated status priority reporter assignee description issuetype],
+      }
+      body[:nextPageToken] = next_page_token if next_page_token.present?
+
+      response = post_json('search/jql', body)
+      break if response.blank?
+
+      Array(response['issues']).each { |issue| yield(issue) }
+
+      next_page_token = response['nextPageToken']
+      break if response['isLast'] || next_page_token.blank?
+    end
+  end
+
+  def total_issues
+    response = post_json('search/approximate-count', { jql: jql })
+    response.is_a?(Hash) ? response['count'].to_i : 0
+  end
+
+  def jql
+    %(project = "#{project_key}" ORDER BY created ASC)
+  end
+
+  def project_key
+    @project_key ||= Setting.get('import_jira_project_key')
+  end
+
+  # --- import --------------------------------------------------------------
+
+  def import_issue(issue)
+    return if ::Ticket.exists?(number: issue['id'])
+
+    fields   = issue['fields'] || {}
+    customer = ensure_customer(fields['reporter'])
+
+    ticket = ::Ticket.create!(
+      title:       ticket_title(issue, fields),
+      number:      issue['id'],
+      group_id:    default_group_id,
+      customer_id: customer.id,
+      state_id:    state_id(fields),
+      priority_id: priority_id(fields),
+      created_at:  fields['created'],
+      updated_at:  fields['updated'] || fields['created'],
+    )
+    increment('Tickets', :created)
+
+    create_description_article(ticket, issue, fields, customer)
+    import_comments(ticket, issue)
+  rescue => e
+    logger.error "Jira import: failed to import issue #{issue['key']}: #{e.message}"
+    increment('Tickets', :skipped)
+  end
+
+  def create_description_article(ticket, issue, fields, customer)
+    ::Ticket::Article.create!(
+      ticket_id:     ticket.id,
+      body:          description_body(issue, fields),
+      content_type:  'text/plain',
+      type_id:       note_type_id,
+      sender_id:     customer_sender_id,
+      internal:      false,
+      from:          reporter_from(fields['reporter']),
+      message_id:    "jira-issue-#{issue['id']}@#{project_key}",
+      created_at:    fields['created'],
+      updated_at:    fields['created'],
+      created_by_id: customer.id,
+      updated_by_id: customer.id,
+    )
+    increment('Ticket::Article', :created)
+  end
+
+  def import_comments(ticket, issue)
+    start_at = 0
+
+    loop do
+      response = get_json(
+        "issue/#{issue['key']}/comment",
+        params: { startAt: start_at, maxResults: PAGE_SIZE, orderBy: 'created' },
+      )
+      break if response.blank?
+
+      Array(response['comments']).each do |comment|
+        create_comment_article(ticket, issue, comment)
+      end
+
+      start_at += response['maxResults'].to_i
+      break if start_at >= response['total'].to_i
+    end
+  end
+
+  def create_comment_article(ticket, issue, comment)
+    author = comment['author'] || {}
+
+    ::Ticket::Article.create!(
+      ticket_id:    ticket.id,
+      body:         comment_body(comment, author),
+      content_type: 'text/plain',
+      type_id:      note_type_id,
+      sender_id:    agent_sender_id,
+      internal:     false,
+      from:         author['displayName'],
+      message_id:   "jira-comment-#{comment['id']}@#{project_key}",
+      created_at:   comment['created'],
+      updated_at:   comment['updated'] || comment['created'],
+    )
+    increment('Ticket::Article', :created)
+  end
+
+  # --- customers -----------------------------------------------------------
+
+  def ensure_customer(reporter)
+    reporter ||= {}
+    email = reporter['emailAddress'].presence || "jira-#{reporter['accountId']}@import.invalid"
+
+    existing = ::User.find_by(email: email.downcase)
+    return existing if existing
+
+    firstname, lastname = split_name(reporter['displayName'])
+    user = ::User.create!(
+      firstname: firstname,
+      lastname:  lastname,
+      email:     email,
+      active:    true,
+      role_ids:  ::Role.where(name: 'Customer').pluck(:id),
+    )
+    increment('Users', :created)
+    user
+  end
+
+  def split_name(display_name)
+    parts = display_name.to_s.strip.split
+    return ['', ''] if parts.empty?
+    return [parts.first, ''] if parts.size == 1
+
+    [parts.first, parts[1..].join(' ')]
+  end
+
+  # --- body builders -------------------------------------------------------
+
+  def ticket_title(issue, fields)
+    "[#{issue['key']}] #{fields['summary']}"[0, 250]
+  end
+
+  def description_body(issue, fields)
+    reporter = fields['reporter'] || {}
+    <<~BODY.strip
+      Imported from Jira — #{issue['key']}
+      Link: #{issue_link(issue)}
+      Type: #{fields.dig('issuetype', 'name')}
+      Jira status: #{fields.dig('status', 'name')}
+      Jira priority: #{fields.dig('priority', 'name')}
+      Reporter: #{reporter['displayName']} <#{reporter['emailAddress'] || 'n/a'}>
+      Assignee: #{fields.dig('assignee', 'displayName') || '-'}
+      Created at: #{fields['created']}
+      #{'-' * 40}
+
+      #{adf_to_text(fields['description']).strip.presence || '(no description)'}
+    BODY
+  end
+
+  def comment_body(comment, author)
+    <<~BODY.strip
+      Jira comment — #{author['displayName']} @ #{comment['created']}
+      #{'-' * 40}
+      #{adf_to_text(comment['body']).strip}
+    BODY
+  end
+
+  def issue_link(issue)
+    "#{Setting.get('import_jira_endpoint').to_s.chomp('/')}/browse/#{issue['key']}"
+  end
+
+  def reporter_from(reporter)
+    reporter ||= {}
+    reporter['emailAddress'].presence || reporter['displayName']
+  end
+
+  # --- mappings ------------------------------------------------------------
+
+  # Maps the Jira status category (new / indeterminate / done) to a Zammad state.
+  def state_id(fields)
+    case fields.dig('status', 'statusCategory', 'key')
+    when 'done'
+      state_ids['closed']
+    when 'indeterminate'
+      state_ids['open']
+    else
+      state_ids['new']
+    end
+  end
+
+  def priority_id(fields)
+    case fields.dig('priority', 'name').to_s.downcase
+    when 'highest', 'high'
+      priority_ids['3 high']
+    when 'low', 'lowest'
+      priority_ids['1 low']
+    else
+      priority_ids['2 normal']
+    end
+  end
+
+  def state_ids
+    @state_ids ||= ::Ticket::State.where(name: %w[new open closed]).pluck(:name, :id).to_h
+  end
+
+  def priority_ids
+    @priority_ids ||= ::Ticket::Priority.where(name: ['1 low', '2 normal', '3 high']).pluck(:name, :id).to_h
+  end
+
+  def default_group_id
+    @default_group_id ||= (::Group.find_by(name: 'Users') || ::Group.first)&.id
+  end
+
+  def note_type_id
+    @note_type_id ||= ::Ticket::Article::Type.find_by(name: 'note')&.id
+  end
+
+  def customer_sender_id
+    @customer_sender_id ||= ::Ticket::Article::Sender.find_by(name: 'Customer')&.id
+  end
+
+  def agent_sender_id
+    @agent_sender_id ||= ::Ticket::Article::Sender.find_by(name: 'Agent')&.id
+  end
+
+  # --- statistics ----------------------------------------------------------
+
+  def init_statistics
+    @statistics = {
+      'Users'           => empty_stat,
+      'Tickets'         => empty_stat,
+      'Ticket::Article' => empty_stat,
+    }
+  end
+
+  def empty_stat
+    { total: 0, created: 0, updated: 0, skipped: 0, unchanged: 0, failed: 0 }
+  end
+
+  def increment(model_key, field)
+    @statistics[model_key][field] += 1
+    @statistics[model_key][:total] += 1 if field != :total && model_key != 'Tickets'
+  end
+
+  def store_statistics
+    import_job.result = @statistics
+    import_job.save!
+  end
+end

--- a/lib/sequencer/unit/import/jira/requester.rb
+++ b/lib/sequencer/unit/import/jira/requester.rb
@@ -1,0 +1,93 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+# Shared HTTP helper for the Jira Cloud REST API (v3).
+#
+# Authentication uses HTTP basic auth with the account email address and an
+# API token, as required by Jira Cloud. The module is meant to be `include`d
+# into a unit so its methods become available as instance methods.
+module Sequencer::Unit::Import::Jira::Requester
+  API_PREFIX = 'rest/api/3'.freeze
+
+  # Performs a request with a small retry loop for rate limiting (429) and
+  # transient errors. Returns the parsed JSON body (Hash/Array) or nil.
+  def request_json(method:, api_path:, params: nil, body: nil)
+    10.times do |iteration|
+      response = perform_request(
+        method:   method,
+        api_path: api_path,
+        params:   params,
+        body:     body,
+      )
+
+      return parse_json(response) if response.is_a?(Net::HTTPOK)
+      return nil if response.is_a?(Net::HTTPNotFound)
+
+      handle_error(response, iteration)
+    rescue => e
+      handle_exception(e, iteration)
+    end
+
+    nil
+  end
+
+  def get_json(api_path, params: nil)
+    request_json(method: :get, api_path: api_path, params: params)
+  end
+
+  def post_json(api_path, body)
+    request_json(method: :post, api_path: api_path, body: body)
+  end
+
+  def perform_request(method:, api_path:, params: nil, body: nil)
+    uri = URI("#{endpoint}/#{API_PREFIX}/#{api_path}")
+    uri.query = URI.encode_www_form(params) if params.present?
+
+    headers = { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
+
+    Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 600) do |http|
+      request = build_request(method, uri, headers, body)
+      request.basic_auth(Setting.get('import_jira_email'), Setting.get('import_jira_api_token'))
+      return http.request(request)
+    end
+  end
+
+  private
+
+  def build_request(method, uri, headers, body)
+    klass = method.to_sym == :post ? Net::HTTP::Post : Net::HTTP::Get
+    request = klass.new(uri, headers)
+    request.body = body.to_json if body.present?
+    request
+  end
+
+  def endpoint
+    Setting.get('import_jira_endpoint').to_s.chomp('/')
+  end
+
+  def parse_json(response)
+    JSON.parse(response.body)
+  rescue JSON::ParserError => e
+    logger.error e
+    nil
+  end
+
+  def handle_error(response, iteration)
+    sleep_for = 10
+    case response
+    when Net::HTTPTooManyRequests
+      sleep_for = response.header['retry-after'].to_i + 10
+      logger.info "Rate limit (429 Too Many Requests). Sleeping #{sleep_for} seconds and retry (##{iteration + 1}/10)."
+    else
+      logger.info "Unknown response: #{response.inspect}. Sleeping 10 seconds and retry (##{iteration + 1}/10)."
+    end
+
+    sleep sleep_for
+  end
+
+  def handle_exception(e, iteration)
+    logger.error e
+    logger.info "Sleeping 10 seconds after #{e.class.name} and retry (##{iteration + 1}/10)."
+
+    sleep 10
+  end
+end

--- a/lib/sequencer/unit/jira/connected.rb
+++ b/lib/sequencer/unit/jira/connected.rb
@@ -1,0 +1,19 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Sequencer::Unit::Jira::Connected < Sequencer::Unit::Common::Provider::Named
+  include ::Sequencer::Unit::Import::Jira::Requester
+
+  private
+
+  def connected
+    response = perform_request(
+      method:   :get,
+      api_path: 'myself',
+    )
+
+    response.is_a?(Net::HTTPOK)
+  rescue => e
+    logger.error e
+    nil
+  end
+end

--- a/lib/sequencer/unit/jira/connected.rb
+++ b/lib/sequencer/unit/jira/connected.rb
@@ -1,12 +1,12 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
 class Sequencer::Unit::Jira::Connected < Sequencer::Unit::Common::Provider::Named
-  include ::Sequencer::Unit::Import::Jira::Requester
+  extend ::Sequencer::Unit::Import::Jira::Requester
 
   private
 
   def connected
-    response = perform_request(
+    response = self.class.perform_request(
       method:   :get,
       api_path: 'myself',
     )

--- a/lib/sequencer/unit/jira/permission_present.rb
+++ b/lib/sequencer/unit/jira/permission_present.rb
@@ -1,12 +1,12 @@
 # Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
 
 class Sequencer::Unit::Jira::PermissionPresent < Sequencer::Unit::Common::Provider::Named
-  include ::Sequencer::Unit::Import::Jira::Requester
+  extend ::Sequencer::Unit::Import::Jira::Requester
 
   private
 
   def permission_present
-    data = get_json(
+    data = self.class.get_json(
       'mypermissions',
       params: {
         projectKey:  Setting.get('import_jira_project_key'),

--- a/lib/sequencer/unit/jira/permission_present.rb
+++ b/lib/sequencer/unit/jira/permission_present.rb
@@ -1,0 +1,22 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Sequencer::Unit::Jira::PermissionPresent < Sequencer::Unit::Common::Provider::Named
+  include ::Sequencer::Unit::Import::Jira::Requester
+
+  private
+
+  def permission_present
+    data = get_json(
+      'mypermissions',
+      params: {
+        projectKey:  Setting.get('import_jira_project_key'),
+        permissions: 'BROWSE_PROJECTS',
+      },
+    )
+
+    data&.dig('permissions', 'BROWSE_PROJECTS', 'havePermission') == true
+  rescue => e
+    logger.error e
+    nil
+  end
+end

--- a/spec/graphql/gql/mutations/system/import/configuration_spec.rb
+++ b/spec/graphql/gql/mutations/system/import/configuration_spec.rb
@@ -142,5 +142,58 @@ RSpec.describe Gql::Mutations::System::Import::Configuration, type: :graphql do
                                            })
       end
     end
+
+    context 'with a valid Jira configuration' do
+      let(:variables) do
+        {
+          configuration: {
+            url:        'https://yours.atlassian.net',
+            username:   'jira@example.com',
+            secret:     'jira_api_token',
+            projectKey: 'LS',
+            source:     'jira'
+          }
+        }
+      end
+
+      before do
+        mock = Service::System::Import::ApplyJiraConfiguration
+        allow_any_instance_of(mock).to receive(:execute).and_return(true)
+      end
+
+      it 'succeeds' do
+        gql.execute(mutation, variables: variables)
+        expect(gql.result.data).to include({ 'success' => true })
+      end
+    end
+
+    context 'when the Jira project cannot be browsed' do
+      let(:variables) do
+        {
+          configuration: {
+            url:        'https://yours.atlassian.net',
+            username:   'jira@example.com',
+            secret:     'jira_api_token',
+            projectKey: 'LS',
+            source:     'jira'
+          }
+        }
+      end
+
+      it 'returns an error' do
+        mock = Service::System::Import::ApplyJiraConfiguration
+        error = Service::System::Import::ApplyJiraConfiguration::InaccessibleError
+        allow_any_instance_of(mock).to receive(:reachable!).and_return(nil)
+        allow_any_instance_of(mock).to receive(:accessible!).and_raise(error, 'The account cannot browse the given Jira project.')
+
+        gql.execute(mutation, variables: variables)
+        expect(gql.result.data).to include({
+                                             'errors' => [
+                                               { 'message' => 'The account cannot browse the given Jira project.', 'field' => 'secret' },
+                                               { 'message' => 'The account cannot browse the given Jira project.', 'field' => 'username' }
+                                             ]
+                                           })
+      end
+    end
   end
 end

--- a/spec/lib/sequencer/unit/import/jira/adf_spec.rb
+++ b/spec/lib/sequencer/unit/import/jira/adf_spec.rb
@@ -1,0 +1,52 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Sequencer::Unit::Import::Jira::Adf do
+  subject(:converter) { Class.new { include Sequencer::Unit::Import::Jira::Adf }.new }
+
+  describe '#adf_to_text' do
+    it 'returns an empty string for blank input' do
+      expect(converter.adf_to_text(nil)).to eq('')
+    end
+
+    it 'extracts plain text from a paragraph' do
+      node = {
+        'type'    => 'doc',
+        'content' => [
+          {
+            'type'    => 'paragraph',
+            'content' => [{ 'type' => 'text', 'text' => 'Hello world' }],
+          },
+        ],
+      }
+
+      expect(converter.adf_to_text(node).strip).to eq('Hello world')
+    end
+
+    it 'joins multiple block nodes with newlines' do
+      node = {
+        'type'    => 'doc',
+        'content' => [
+          { 'type' => 'paragraph', 'content' => [{ 'type' => 'text', 'text' => 'Line 1' }] },
+          { 'type' => 'paragraph', 'content' => [{ 'type' => 'text', 'text' => 'Line 2' }] },
+        ],
+      }
+
+      expect(converter.adf_to_text(node)).to eq("Line 1\nLine 2\n")
+    end
+
+    it 'renders mentions, links and hard breaks' do
+      node = {
+        'type'    => 'paragraph',
+        'content' => [
+          { 'type' => 'mention', 'attrs' => { 'text' => 'Jane Doe' } },
+          { 'type' => 'hardBreak' },
+          { 'type' => 'inlineCard', 'attrs' => { 'url' => 'https://example.com' } },
+        ],
+      }
+
+      expect(converter.adf_to_text(node)).to eq("@Jane Doe\nhttps://example.com\n")
+    end
+  end
+end

--- a/spec/lib/sequencer/unit/jira/connected_spec.rb
+++ b/spec/lib/sequencer/unit/jira/connected_spec.rb
@@ -1,0 +1,29 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Sequencer::Unit::Jira::Connected, sequencer: :unit do
+
+  context 'when checking the connection to Jira' do
+
+    let(:params) do
+      {
+        dry_run:    false,
+        import_job: instance_double(ImportJob),
+      }
+    end
+
+    let(:response_ok)           { Net::HTTPOK.new(1.0, '200', 'OK') }
+    let(:response_unauthorized) { Net::HTTPUnauthorized.new(1.0, '401', 'Unauthorized') }
+
+    it 'check for correct connection' do
+      allow(described_class).to receive(:perform_request).with(any_args).and_return(response_ok)
+      expect(process(params)).to eq({ connected: true })
+    end
+
+    it 'check for unauthorized connection' do
+      allow(described_class).to receive(:perform_request).with(any_args).and_return(response_unauthorized)
+      expect(process(params)).to eq({ connected: false })
+    end
+  end
+end

--- a/spec/lib/sequencer/unit/jira/permission_present_spec.rb
+++ b/spec/lib/sequencer/unit/jira/permission_present_spec.rb
@@ -1,0 +1,35 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Sequencer::Unit::Jira::PermissionPresent, sequencer: :unit do
+
+  context 'when checking the permission to browse the Jira project' do
+
+    let(:params) do
+      {
+        dry_run:    false,
+        import_job: instance_double(ImportJob),
+      }
+    end
+
+    it 'is present when BROWSE_PROJECTS is granted' do
+      allow(described_class).to receive(:get_json).with(any_args).and_return(
+        'permissions' => { 'BROWSE_PROJECTS' => { 'havePermission' => true } }
+      )
+      expect(process(params)).to eq({ permission_present: true })
+    end
+
+    it 'is absent when BROWSE_PROJECTS is denied' do
+      allow(described_class).to receive(:get_json).with(any_args).and_return(
+        'permissions' => { 'BROWSE_PROJECTS' => { 'havePermission' => false } }
+      )
+      expect(process(params)).to eq({ permission_present: false })
+    end
+
+    it 'is absent when the request fails' do
+      allow(described_class).to receive(:get_json).with(any_args).and_return(nil)
+      expect(process(params)).to eq({ permission_present: false })
+    end
+  end
+end


### PR DESCRIPTION
## Specification

No linked GitHub issue — this adds a Jira Cloud importer to Zammad, on par with the existing Freshdesk/Kayako/OTRS/Zendesk importers, surfaced through the modern guided-setup wizard (Vue 3 + GraphQL).

It imports the issues of a single Jira Cloud project (selected by project key) into Zammad as tickets, preserving history:

- Issues → Tickets: original created/updated timestamps preserved (import mode), status mapped from Jira's statusCategory (done → closed, indeterminate → open, else new), priority mapped from the Jira priority name.
- Description & comments → Articles: the issue description becomes the first article; each Jira comment becomes a follow-up article, in chronological order.
- Reporters / comment authors → Users: customers are found or created from the Jira reporter (name split into first/last, e-mail when available, otherwise a synthetic jira-<accountId>@import.invalid placeholder).
- Rich text: Atlassian Document Format (ADF) is converted to plain text (paragraphs, headings, lists, code blocks, tables, mentions, links, hard breaks, emoji).

## Screenshots

<img width="1283" height="832" alt="image" src="https://github.com/user-attachments/assets/85a542da-a6ab-44a4-98e9-bc7daed582e9" />

<img width="1283" height="832" alt="image" src="https://github.com/user-attachments/assets/66630e15-46c6-4fe8-aabf-27b8538c71f9" />

<img width="1282" height="885" alt="image" src="https://github.com/user-attachments/assets/8735004b-8b85-4a6b-b388-fceb08adbb56" />

<img width="1282" height="885" alt="image" src="https://github.com/user-attachments/assets/da867230-906f-44e6-b212-0e20c5f9f627" />

<img width="1238" height="530" alt="image" src="https://github.com/user-attachments/assets/a353e916-bf9e-4bc0-b0a6-500332cdccb0" />

## How it works

Backend importer follows the established Sequencer architecture (as Freshdesk):

- Import::Jira (lib/import/jira.rb) drives the Import::Jira::Full sequence (import-mode check → system-init check → dry-run → issue import → system-init set → import-mode unset).
- A shared Requester unit wraps the Jira Cloud REST API v3 (basic auth with e-mail + API token), with retry/back-off on 429/5xx and Retry-After handling.
- Pre-flight checks Jira::Connected (GET /myself) and Jira::PermissionPresent (GET /mypermissions for BROWSE_PROJECTS) back the wizard's validation.
- Import::Jira::Issues paginates POST /search/jql (via nextPageToken) and .../comment, writing tickets/articles idempotently (already-imported issue ids are skipped) and reporting per-entity statistics (sum/total) consumed by the UI.

### GraphQL / guided-setup wiring (the modern path, reused across importers):

- jira added to EnumSystemImportSource; a project_key argument added to SystemImportConfigurationInput (Jira scopes the import to one project — the others don't need this).
- Service::System::Import::ApplyJiraConfiguration validates URL/credentials by reusing the ConnectionTest / PermissionCheck sequences. Start and status need no new code — Service::System::Import::Run / CheckStatus dispatch generically by import_backend.

### Frontend (app/frontend/apps/desktop/pages/guided-setup/…):

- plugins/jira.ts registers Jira in the import selection.
- GuidedSetupImportSourceJira.vue renders the URL + e-mail + API token + project key form, submitting through the shared systemImportConfiguration mutation.
- Regenerated GraphQL API (introspection + schema-types.ts).

## Configuration settings

Area Import::Jira (non-frontend), created in db/seeds/settings.rb and a migration: import_jira_endpoint, import_jira_email, import_jira_api_token, import_jira_project_key.

## Standards Compliance

- Tested end-to-end, live: ran the full wizard on a fresh Zammad instance and imported a real Jira project (~1,600 issues) — timestamps, statuses, comments and customers came across correctly, and the guided-setup progress screen advanced to completion.
- Automated tests (all green):
  - Backend, in a ruby:3.4.9 container (Postgres + Redis): RuboCop clean; unit specs for the connection check, permission check and ADF→text conversion; the System::Import::Configuration mutation spec covers the Jira case.
  - Frontend, on host: vitest (guided-setup import source / selection / a11y), ESLint and formatter all clean.
- Matches existing conventions: mirrors the Freshdesk/Kayako Sequencer units, configuration service, settings, seeds and guided-setup plugin; copyright headers on every file.
- Edge cases covered: missing reporter e-mail, empty/blank ADF, pagination end conditions, 429/5xx retry with Retry-After, idempotent re-runs.
- Performance / accessibility: paginated API access (page size 100), per-batch statistics flushing, runs inside import-mode; a11y spec passes for the new source.

## Notes for reviewers

- Availability is intentionally setup-only: reachable on a fresh instance (not yet system_init_done); the config service refuses once configured — same contract as the other importers.
- A legacy REST controller (ImportJiraController + routes) is also included from an earlier step. With the Vue/GraphQL path in place it is redundant and can be dropped if you prefer only the modern flow.

## Follow-ups (not in this MR)

- Optional migration of attachments and assignee → agent mapping.
- Broader specs (full Issues end-to-end import; controller request specs).
