### PR TITLE
Fix S/MIME decryption for forwarded emails

### DIFF
--- a/lib/secure_mailing/smime/incoming.rb
+++ b/lib/secure_mailing/smime/incoming.rb
@@ -279,6 +279,9 @@ class SecureMailing::SMIME::Incoming < SecureMailing::Backend::HandlerIncoming
       mail[:mail_instance].cc.each { |cc| certs += ::SMIMECertificate.find_by_email_address(cc, filter: { key: 'private', usage: :encryption }) }
     end
 
-    certs
+    delivered_to = mail[:mail_instance]['Delivered-To']&.value
+    certs += ::SMIMECertificate.find_by_email_address(delivered_to, filter: { key: 'private', usage: :encryption }) if delivered_to.present?
+
+    certs.uniq
   end
 end

--- a/spec/lib/secure_mailing/smime_spec.rb
+++ b/spec/lib/secure_mailing/smime_spec.rb
@@ -846,6 +846,27 @@ RSpec.describe SecureMailing::SMIME do
           expect(mail['x-zammad-article-preferences'][:security][:encryption][:comment]).to eq(recipient_certificate_subject)
         end
 
+        context 'when recipient is only present in Delivered-To' do
+          let(:mail) do
+            smime_mail = build_mail
+
+            smime_mail.to = 'forwarding-address@example.com'
+            smime_mail.cc = nil
+            smime_mail['Delivered-To'] = recipient_email_address
+
+            mail = Channel::EmailParser.new.parse(smime_mail.to_s)
+            SecureMailing.incoming(mail)
+
+            mail
+          end
+
+          it 'decrypts' do
+            expect(mail[:body]).to include(raw_body)
+            expect(mail['x-zammad-article-preferences'][:security][:encryption][:success]).to be true
+            expect(mail['x-zammad-article-preferences'][:security][:encryption][:comment]).to eq(recipient_certificate_subject)
+          end
+        end
+
         it_behaves_like 'HttpLog writer', 'success'
 
         context 'expired allowed' do


### PR DESCRIPTION
Fixes #6357

### Summary

Fix S/MIME decryption for forwarded messages where the actual S/MIME recipient is present in `Delivered-To` but not in the `To` or `Cc` headers.

`SecureMailing::SMIME::Incoming#decryption_certificates` currently selects candidate private keys using only `To` and `Cc`. This can fail after forwarding because these headers may retain the original recipient while the final mailbox address is provided in `Delivered-To`.

This change adds `Delivered-To` to the candidate certificate lookup and de-duplicates the resulting certificates.

### Example

A forwarded message may contain:

```text
To: forwarding-address@example.com
Delivered-To: smime-recipient@example.com
```

while the S/MIME envelope itself is encrypted for the certificate belonging to `smime-recipient@example.com`.

Before this change, Zammad reports:

```text
The private key for decryption could not be found.
```

With this change, the corresponding private key is found and the message is successfully decrypted.

### Tests

Added a regression test which:

* creates an S/MIME-encrypted message for the configured recipient;
* replaces `To` with a forwarding address;
* removes `Cc`;
* sets the actual recipient only in `Delivered-To`;
* verifies that the message is successfully decrypted.

The regression test fails on unchanged `develop` and passes with this change.

Validation:

```text
spec/lib/secure_mailing/smime_spec.rb
64 examples, 0 failures

RuboCop
2 files inspected, no offenses detected
```
