### PR TITLE
Fix: Auth::TwoFactor#initiate_authentication calls an undefined method

### DIFF
--- a/lib/auth/two_factor.rb
+++ b/lib/auth/two_factor.rb
@@ -52,7 +52,7 @@ class Auth::TwoFactor
   def initiate_authentication(method)
     return {} if method.nil?
 
-    method_object = method_object(method)
+    method_object = authentication_method_object(method)
     return {} if method_object.nil?
 
     result = method_object.initiate_authentication

--- a/spec/lib/auth/two_factor_spec.rb
+++ b/spec/lib/auth/two_factor_spec.rb
@@ -117,6 +117,19 @@ RSpec.describe Auth::TwoFactor, current_user_id: 1 do
     end
   end
 
+  describe '#initiate_authentication' do
+    it 'returns an empty hash for an unknown method' do
+      expect(instance.initiate_authentication('does_not_exist')).to eq({})
+    end
+
+    it 'delegates to the resolved authentication method object' do
+      create(:user_two_factor_preference, :security_keys, user: user)
+      allow(WebAuthn::Credential).to receive(:options_for_get).with(any_args).and_return(:challenge)
+
+      expect(instance.initiate_authentication('security_keys')).to eq(:challenge)
+    end
+  end
+
   describe '#user_authentication_methods' do
     before { create(:user_two_factor_preference, :authenticator_app, user: user) }
 


### PR DESCRIPTION
`Auth::TwoFactor#initiate_authentication` (lib/auth/two_factor.rb:55) calls `method_object(method)`, which is not defined anywhere on the class. The only method it can mean is `authentication_method_object`, defined at line 79 and already used correctly by two sibling methods in the same class: `verify?` (line 38) and `verify_configuration?` (line 67). Calling `initiate_authentication` with any non-nil argument raises `NoMethodError: undefined method 'method_object'`.

I could not find a current caller of this exact method (it takes one argument): a repo-wide search for `.initiate_authentication(` with a parenthesized argument returns nothing. The two HTTP entry points that mention "initiate_authentication" (app/controllers/sessions_controller.rb:306 and app/graphql/gql/mutations/two_factor_method_initiate_authentication.rb:42) resolve the method object themselves via `authentication_method_object` and then call the zero-argument `initiate_authentication` defined on that method object's own class (`Auth::TwoFactor::AuthenticationMethod`), so neither one reaches this line.

The class itself is not abandoned: `Auth::TwoFactor` is the facade instantiated for every user (`User#auth_two_factor`, `Auth::User#two_factor`), and its sibling methods `verify?`/`verify_configuration?` are in active use. This one method's dispatch is a one-word typo, not a missing implementation, so I'm proposing the one-word fix that lines it up with its siblings. Whether to drop this bit of unused public API from the facade instead is a product decision, happy to go either way.

`spec/lib/auth/two_factor_spec.rb` had no coverage for `#initiate_authentication`. Added two examples: the unknown-method short-circuit and delegation to the resolved method object.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.