### PR TITLE
Fix: Cleanup action job name misses job prefix on payload args

### DIFF
--- a/lib/background_services/service/base_delayed_jobs/cleanup_action.rb
+++ b/lib/background_services/service/base_delayed_jobs/cleanup_action.rb
@@ -55,7 +55,7 @@ class BackgroundServices
           end
 
           if job.payload_object.respond_to?(:args)
-            job_name += " - ARGS: #{payload_object.args.inspect}"
+            job_name += " - ARGS: #{job.payload_object.args.inspect}"
           end
 
           job_name

--- a/spec/lib/background_services/service/base_delayed_jobs/cleanup_action_spec.rb
+++ b/spec/lib/background_services/service/base_delayed_jobs/cleanup_action_spec.rb
@@ -103,5 +103,18 @@ RSpec.describe BackgroundServices::Service::BaseDelayedJobs::CleanupAction do
       instance.cleanup
       expect(latest_job).to be_destroyed
     end
+
+    context 'when the payload responds to args (legacy Delayed::PerformableMethod)' do
+      let(:latest_job) { Delayed::Job.enqueue(Delayed::PerformableMethod.new(Kernel, :puts, ['sample-arg'])) }
+
+      it 'includes the payload args in the logged job name' do
+        latest_job.update! locked_at: 1.year.ago
+
+        allow(Rails.logger).to receive(:warn)
+        instance.cleanup
+
+        expect(Rails.logger).to have_received(:warn).with(a_string_including('ARGS: ["sample-arg"]'))
+      end
+    end
   end
 end


### PR DESCRIPTION
`CleanupAction#job_name` builds the log line for a locked delayed job:

```ruby
def job_name
  job_name = job.name

  if (object_id = job.payload_object.try(:object).try(:id))
    job_name += " (id: #{object_id})"
  end

  if job.payload_object.respond_to?(:args)
    job_name += " - ARGS: #{payload_object.args.inspect}"
  end

  job_name
end
```

The `ARGS` branch calls `payload_object.args.inspect` without the `job.` receiver. Lines 53 and 65 of this same private method call `job.payload_object` correctly, so this is a missed receiver on one line, not a different intent.

`payload_object` is not a local variable and not a method on `CleanupAction`, so Ruby resolves the bare identifier and raises `NameError` (not `NoMethodError`) the moment this branch runs: `undefined local variable or method 'payload_object' for an instance of BackgroundServices::Service::BaseDelayedJobs::CleanupAction`.

The branch only runs when `job.payload_object.respond_to?(:args)`, which is true for jobs enqueued through delayed_job's own `Delayed::PerformableMethod` (the legacy non-ActiveJob path), not for every job. When `CleanupAction#cleanup` hits a locked job of that kind, `job_name` raises instead of returning the log string, so the warning in `#cleanup` never gets logged.

Fix: use `job.payload_object.args.inspect`, matching lines 53 and 65.

Added a spec covering a job whose payload responds to `:args` (built via `Delayed::PerformableMethod`), asserting the logged message includes the args. It fails with the reported `NameError` against the current code and passes with the fix.

> Spotted by itaruby(to be released), a Ruby type checker I'm working on.
