### PR TITLE
Fix: Compare limit against @size, not undefined size

### DIFF
--- a/config/initializers/active_record_as_batches.rb
+++ b/config/initializers/active_record_as_batches.rb
@@ -28,7 +28,7 @@ module ActiveRecord
 
           if @limit
             @limit -= records.size
-            if @limit < size
+            if @limit < @size
               @size = @limit
             end
 

--- a/spec/lib/core_ext/relation/as_batches_spec.rb
+++ b/spec/lib/core_ext/relation/as_batches_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe 'AsBatches' do
     result
   end
 
+  def priorities_with_limit(limit, size)
+    result = []
+    Ticket::Priority.reorder(name: :asc).limit(limit).as_batches(size: size) do |prio|
+      result << prio
+    end
+    result
+  end
+
   context 'when batch is smaller then total result' do
     it 'does return all priorities ascending' do
       expect(priorities_asc(1)).to eq([ Ticket::Priority.find_by(name: '1 low'), Ticket::Priority.find_by(name: '2 normal'), Ticket::Priority.find_by(name: '3 high') ])
@@ -36,6 +44,12 @@ RSpec.describe 'AsBatches' do
 
     it 'does return all priorities decending' do
       expect(priorities_desc(100)).to eq([ Ticket::Priority.find_by(name: '3 high'), Ticket::Priority.find_by(name: '2 normal'), Ticket::Priority.find_by(name: '1 low') ])
+    end
+  end
+
+  context 'when a .limit is chained before as_batches' do
+    it 'does return only the outer-limited priorities, batching by size' do
+      expect(priorities_with_limit(2, 1)).to eq([ Ticket::Priority.find_by(name: '1 low'), Ticket::Priority.find_by(name: '2 normal') ])
     end
   end
 end


### PR DESCRIPTION
`AsBatches::Batch#as_batches` (`config/initializers/active_record_as_batches.rb:31`) has:

```ruby
if @limit < size
  @size = @limit
end
```

There is no `size` in scope here, only `@size`. That is what every other reference in the class uses: the initializer (`@size = args[:size] || 100`, line 13; `@size = @limit`, line 16), `get_records` (`query.offset(@offset).limit(@size).all`, line 20), and the line right below the buggy one (`@size = @limit`, line 32). The bare `size` on line 31 is a typo for `@size`, not an intentional reference to something else, since nothing named `size` (local, method, or otherwise) is defined anywhere in `Batch`.

Calling this line raises `NameError: undefined local variable or method 'size'`.

**Honest scope note**: I checked every current call site of `.as_batches` in this codebase, and none of them chain `.limit(...)` before it. That means `@limit` is always falsy on entry, the `if @limit` guard around this line never opens, and the bug is not firing in production today. It's not a live crash to fix urgently, it's dead code by accident: the entire `@limit` branch of this method is unreachable *without* the bug (nothing ever sets `@limit`), and unreachable *with* the bug too, just for a different reason (it would raise instead of run). The first caller anywhere that writes `SomeRelation.limit(n).as_batches { ... }` hits this immediately.

Fixed the typo and added a spec that chains `.limit` before `.as_batches`, which crashes against the old code and passes against the fix. Verified the failure/pass split with a standalone harness outside the zammad test suite (Rails/DB not available here), reproducing the exact buggy and fixed logic against a fake relation:

```
2 examples, 1 failure
NameError:
  undefined local variable or method 'size' for an instance of BatchBuggy
```

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
