### PR TITLE
feat: allow IP ranges as trusted proxies

### DIFF
--- a/lib/sessions/event/base.rb
+++ b/lib/sessions/event/base.rb
@@ -128,10 +128,16 @@ class Sessions::Event::Base
 
     return if !raw_header
 
+    is_trusted_proxy = lambda do |ip|
+      Rails.application.config.action_dispatch.trusted_proxies.any? { |proxy| proxy.include?(IPAddr.new(ip)) }
+    rescue IPAddr::InvalidAddressError
+      false
+    end
+
     raw_header
       .split(',')
       .map(&:strip)
-      .difference(Rails.application.config.action_dispatch.trusted_proxies)
+      .reject { |ip| is_trusted_proxy.call(ip) }
       .last
   end
 

--- a/lib/zammad/trusted_proxies.rb
+++ b/lib/zammad/trusted_proxies.rb
@@ -19,12 +19,12 @@ module Zammad
       end
 
       def resolve(entry)
-        entry if IPAddr.new(entry)
+        IPAddr.new(entry)
       rescue IPAddr::InvalidAddressError
         Resolv.getaddresses(entry).tap do |resolved|
           # Rails.logger may not be available here, so we use warn directly.
           warn "Error: ignoring trusted proxy '#{entry}' because it cannot be resolved." if resolved.empty?
-        end
+        end.map { |ip| IPAddr.new(ip) }
       end
 
       def parse_env

--- a/spec/lib/sessions/event/base_spec.rb
+++ b/spec/lib/sessions/event/base_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Sessions::Event::Base do
 
     context 'with X-Forwarded-For' do
       before do
-        allow(Rails.application.config.action_dispatch).to receive(:trusted_proxies).and_return(trusted_proxies)
+        allow(Rails.application.config.action_dispatch).to receive(:trusted_proxies).and_return(trusted_proxies.map { |proxy| IPAddr.new(proxy) })
       end
 
-      let(:trusted_proxies) { ['127.0.0.1', '::1'] }
+      let(:trusted_proxies) { ['127.0.0.1', '::1', '172.16.0.0/12'] }
 
       context 'with external IP' do
 
-        let(:headers) { { 'X-Forwarded-For' => '1.2.3.4 , 5.6.7.8, 127.0.0.1 , ::1' } }
+        let(:headers) { { 'X-Forwarded-For' => '1.2.3.4 , 5.6.7.8, 172.31.0.7 , 127.0.0.1 , ::1' } }
 
         it 'returns the correct value' do
           expect(instance.remote_ip).to eq('5.6.7.8')


### PR DESCRIPTION
This refactors `Rails.application.config.action_dispatch.trusted_proxies` to contain `IPAddr` objects instead of plain strings. This allows us to match IP ranges instead of only addresses. See the modified test for what it enables. We've also verified that this works with trusted proxies that are hostnames. It does not change existing behaviour in any way, as far as we can tell.

<!--
Hi there - a lot of love for starting a pull request 😍. Please ensure the following things before creation - thank you!

- Create your pull request against the develop branch. We don't accept changes to stable branches.
- Add a reference to the issue you are trying to fix. Just add a # and the number.
- Make sure to check out the developer manual in doc/developer_manual.
- Add tests for your changes. Feel free to ask for support. We are happy to help you.

* The upper textblock will be removed automatically when you submit your Pull Request *
-->
