### PR TITLE
Fix: Wrong number of arguments in create_knowledge_base_categories call

### DIFF
--- a/lib/fill_db.rb
+++ b/lib/fill_db.rb
@@ -487,7 +487,12 @@ or if you only want to create 100 tickets
 
     locale = knowledge_base.kb_locales.first
 
-    category_pool = categories.presence || create_knowledge_base_categories(categories_amount, knowledge_base.id, locale.id, sleep_time)
+    category_pool = categories.presence || create_knowledge_base_categories(
+      amount:            categories_amount,
+      knowledge_base_id: knowledge_base.id,
+      locale_id:         locale.id,
+      sleep_time:        sleep_time,
+    )
     if category_pool.blank?
       puts " Found #{category_pool.count} categories, aborting!"
       return


### PR DESCRIPTION
`FillDb.create_knowledge_base_answers` calls `create_knowledge_base_categories(categories_amount, knowledge_base.id, locale.id, sleep_time)` with four positional arguments, but `create_knowledge_base_categories` takes a single `params` hash and reads `params[:amount]`, `params[:knowledge_base_id]`, `params[:locale_id]` and `params[:sleep_time]` from it. Calling it positionally raises:

```
ArgumentError: wrong number of arguments (given 4, expected 1)
```

This path is documented, not hypothetical. The module docblock at the top of `lib/fill_db.rb` lists `FillDb.load(knowledge_base_answers: 100, nice: 0)` as supported usage. Requesting `knowledge_base_answers` without also requesting `knowledge_base_categories` leaves `categories` blank, so `categories.presence` is falsy and execution falls through to the broken call, crashing the demo/seed run.

The fix mirrors the correct call to the same method a few lines above, at line 374 (`create_knowledge_base_categories(amount:, knowledge_base_id:, locale_id:, sleep_time:)`), which already uses keyword arguments matching the method definition.

`lib/fill_db.rb` has no spec suite in this repo, so no test is included with this change.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.