### PR TITLE
fix(system-filters): Support colons after Service-Now incident number

### DIFF
--- a/app/models/channel/filter/service_now_check.rb
+++ b/app/models/channel/filter/service_now_check.rb
@@ -2,6 +2,6 @@
 
 class Channel::Filter::ServiceNowCheck < Channel::Filter::BaseExternalCheck
   MAIL_HEADER        = 'x-servicenow-generated'.freeze
-  SOURCE_ID_REGEX    = %r{\s(INC\d+)\s}
+  SOURCE_ID_REGEX    = %r{\s(INC\d+)[\s:]}
   SOURCE_NAME_PREFIX = 'ServiceNow'.freeze
 end

--- a/test/data/mail/mail089.box
+++ b/test/data/mail/mail089.box
@@ -1,7 +1,7 @@
 From: IT example <example@service-now.com>
 To: support@example.com
 Message-ID: <18659453.58107.1576665116411@app129169.gva3.service-now.com>
-Subject: Incident INC678439 -- zugewiesen an EXT-XXXINIS
+Subject: Incident INC678439: -- zugewiesen an EXT-XXXINIS
 MIME-Version: 1.0
 Content-Type: multipart/mixed;
     boundary="----=_Part_58105_29005161.1576665006397"


### PR DESCRIPTION
This change allows for the [Service-Now System Filter](https://admin-docs.zammad.org/en/latest/channels/email/filters/system-filters.html) to also work on issue numbers in subjects that end in a colon instead of a space.

Currently something like `Incident INC678439: updated xyz` does not match the regex and causes a new issue to be opened up. In order to combat this, the regex has been changed to allow for either option.

I've also adjusted one of test cases to verify both options work now.

For the future, it would be nice if this regex could be customized as a global setting or if even custom matching rules for arbitrary ticketing systems would be implemented. 