### PR TITLE
Fixes #3934 - Allow mapping one LDAP attribute to multiple Zammad attributes

### DIFF
--- a/app/assets/javascripts/app/controllers/_integration/ldap.coffee
+++ b/app/assets/javascripts/app/controllers/_integration/ldap.coffee
@@ -627,10 +627,13 @@ class ConnectionWizard extends App.ControllerWizardModal
     length = user_attributes.source.length-1
     for count in [0..length]
       if user_attributes.source[count] && user_attributes.dest[count]
-        user_attributes_local[user_attributes.source[count]] = user_attributes.dest[count]
+        if !_.isArray(user_attributes_local[user_attributes.source[count]])
+          user_attributes_local[user_attributes.source[count]] = []
+        if !_.contains(user_attributes_local[user_attributes.source[count]], user_attributes.dest[count])
+          user_attributes_local[user_attributes.source[count]].push user_attributes.dest[count]
 
-    requiredAttribute = Object.keys(user_attributes_local).some( (local_attribute) ->
-      return user_attributes_local[local_attribute] == 'login'
+    requiredAttribute = _.some(_.values(user_attributes_local), (dest_attributes) ->
+      return _.contains(dest_attributes, 'login')
     )
 
     @wizardConfig.user_attributes = user_attributes_local
@@ -667,8 +670,10 @@ class ConnectionWizard extends App.ControllerWizardModal
   buildRowsUserMap: (user_attribute_map) =>
 
     el = []
-    for source, dest of user_attribute_map
-      el.push @buildRowUserAttribute(source, dest)
+    for source, dests of user_attribute_map
+      # a mapping value can be a single Zammad attribute or a list of them
+      for dest in [].concat(dests)
+        el.push @buildRowUserAttribute(source, dest)
     el
 
   buildRowUserAttribute: (source, dest) =>

--- a/app/assets/javascripts/app/views/integration/ldap.jst.eco
+++ b/app/assets/javascripts/app/views/integration/ldap.jst.eco
@@ -68,10 +68,12 @@
         <tr>
           <th width="40%"><%- @T('%s Attribute', 'LDAP') %>
           <th width="60%"><%- @T('%s Attribute', 'Zammad') %>
-        <% for key, value of @config.user_attributes: %>
-          <tr>
-            <td class="settings-list-row-control"><%= key %>
-            <td class="settings-list-row-control"><%= value %>
+        <% for key, values of @config.user_attributes: %>
+          <% for value in [].concat(values): %>
+            <tr>
+              <td class="settings-list-row-control"><%= key %>
+              <td class="settings-list-row-control"><%= value %>
+          <% end %>
         <% end %>
       </thead>
       <tbody>

--- a/db/migrate/20260824120000_issue3934_ldap_multi_user_attribute_mapping.rb
+++ b/db/migrate/20260824120000_issue3934_ldap_multi_user_attribute_mapping.rb
@@ -1,0 +1,16 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+class Issue3934LdapMultiUserAttributeMapping < ActiveRecord::Migration[8.0]
+  def change
+    # return if it's a new setup
+    return if !Setting.exists?(name: 'system_init_done')
+
+    LdapSource.find_each do |source|
+      user_attributes = source.preferences['user_attributes']
+      next if user_attributes.blank?
+
+      source.preferences['user_attributes'] = user_attributes.transform_values { |dest| Array.wrap(dest) }
+      source.save!
+    end
+  end
+end

--- a/lib/ldap/user.rb
+++ b/lib/ldap/user.rb
@@ -171,7 +171,18 @@ class Ldap
     attr_reader :config
 
     def login_attribute
-      @login_attribute ||= config[:user_attributes]&.key('login') || uid_attribute
+      @login_attribute ||= mapped_login_attribute || uid_attribute
+    end
+
+    # Looks up the LDAP attribute which is mapped to the Zammad 'login' attribute.
+    # A mapping value can be a single Zammad attribute or a list of them.
+    # Only 'keys' and '[]' are used here, because the config may also be an
+    # ActionController::Parameters instance, which is not a Hash.
+    def mapped_login_attribute
+      user_attributes = config[:user_attributes]
+      return if user_attributes.blank?
+
+      user_attributes.keys.find { |source| Array.wrap(user_attributes[source]).include?('login') }
     end
 
     def handle_config

--- a/lib/sequencer/unit/import/common/mapping/flat_keys.rb
+++ b/lib/sequencer/unit/import/common/mapping/flat_keys.rb
@@ -20,9 +20,9 @@ class Sequencer::Unit::Import::Common::Mapping::FlatKeys < Sequencer::Unit::Base
   def mapped
     @mapped ||= begin
       resource_with_indifferent_access = resource.with_indifferent_access
-      mapping.symbolize_keys.to_h do |source, local|
-        [local, resource_with_indifferent_access[source]]
-      end.with_indifferent_access
+      mapping.symbolize_keys.flat_map do |source, locals|
+        Array.wrap(locals).map { |local| [local, resource_with_indifferent_access[source]] }
+      end.to_h.with_indifferent_access
     end
   end
 

--- a/spec/db/migrate/issue3934_ldap_multi_user_attribute_mapping_spec.rb
+++ b/spec/db/migrate/issue3934_ldap_multi_user_attribute_mapping_spec.rb
@@ -1,0 +1,72 @@
+# Copyright (C) 2012-2026 Zammad Foundation, https://zammad-foundation.org/
+
+require 'rails_helper'
+
+RSpec.describe Issue3934LdapMultiUserAttributeMapping, type: :db_migration do
+
+  let!(:ldap_source) { create(:ldap_source, preferences: preferences) }
+
+  context 'with a legacy single attribute mapping' do
+    let(:preferences) do
+      {
+        'user_uid'        => 'uid',
+        'user_attributes' => { 'cn' => 'firstname', 'uid' => 'login' },
+      }
+    end
+
+    it 'converts the mapping values to arrays' do
+      migrate
+      ldap_source.reload
+
+      expect(ldap_source.preferences['user_attributes']).to eq(
+        { 'cn' => ['firstname'], 'uid' => ['login'] }
+      )
+    end
+  end
+
+  context 'with an already converted mapping' do
+    let(:preferences) do
+      {
+        'user_attributes' => { 'mail' => %w[login email] },
+      }
+    end
+
+    it 'keeps the mapping unchanged' do
+      migrate
+      ldap_source.reload
+
+      expect(ldap_source.preferences['user_attributes']).to eq(
+        { 'mail' => %w[login email] }
+      )
+    end
+  end
+
+  context 'with a partially converted mapping' do
+    let(:preferences) do
+      {
+        'user_attributes' => { 'mail' => %w[login email], 'cn' => 'firstname' },
+      }
+    end
+
+    it 'converts only the remaining single values' do
+      migrate
+      ldap_source.reload
+
+      expect(ldap_source.preferences['user_attributes']).to eq(
+        { 'mail' => %w[login email], 'cn' => ['firstname'] }
+      )
+    end
+  end
+
+  context 'without a user attribute mapping' do
+    let(:preferences) do
+      {
+        'user_uid' => 'uid',
+      }
+    end
+
+    it 'does not fail' do
+      expect { migrate }.not_to raise_error
+    end
+  end
+end

--- a/spec/lib/ldap/user_spec.rb
+++ b/spec/lib/ldap/user_spec.rb
@@ -133,6 +133,63 @@ RSpec.describe Ldap::User do
 
         it_behaves_like 'validates credentials'
       end
+
+      context 'with a login attribute mapping' do
+
+        shared_examples 'binds with the given login attribute' do |expected_attribute|
+          it "uses '#{expected_attribute}' in the bind filter" do
+            connection = double
+            allow(mocked_ldap).to receive(:connection).and_return(connection)
+
+            allow(mocked_ldap).to receive(:base_dn)
+            allow(connection).to receive(:bind_as).and_return(true)
+
+            instance.valid?('example_username', 'password')
+
+            expect(connection).to have_received(:bind_as).with(
+              base:     anything,
+              filter:   "(#{expected_attribute}=example_username)",
+              password: 'password',
+            )
+          end
+        end
+
+        context 'when mapped to a single Zammad attribute' do
+          let(:initialization_config) do
+            {
+              uid_attribute:   'objectguid',
+              filter:          '(objectClass=user)',
+              user_attributes: { 'mail' => 'login' },
+            }
+          end
+
+          it_behaves_like 'binds with the given login attribute', 'mail'
+        end
+
+        context 'when mapped to multiple Zammad attributes' do
+          let(:initialization_config) do
+            {
+              uid_attribute:   'objectguid',
+              filter:          '(objectClass=user)',
+              user_attributes: { 'mail' => %w[login email] },
+            }
+          end
+
+          it_behaves_like 'binds with the given login attribute', 'mail'
+        end
+
+        context 'when no attribute is mapped to login' do
+          let(:initialization_config) do
+            {
+              uid_attribute:   'objectguid',
+              filter:          '(objectClass=user)',
+              user_attributes: { 'mail' => %w[email] },
+            }
+          end
+
+          it_behaves_like 'binds with the given login attribute', 'objectguid'
+        end
+      end
     end
 
     describe '#attributes' do

--- a/spec/lib/sequencer/sequence/import/ldap/users_spec.rb
+++ b/spec/lib/sequencer/sequence/import/ldap/users_spec.rb
@@ -178,4 +178,74 @@ RSpec.describe Sequencer::Sequence::Import::Ldap::Users, sequencer: :sequence do
       end
     end
   end
+
+  context 'when one LDAP attribute is mapped to multiple Zammad attributes' do
+
+    it 'imports the value into all mapped attributes', last_admin_check: false do
+
+      user_entry               = build(:ldap_entry)
+      user_entry['objectguid'] = ['user1337']
+      user_entry['mail']       = ['Hans@Example.COM']
+      user_entry['first_name'] = ['Hans']
+
+      group_entry           = build(:ldap_entry)
+      group_entry['member'] = [user_entry.dn]
+
+      ldap_config = {
+        id:              ldap_source.id,
+        user_filter:     'user=filter',
+        group_role_map:  {
+          group_entry.dn => [1, 2]
+        },
+        user_attributes: {
+          'mail'       => %w[login email],
+          'first_name' => 'firstname',
+        },
+        user_uid:        'objectguid',
+      }
+
+      import_job = build_stubbed(:import_job, name: 'Import::Ldap')
+
+      connection = double(
+        host:    'example.com',
+        port:    1337,
+        ssl:     true,
+        base_dn: 'test'
+      )
+
+      # LDAP::Group and Sequencer::Unit::Import::Ldap::Users::SubSequence
+      allow(connection).to receive(:search).and_yield(group_entry).and_yield(user_entry)
+
+      # LDAP::Group and Sequencer::Unit::Import::Ldap::Users::Total
+      allow(connection).to receive_messages(entries?: true, count: 1)
+
+      expect do
+        process(
+          dry_run:         false,
+          resource:        ldap_config,
+          ldap_connection: connection,
+          import_job:      import_job,
+        )
+      end.to change(User, :count).by(1)
+
+      imported_user = User.last
+
+      expect(imported_user).to have_attributes(
+        login:     'hans@example.com',
+        email:     'hans@example.com',
+        firstname: 'Hans',
+      )
+
+      # a second run must find the existing user by the shared value
+      # instead of creating a duplicate
+      expect do
+        process(
+          dry_run:         false,
+          resource:        ldap_config,
+          ldap_connection: connection,
+          import_job:      import_job,
+        )
+      end.not_to change(User, :count)
+    end
+  end
 end

--- a/spec/lib/sequencer/unit/import/common/mapping/flat_keys_spec.rb
+++ b/spec/lib/sequencer/unit/import/common/mapping/flat_keys_spec.rb
@@ -37,4 +37,55 @@ RSpec.describe Sequencer::Unit::Import::Common::Mapping::FlatKeys, sequencer: :u
     )
     expect(provided[:mapped]).to be_a(ActiveSupport::HashWithIndifferentAccess)
   end
+
+  it 'maps one source attribute to multiple local attributes' do
+
+    parameters = {
+      resource: {
+        remote_attribute: 'value',
+      }
+    }
+
+    mapping = {
+      remote_attribute: %i[local_attribute another_local_attribute]
+    }
+
+    provided = process(parameters) do |instance|
+      allow(instance).to receive(:mapping).and_return(mapping)
+    end
+
+    expect(provided).to eq(
+      mapped: {
+        'local_attribute'         => 'value',
+        'another_local_attribute' => 'value',
+      }
+    )
+  end
+
+  it 'maps single and multiple local attributes side by side' do
+
+    parameters = {
+      resource: {
+        remote_attribute:       'value',
+        other_remote_attribute: 'other value',
+      }
+    }
+
+    mapping = {
+      remote_attribute:       %i[local_attribute another_local_attribute],
+      other_remote_attribute: :other_local_attribute,
+    }
+
+    provided = process(parameters) do |instance|
+      allow(instance).to receive(:mapping).and_return(mapping)
+    end
+
+    expect(provided).to eq(
+      mapped: {
+        'local_attribute'         => 'value',
+        'another_local_attribute' => 'value',
+        'other_local_attribute'   => 'other value',
+      }
+    )
+  end
 end

--- a/spec/lib/sequencer/unit/import/ldap/user/mapping_spec.rb
+++ b/spec/lib/sequencer/unit/import/ldap/user/mapping_spec.rb
@@ -24,6 +24,32 @@ RSpec.describe Sequencer::Unit::Import::Ldap::User::Mapping, sequencer: :unit do
       resource:    resource,
     )
 
-    expect(provided['lastname']).to be_nil
+    expect(provided[:mapped]['lastname']).to be_nil
+  end
+
+  it 'maps one LDAP attribute to multiple Zammad attributes' do
+
+    ldap_config = {
+      user_attributes: {
+        mail:      %w[login email],
+        firstName: 'firstname',
+      }
+    }
+
+    resource = {
+      mail:      'some@example.com',
+      firstName: 'Some',
+    }
+
+    provided = process(
+      ldap_config: ldap_config,
+      resource:    resource,
+    )
+
+    expect(provided[:mapped]).to include(
+      'login'     => 'some@example.com',
+      'email'     => 'some@example.com',
+      'firstname' => 'Some',
+    )
   end
 end


### PR DESCRIPTION
Fixes #3934.

One LDAP attribute can now be mapped to several Zammad attributes, e.g. `mail` to both `login` and `email`.

The mapping was stored in a hash keyed by the LDAP attribute, so a second row for the same attribute overwrote the first. A mapping value can now be a list (the same way `group_role_map` already works for group-to-role mappings, which was converted to lists back in `20170529132120_ldap_multi_group_mapping.rb`). A migration converts existing mappings, and both shapes are still accepted on read, so backwards compatibility is ensured.

This also gets rid of the confusing wizard behavior, that adding two rows for the same LDAP attribute silently dropped one on save, and saving then failed with `Attribute 'login' is required in the mapping`.

Specs added for the mapping unit, `#login_attribute`, the full import sequence and the migration.