### PR TITLE
Add `filter` parameter `enabled: true` in order to fetch only enabled object types and add a language parameter to the query

### DIFF
--- a/lib/idoit.rb
+++ b/lib/idoit.rb
@@ -19,6 +19,9 @@ returns
 
     params = {
       apikey: api_token,
+      filter: {
+              enabled: true,
+      },
     }
 
     _query('cmdb.object_types', params, _url_cleanup(endpoint), verify_ssl: verify_ssl)
@@ -93,7 +96,12 @@ or with filter:
 
     params = {
       apikey: setting[:api_token],
+      language: _current_language,
     }
+
+    filter ||= {}
+    filter = filter.merge(enabled: true) if method == 'cmdb.object_types'
+
     if filter.present?
       params[:filter] = filter
     end
@@ -152,5 +160,14 @@ or with filter:
 
     url.gsub!(%r{src/jsonrpc.php}, '')
     url.gsub(%r{([^:])//+}, '\\1/')
+  end
+
+  def self._current_language
+    locale = UserInfo.current_user&.preferences&.dig(:locale) ||
+             UserInfo.current_user&.preferences&.dig('locale') ||
+             Setting.get('locale_default') ||
+             'en'
+
+    locale.to_s.split(/[-_]/).first
   end
 end


### PR DESCRIPTION
## Summary

This change adds a `enabled: true` filter to the `cmdb.object_types` requests sent to the i-doit API.

The i-doit API supports this filter to return only enabled object types. Without it, disabled object types are returned and displayed as options in the corresponding select field.

## Changes

- Add `filter: { enabled: true }` to `Idoit.verify`.
- Merge `enabled: true` into filters for `Idoit.query('cmdb.object_types', ...)`.
- Preserve existing filters passed by callers.
- Handle `nil` filters defensively.
- Send the i-doit API request language based on the current Zammad user locale.

## Motivation

Disabled object types should not be offered through the Zammad i-doit integration. Filtering avoids exposing object types that are not intended to be used.

If i-doit provides translations of object type titles, the translated titles should be used as option names in the corresponding select field

## Testing

Tested against an i-doit JSON-RPC API using `cmdb.object_types` with the `enabled` filter.
Verified that only enabled object types are returned.

Tested with different languages (Deutsch, English (United States) and Français) configured in the profile settings. 
Verified that the object type titles are shown in german if Deutsch is configured and in english with the other languages.
