### PR TITLE
Fixes #6297 - Anthropic provider fails on Claude models that return thinking blocks

### DIFF
--- a/lib/ai/provider/anthropic.rb
+++ b/lib/ai/provider/anthropic.rb
@@ -119,7 +119,9 @@ class AI::Provider::Anthropic < AI::Provider
     data = validate_response!(response)
     extract_response_metadata(data)
 
-    data['content'].first['text']
+    # Models with extended thinking return one or more 'thinking' blocks before
+    # the 'text' block, so the answer is not necessarily the first element.
+    data['content'].find { |block| block['type'] == 'text' }&.fetch('text', nil)
   end
 
   def embeddings(input:)

--- a/spec/lib/ai/provider/anthropic_spec.rb
+++ b/spec/lib/ai/provider/anthropic_spec.rb
@@ -64,6 +64,26 @@ RSpec.describe AI::Provider::Anthropic, integration: true, required_envs: %w[ANT
       end
     end
 
+    context 'when the response contains thinking blocks' do
+      it 'returns the content of the text block' do
+        allow(UserAgent).to receive(:post).and_return(
+          UserAgent::Result.new(
+            success: true,
+            code:    200,
+            data:    {
+              'content' => [
+                { 'type' => 'thinking', 'thinking' => '', 'signature' => 'Et...' },
+                { 'type' => 'text', 'text' => '{ "connected": "true" }' },
+              ],
+              'usage'   => { 'input_tokens' => 1, 'output_tokens' => 1 },
+            },
+          )
+        )
+
+        expect(ai_provider.ask(prompt_system:, prompt_user:)).to match({ 'connected' => 'true' })
+      end
+    end
+
     context 'when metadata is extracted' do
       it 'stores metadata from response' do
         ai_provider.ask(prompt_system:, prompt_user:)


### PR DESCRIPTION
Fixes #6297

Claude 5 models have adaptive thinking enabled by default and return a `thinking` content block before the `text` block. `data['content'].first['text']` then evaluates to `nil` and the service layer reports "The response could not be processed", even though the API call returned 200.

This selects the first content block of type `text` instead of the first block. For responses without thinking blocks the first block is the text block, so behaviour for existing models such as `claude-sonnet-4-6` and `claude-haiku-4-5` is unchanged.

Disabling thinking, as done for the Ollama provider in #5984 with `think: false`, is not a viable equivalent here: on Claude Fable 5 an explicit `thinking: {"type": "disabled"}` returns 400 at any effort level, and on Claude Opus 5 it is rejected at effort `xhigh` or `max`. Both models are already listed in `DEFAULT_OPTIONS[:models_without_temperature]`.

Added a spec that stubs a response containing a thinking block and asserts the text block is returned.

Verified against the live API on 7.1.2 by prepending the patched `chat` method in a `rails runner` process and running `AI::Service::TicketSummarize` three times with `claude-sonnet-5`. All three responses contained a thinking block, the previous code extracted `nil` in all three, and the patched code returned the summary correctly in all three.
