### PR TITLE
Remove unused OnlineNotificationPolicy#relation

### DIFF
--- a/app/policies/online_notification_policy.rb
+++ b/app/policies/online_notification_policy.rb
@@ -35,10 +35,6 @@ class OnlineNotificationPolicy < ApplicationPolicy
     end
   end
 
-  def relation
-    object_klass.find_by(id: record.o_id)
-  end
-
   def without_relation_permission_field_scope
     @without_relation_permission_field_scope ||=
       ApplicationPolicy::FieldScope.new(allow: %i[seen type_name object_name created_at updated_at])


### PR DESCRIPTION
`OnlineNotificationPolicy#relation` (private, `app/policies/online_notification_policy.rb:38-40`) calls `object_klass`, a method that does not exist on `OnlineNotificationPolicy` or anywhere in its ancestor chain (`ApplicationPolicy`, `PunditPolicy`). Calling it always raises:

```
NameError: undefined local variable or method 'object_klass' for an instance of OnlineNotificationPolicy
```

It also has no reachable caller. Zammad's authorization stack (`pundit` 2.5.2, pinned in `Gemfile:49` / `Gemfile.lock:570`) has exactly two dynamic-dispatch entry points into a policy, and `relation` matches neither:

- `Pundit::Authorization#authorize` (`lib/pundit/authorization.rb:90`) derives the query from the controller action when none is given (`query ||= "#{action_name}?"`), and `Pundit::Context#authorize` (`lib/pundit/context.rb:70`) invokes it with `policy.public_send(query)`, always a `?`-suffixed action name, never `relation`.
- `Pundit::Context#policy_scope` (`lib/pundit/context.rb:119`) calls `.resolve` on a `<Model>Policy::Scope` class, but there is no `OnlineNotificationPolicy::Scope` anywhere in the repo, so this path never touches `OnlineNotificationPolicy` at all.

Zammad's own dispatch code confirms the same thing. `ApplicationController::Authorizes#authorize!` (`app/controllers/application_controller/authorizes.rb:9-11`) just forwards to Pundit's `authorize`. `OnlineNotificationsController` (`app/controllers/online_notifications_controller.rb:4`) only ever triggers this for `show`, `update` and `destroy` (`prepend_before_action -> { authorize! }, only: %i[show update destroy]`), giving `show?`/`update?`/`destroy?`. The GraphQL mutations do the same explicitly: `Gql::Mutations::OnlineNotification::Delete` (`app/graphql/gql/mutations/online_notification/delete.rb:7`, `loads_pundit_method: :destroy?`) and `::MarkAllAsSeen` (`app/graphql/gql/mutations/online_notification/mark_all_as_seen.rb:7`, `loads_pundit_method: :update?`). The existing spec (`spec/policies/online_notification_policy_spec.rb:13,24,34,40` for `permit_actions`/`forbid_actions`, `:16,27` for direct `policy.show?` calls) only exercises `show?`/`update?`/`destroy?`, never `relation`.

`relation` was added alongside `without_relation_permission_field_scope` in `b303d31f8` (2023-03-17, "Mobile - Improve online notification handling without relation object permission"). Only `without_relation_permission_field_scope` ended up wired into `show?` (line 8); `relation` has been dead code since that commit.

Renaming the broken `object_klass` call would just resurrect a method nothing calls; the scope logic it appears to have been meant for already lives in `related_accessible?`/`without_relation_permission_field_scope`, so there is no missing behavior to restore. Removing it deletes code that cannot execute instead of repairing an illusion of behavior that has no caller to observe it.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.

